### PR TITLE
Typo in 'ephad' -> 'ehpad' + module to avoid typo

### DIFF
--- a/app/models/vaccination_center.rb
+++ b/app/models/vaccination_center.rb
@@ -1,13 +1,22 @@
 class VaccinationCenter < ApplicationRecord
 
   validates_presence_of :name, :description, :address, :lat, :lon, :phone_number
-  validates :kind, inclusion: { in: ['Centre de vaccination', 'Cabinet médical', 'Pharmacie', 'Ephad'] }
+  validates :kind, inclusion: { in: VaccinationCenter::Kinds::ALL }
 
   has_many :partner_vaccination_center
   has_many :partner, through: :partner_vaccination_center
   belongs_to :confirmer, class_name: 'User', optional: true
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }
+
+  module Kinds
+    CENTRE_VACCINATION = 'Centre de vaccination'
+    CABINET_MEDICAL = 'Cabinet médical'
+    PHARMACIE = 'Pharmacie'
+    EHPAD = 'Ehpad'
+
+    ALL = [CENTRE_VACCINATION, CABINET_MEDICAL, PHARMACIE, EHPAD].freeze
+  end
 
   def confirmed?
     confirmed_at.present?

--- a/app/views/partners/vaccination_centers/new.html.haml
+++ b/app/views/partners/vaccination_centers/new.html.haml
@@ -19,7 +19,7 @@
       = simple_form_for [:partners, @vaccination_center] do |f|
         = f.input :name, label: 'Nom du centre', error: 'Nom requis', placeholder: 'Centre de vaccination Marseille'
         = f.input :description, label: 'Description', error: 'Description requise', placeholder: 'Description du lieu de vaccination'
-        = f.input :kind, label: 'Type de centre de vaccination', :collection => ['Centre de vaccination', 'Cabinet médical', 'Pharmacie', 'Ephad']
+        = f.input :kind, label: 'Type de centre de vaccination', collection: VaccinationCenter::Kinds::ALL
         %p.mtop2
           Type(s) de vaccins disponibles
         = f.input :pfizer, as: :boolean, label: "Pfizer", checked_value: true, unchecked_value: false, class: 'form-check-inline'


### PR DESCRIPTION
L'utilisation d'un module évite les recopies et les erreurs.