### PR TITLE
Add Rubocop and progressively activate cops

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,6 +20,17 @@ jobs:
         with:
           # prettier CLI arguments.
           args: --check .
+      - name: Set up Ruby 2.7.3
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.3
+      - name: Cache gems
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-rubocop-
       - name: Install gems
         run: |
           bundle config path vendor/bundle

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,5 +20,10 @@ jobs:
         with:
           # prettier CLI arguments.
           args: --check .
+      - name: Install gems
+        run: |
+          bundle config path vendor/bundle
+          bundle config set without 'default doc job cable storage ujs test db'
+          bundle install --jobs 4 --retry 3
       - name: Run RuboCop
         run: bundle exec rubocop --parallel

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,3 +20,5 @@ jobs:
         with:
           # prettier CLI arguments.
           args: --check .
+      - name: Run RuboCop
+        run: bundle exec rubocop --parallel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,10 +61,6 @@ jobs:
           bundle exec rails db:create db:migrate
       - name: Run tests
         run: bundle exec rspec --format RspecJunitFormatter --out rspec.xml
-      # - name: Codecov
-      #   uses: codecov/codecov-action@v1.3.2
-      #   with:
-      #     token: ${{ secrets.CODECOV_TOKEN }}
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ AllCops:
     - "Gemfile"
     - "db/schema.rb"
     - "node_modules/**/*"
+    - vendor/bundle/**/*
 
 Layout/ArgumentAlignment:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,37 @@
+require:
+  - rubocop-faker
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rake
+  - rubocop-rspec
+
+AllCops:
+  NewCops: enable
+  TargetRubyVersion: 2.7.3
+  Include:
+    - "**/Rakefile"
+    - "**/config.ru"
+    - "**/*.rb"
+  Exclude:
+    - "bin/**/*"
+    - "db/**/*"
+    - "config/**/*"
+    - "Gemfile"
+    - "db/schema.rb"
+    - "node_modules/**/*"
+Layout/LineLength:
+  Max: 90
+  Exclude:
+    - "**/swagger_docs/**/*"
+    - "app/admin/item.rb"
+    - "spec/**/*"
+  IgnoredPatterns: ['\#']
+
+Metrics/BlockLength:
+  Exclude:
+    - "**/admin/**/*"
+    - "spec/**/*"
+Rails:
+  Enabled: true
+Style/Documentation:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,19 +19,137 @@ AllCops:
     - "Gemfile"
     - "db/schema.rb"
     - "node_modules/**/*"
-Layout/LineLength:
-  Max: 90
-  Exclude:
-    - "**/swagger_docs/**/*"
-    - "app/admin/item.rb"
-    - "spec/**/*"
-  IgnoredPatterns: ['\#']
 
+Layout/ArgumentAlignment:
+  Enabled: false
+Layout/ArrayAlignment:
+  Enabled: false
+Layout/FirstHashElementIndentation:
+  Enabled: false
+Layout/LineLength:
+  Enabled: false
+Layout/MultilineMethodCallIndentation:
+  Enabled: false
+Layout/MultilineOperationIndentation:
+  Enabled: false
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: false
+
+Lint/UnusedBlockArgument:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
 Metrics/BlockLength:
