### PR TITLE
Add Blind Index to user email

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'pghero'
 gem 'pg_query', '>= 0.9.0'
 gem 'sidekiq'
 gem 'geocoder'
+gem 'blind_index'
 gem 'lockbox'
 gem 'appsignal'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     appsignal (3.0.2)
       rack
+    argon2-kdf (0.1.6)
     autoprefixer-rails (10.2.4.0)
       execjs
     bcrypt (3.1.16)
@@ -73,6 +74,9 @@ GEM
       chartkick (>= 3.2)
       railties (>= 5)
       safely_block (>= 0.1.1)
+    blind_index (2.2.0)
+      activesupport (>= 5)
+      argon2-kdf (>= 0.1.1)
     bootsnap (1.7.3)
       msgpack (~> 1.0)
     bootstrap (5.0.0.beta2)
@@ -340,6 +344,7 @@ DEPENDENCIES
   appsignal
   autoprefixer-rails
   blazer
+  blind_index
   bootsnap (>= 1.4.4)
   bootstrap (~> 5.0.0.beta2)
   byebug

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,9 @@ class User < ApplicationRecord
   encrypts :lastname
   encrypts :address
   encrypts :phone_number
-  encrypts :email, migrating: true
+  encrypts :email
+
+  blind_index :email, migrating: true
 
   validates :firstname, presence: true
   validates :lastname, presence: true

--- a/db/migrate/20210404211710_add_blind_index_to_users.rb
+++ b/db/migrate/20210404211710_add_blind_index_to_users.rb
@@ -1,0 +1,6 @@
+class AddBlindIndexToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :email_bidx, :string
+    add_index :users, :email_bidx, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_04_190311) do
+ActiveRecord::Schema.define(version: 2021_04_04_211710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -113,8 +113,10 @@ ActiveRecord::Schema.define(version: 2021_04_04_190311) do
     t.text "phone_number_ciphertext"
     t.text "address_ciphertext"
     t.text "email_ciphertext"
+    t.string "email_bidx"
     t.string "email"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token"
+    t.index ["email_bidx"], name: "index_users_on_email_bidx", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
Take 2 at fixing #59.

Following [this tutorial](https://ankane.org/securing-user-emails-lockbox), we need the `blind_index` gem in combination with Lockbox to allow Devise to work with encrypted emails.

Once this is deployed, we'll run in a `heroku run rails c`:

```ruby
Lockbox.migrate(User)
```