### PR TITLE
Création de faux volontaires en base de développement

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,6 +7,9 @@
 # Ignore rake tasks
 lib/tasks/*.rake
 
+# Ignore Ruby files
+**/*.rb
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,11 @@
+# Ignore this file!
+.prettierignore
+
 # Ignore bundler config.
 /.bundle
+
+# Ignore rake tasks
+lib/tasks/*.rake
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -1,4 +1,32 @@
 namespace :populate do
+  desc "Generate fake users"
+  task users: :environment do
+    puts "How many users do you want? (~1s / user)"
+    print "> "
+    count = gets.chomp.to_i
+    puts "Generating #{count} users..."
+    count.times do |i|
+      user = User.new(
+        firstname: Faker::Name.first_name,
+        lastname: Faker::Name.last_name,
+        email: Faker::Internet.unique.email(domain: "covidliste.com"),
+        birthdate: Faker::Date.between(from: 100.years.ago, to: 18.years.ago),
+        address: Faker::Address.full_address,
+        password: Faker::Internet.password,
+        phone_number: Faker::PhoneNumber.phone_number,
+        toc: true,
+        statement: true
+      )
+      user.skip_confirmation!
+      user.save!
+      user.update_columns(confirmed_at: Time.now.utc)
+      GeocodeUserJob.perform_now(user.id)
+      user.reload
+      puts "#{i + 1}. #{user.full_name}, #{user.age} ans - #{user.address} (#{user.lat}, #{user.lon})"
+    end
+    puts "Done."
+  end
+
   desc "Create a new validated Vaccination center with a new partner"
   task create_vaccination_center_with_partner_and_validate: :environment do
     partner = Partner.new(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,9 @@
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
 require "simplecov"
-SimpleCov.start
+SimpleCov.start do
+  add_filter "lib/tasks"
+end
 
 if ENV["CI"] == "true"
   require "codecov"


### PR DESCRIPTION
Fixes  #202

Utilisation :

```bash
bin/rails populate:users
```

Le prompt va demander un nombre (par exemple `100`) et créer le nombre de volontaires équivalents.