-  Exclude:
-    - "**/admin/**/*"
-    - "spec/**/*"
+  Enabled: false
+Metrics/ClassLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+
 Rails:
   Enabled: true
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: false
+Rails/ApplicationJob:
+  Enabled: false
+Rails/ContentTag:
+  Enabled: false
+Rails/Date:
+  Enabled: false
+Rails/FindEach:
+  Enabled: false
+Rails/HasAndBelongsToMany:
+  Enabled: false
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+Rails/LinkToBlank:
+  Enabled: false
+Rails/OutputSafety:
+  Enabled: false
+Rails/PluralizationGrammar:
+  Enabled: false
+Rails/SkipsModelValidations:
+  Enabled: false
+Rails/TimeZone:
+  Enabled: false
+Rails/Validation:
+  Enabled: false
+Rails/WhereEquals:
+  Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false
+RSpec/ContextWording:
+  Enabled: false
+RSpec/DescribedClass:
+  Enabled: false
+RSpec/EmptyLineAfterExample:
+  Enabled: false
+RSpec/EmptyLineAfterFinalLet:
+  Enabled: false
+RSpec/EmptyLineAfterHook:
+  Enabled: false
+RSpec/EmptyLineAfterSubject:
+  Enabled: false
+RSpec/ExampleLength:
+  Enabled: false
+RSpec/ExampleWording:
+  Enabled: false
+RSpec/ExpectChange:
+  Enabled: false
+RSpec/LeadingSubject:
+  Enabled: false
+RSpec/LetSetup:
+  Enabled: false
+RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+RSpec/NamedSubject:
+  Enabled: false
+RSpec/NotToNot:
+  Enabled: false
+RSpec/RepeatedExample:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Enabled: false
 Style/Documentation:
+  Enabled: false
+Style/EmptyMethod:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/IfUnlessModifier:
+  Enabled: false
+Style/MultilineBlockChain:
+  Enabled: false
+Style/MutableConstant:
+  Enabled: false
+Style/NumericLiterals:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/RescueStandardError:
+  Enabled: false
+Style/SingleArgumentDig:
+  Enabled: false
+Style/StringConcatenation:
+  Enabled: false
+Style/StringLiterals:
+  Enabled: false
+Style/StringLiteralsInInterpolation:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/WhileUntilModifier:
+  Enabled: false
+Style/WordArray:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,13 @@ group :development, :test do
   gem "faker", git: "https://github.com/faker-ruby/faker.git", branch: "master"
   gem "pry-byebug"
   gem "pry-rails"
+
+  gem "rubocop", require: false
+  gem "rubocop-faker", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+  gem "rubocop-rake", require: false
+  gem "rubocop-rspec", require: false
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,9 +344,21 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
+    rubocop-faker (1.1.0)
+      faker (>= 2.12.0)
+      rubocop (>= 0.82.0)
     rubocop-performance (1.10.1)
       rubocop (>= 0.90.0, < 2.0)
       rubocop-ast (>= 0.4.0)
+    rubocop-rails (2.9.1)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 0.90.0, < 2.0)
+    rubocop-rake (0.5.1)
+      rubocop
+    rubocop-rspec (2.2.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.4)
     ruby_parser (3.15.1)
@@ -490,6 +502,12 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0)
   rspec-sidekiq
   rspec_junit_formatter
+  rubocop
+  rubocop-faker
+  rubocop-performance
+  rubocop-rails
+  rubocop-rake
+  rubocop-rspec
   sass-rails (>= 6)
   selenium-webdriver
   sidekiq
@@ -510,4 +528,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.2.15
+   2.2.16

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Covidliste makes it easy to manage waiting lists for vaccination centers.
 If you don't already have them :
 
 - Install ruby 2.7.3 `rbenv install 2.7.3 && rbenv global 2.7.3`
-- Install bundler 2.2.15 `gem install bundler:2.2.15`
+- Install bundler 2.2.16 `gem install bundler:2.2.16`
 - Install yarn `npm i -g yarn`
 - Install redis `brew install redis`
 


### PR DESCRIPTION
Hi there,

First, thank you for leading this great project.

This Pull Request is a proposal to install Rubocop as part of the CI workflow. It pairs beautifully with Standard and Prettier and aims at progressively enforcing a set of good practices among all contributors.

What this PR **does not** is _imposing a particular programming style_. I believe it is up to the project's maintainers to define one if they deem it relevant, and to configure it the way it suits them best. Therefore : 

1. All Rubocop cops that have been offended so far are individually deactivated in `.rubocop.yml`
2. You can choose to progressively enforce new rules by removing a deactivated cop
3. You can also choose to add a custom config to one / multiple cops

PS: I'm writing in English since I'm not sure every contributor here speaks French, but feel free to ask for a translation and I'll gladly do it