### PR TITLE
Les campagnes ne peuvent avoir le que le jour-même

### DIFF
--- a/app/views/partners/campaigns/new.html.haml
+++ b/app/views/partners/campaigns/new.html.haml
@@ -15,6 +15,13 @@
         %h5 Plage horaire de disponibilité des vaccins
 
         .row
+          .col
+            %div.alert.alert-primary
+              La campagne aura lieu
+              %strong aujourd'hui #{l Date.today, format: "%e %B"}
+              \: il n'est pas encore possible de planifier plus loin.
+
+        .row
           .col.col-6
             = f.input :starts_at, as: :time, label: "Début"
           .col.col-6


### PR DESCRIPTION
C'est maintenant précisé sur le formulaire de création d'une campagne :

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/414418/114267524-75accf80-99fc-11eb-8425-40a30f523a68.png">
