### PR TITLE
Add index on users#confirmation_token

### DIFF
--- a/db/migrate/20210404083340_add_user_confirmation_token_index.rb
+++ b/db/migrate/20210404083340_add_user_confirmation_token_index.rb
@@ -1,0 +1,6 @@
+class AddUserConfirmationTokenIndex < ActiveRecord::Migration[6.1]
+  def change
+    commit_db_transaction
+    add_index :users, [:confirmation_token], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_03_113911) do
+ActiveRecord::Schema.define(version: 2021_04_04_083340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,6 +113,7 @@ ActiveRecord::Schema.define(version: 2021_04_03_113911) do
     t.text "lastname_ciphertext"
     t.text "phone_number_ciphertext"
     t.text "address_ciphertext"
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
As per PgHero recommendation, we need this index to speed up some queries:

<img width="776" alt="image" src="https://user-images.githubusercontent.com/414418/113503320-6c6dbf80-9531-11eb-93a3-23dccb7700af.png">
