### PR TITLE
Don't break line for thousands separator

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
     else
       @user = User.new
       @users_count = Rails.cache.fetch(:users_count, expires_in: 1.minute) do
-        number_with_delimiter(User.count, locale: :fr)
+        number_with_delimiter(User.count, locale: :fr).gsub(" ", "&nbsp;").html_safe
       end
     end
   end


### PR DESCRIPTION
Empêche le retour à la ligne en plein milieu du nombre de users inscrits sur certains téléphones.

C'est le premier nombre que l'on voit, c'est donc important.

# Avant
![image](https://user-images.githubusercontent.com/20317297/113596174-35cf9c00-963a-11eb-9b7e-4cc056f8b68b.png)

# Après
![image](https://user-images.githubusercontent.com/20317297/113596214-441db800-963a-11eb-8dc8-bd270e7a25c1.png)
