### PR TITLE
Improve accessibility by changing the primary color

### DIFF
--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -2,7 +2,7 @@
 
 // For example:
 $red: #FD1015;
-$blue: #167FFB;
+$blue: #0251af;
 $yellow: #FFC65A;
 $orange: #E67E22;
 $green: #1EDD88;


### PR DESCRIPTION
Respect AAA WCAG contrast guidelines

<img width="1103" alt="image" src="https://user-images.githubusercontent.com/5855339/114239424-5d01d280-9986-11eb-8b91-7c62e8c26379.png">

Before
<img width="314" alt="image" src="https://user-images.githubusercontent.com/5855339/114239287-2b890700-9986-11eb-88a7-4c875cbd5a5f.png">

After
<img width="315" alt="image" src="https://user-images.githubusercontent.com/5855339/114239321-393e8c80-9986-11eb-9bf2-6b33b42410a1.png">
