### PR TITLE
Ajoute l'installation de postgresql dans le readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If you don't already have them :
 - Install bundler 2.2.15 `gem install bundler:2.2.15`
 - Install yarn `npm i -g yarn`
 - Install redis `brew install redis`
+- Install postgresql `brew install postgresql`
 
 ### Dependencies
 


### PR DESCRIPTION
Nécessaire pour faire tourner l'env de dev

J'ai aussi installé [Postgres.app](https://postgresapp.com) (`brew install --cask postgres`) mais ne sais pas si c'est une bonne pratique