### PR TITLE
Attempt to fix actions for forks

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,7 +3,7 @@ name: Quality
 # triggers on
 on:
   - push
-  - pull_request
+  - pull_request_target
 
 jobs:
   quality:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 # triggers on
 on:
   - push
-  - pull_request
+  - pull_request_target
 
 jobs:
   test:


### PR DESCRIPTION
- The issue is known and well commented in this [github/actions issue](https://github.com/actions/first-interaction/issues/10)
- According to [the Github article mentioned at the bottom](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/) using `pull_request_target` instead runs the checks from the base of the pull request instead of the fork's.
- In my understanding it's secure and may be the solution to the problem.