### PR TITLE
Fix prettier lefthook for non prettier formatable files

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,4 +5,4 @@ pre-commit:
       glob: "*.{rb}"
       run: bin/standardrb
     prettier:
-      run: yarn prettier --write {staged_files}
+      run: yarn prettier --write .


### PR DESCRIPTION
* Suite à cette PR #238 j'ai remarqué que prettier essayait de formatter des fichiers qu'il ne pouvait pas formatter. C'est ce qu'il fait quand on lui passe une liste de fichiers.
* Pour faire simple, j'ai fait comme standard et je le fais tout formatter. Pas de problème de perf pour l'instant.