### PR TITLE
Attempt to fix #278 Human Friendly Phone Number

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,7 @@ class UsersController < ApplicationController
 
   def show
     @user = current_user
+    @user.phone_number = @user.human_friendly_phone_number
     respond_to do |format|
       format.html
       format.csv do
@@ -39,6 +40,7 @@ class UsersController < ApplicationController
     else
       flash.now[:error] = "Impossible d'enregistrer vos modifications."
     end
+    @user.phone_number = @user.human_friendly_phone_number
     render action: :show
   end
 

--- a/app/models/concerns/has_phone_number_concern.rb
+++ b/app/models/concerns/has_phone_number_concern.rb
@@ -8,6 +8,11 @@ module HasPhoneNumberConcern
     validates :phone_number, length: {minimum: 7, maximum: 15, allow_blank: false}
   end
 
+  def human_friendly_phone_number
+    phone_number.gsub(/^33/, "0").match(/(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/).captures
+      .join(" ")
+  end
+
   private
 
   def format_phone_number

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,6 +50,8 @@ RSpec.describe User, type: :model do
   end
 
   describe "Phone format" do
+    it_behaves_like "has phone number"
+
     it "format phone number correctly" do
       user.phone_number = "06 11 22 33 44"
       expect(user).to be_valid

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,8 @@ if ENV["CI"] == "true"
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
 end
 
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/support/has_phone_number_spec.rb
+++ b/spec/support/has_phone_number_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_examples "has phone number" do |param|
+  let(:model) { create(described_class.to_s.underscore.to_sym) }
+
+  describe "#human_friendly_phone_number" do
+    subject { model.human_friendly_phone_number }
+
+    it "formats the phone number for the view" do
+      allow(model).to receive(:phone_number).and_return("33612345678")
+      expect(subject).to eq "06 12 34 56 78"
+    end
+  end
+end


### PR DESCRIPTION
This formats the phone number in the user profile to avoid confusion

<img width="930" alt="Screenshot 2021-04-11 at 10 48 29" src="https://user-images.githubusercontent.com/7141798/114298255-bfa5bc00-9ab5-11eb-93dc-9f69b0b0440f.png">
