### PR TITLE
Underline links to improve readability

### DIFF
--- a/app/views/mailer/_styles.html.haml
+++ b/app/views/mailer/_styles.html.haml
@@ -22,14 +22,6 @@
   .mtop3{margin-top:30px;}
   .mtop4{margin-top:40px;}
 
-  a{
-    color: #337ab7;
-    text-decoration: none;
-  }
-  a:hover{
-    text-decoration: underline !important;
-  }
-
   .padding {
     padding: 20px 0 !important;
   }


### PR DESCRIPTION
Also remove unused code. Did not try locally.

<img width="631" alt="image" src="https://user-images.githubusercontent.com/5855339/114239548-83277280-9986-11eb-8dcd-6b9f72a93852.png">
