### PR TITLE
add foundation for using pundit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem "standard"
 gem "twilio-ruby", "~> 5.50"
 gem "valid_email"
 gem "lefthook"
+gem "pundit", "~> 2.1"
 
 group :development, :test do
   gem "dotenv-rails", "2.7.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,8 @@ GEM
     public_suffix (4.0.6)
     puma (5.2.2)
       nio4r (~> 2.0)
+    pundit (2.1.0)
+      activesupport (>= 3.0.0)
     raabro (1.4.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -492,6 +494,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 5.0)
+  pundit (~> 2.1)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.1)
   rolify

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -16,5 +16,10 @@ module Admin
         redirect_to(root_path)
       end
     end
+
+    def skip_pundit?
+      # TODO add a real policy
+      true
+    end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,9 @@
 class ApplicationController < ActionController::Base
+  include Pundit
   protect_from_forgery prepend: true
+
+  after_action :verify_authorized, except: :index, unless: :skip_pundit?
+  after_action :verify_policy_scoped, only: :index, unless: :skip_pundit?
 
   unless Rails.env.development?
     content_security_policy do |policy|
@@ -10,5 +14,9 @@ class ApplicationController < ActionController::Base
       policy.script_src :strict_dynamic
       policy.style_src :self, :https, :unsafe_inline
     end
+  end
+
+  def skip_pundit?
+    devise_controller?
   end
 end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -25,4 +25,9 @@ class MatchesController < ApplicationController
     flash[:error] = "Désolé, ce lien d'invitation n'est pas valide."
     redirect_to root_path
   end
+
+  def skip_pundit?
+    # TODO add a real policy
+    true
+  end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,4 +12,10 @@ class PagesController < ApplicationController
   def robots
     render "pages/robots", layout: false, content_type: "text/plain"
   end
+
+  private
+
+  def skip_pundit?
+    true
+  end
 end

--- a/app/controllers/partners/campaigns_controller.rb
+++ b/app/controllers/partners/campaigns_controller.rb
@@ -94,5 +94,10 @@ module Partners
     def simulate_params
       params.require(:campaign).permit(:min_age, :max_age, :max_distance_in_meters, :vaccine_type, :available_doses)
     end
+
+    def skip_pundit?
+      # TODO add a real policy
+      true
+    end
   end
 end

--- a/app/controllers/partners/vaccination_centers_controller.rb
+++ b/app/controllers/partners/vaccination_centers_controller.rb
@@ -57,5 +57,10 @@ module Partners
     def sort_direction
       %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
     end
+
+    def skip_pundit?
+      # TODO add a real policy
+      true
+    end
   end
 end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -32,4 +32,9 @@ class PartnersController < ApplicationController
   def sort_direction
     %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
   end
+
+  def skip_pundit?
+    # TODO add a real policy
+    true
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -79,4 +79,9 @@ class UsersController < ApplicationController
       redirect_to root_path
     end
   end
+
+  def skip_pundit?
+    # TODO add a real policy
+    true
+  end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,49 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end


### PR DESCRIPTION
As part of #305 this PR adds the foundation for using Pundit to handle authorizations.

To make it easier to review this PR only adds the foundation with `skip_pundit?` function in every controller. The idea is to then split each policy in individual PR for easier reviews.