### PR TITLE
[Geocoding] remove unused code to get lat/lon for users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -68,8 +68,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:firstname, :lastname, :email, :phone_number, :toc, :address, :birthdate, :lat,
-      :lon, :zipcode, :city, :password, :statement)
+    params.require(:user).permit(:firstname, :lastname, :email, :phone_number, :toc, :address, :birthdate, :password, :statement)
   end
 
   def sign_out_if_anonymized!

--- a/app/javascript/plugins/places_autocomplete.js
+++ b/app/javascript/plugins/places_autocomplete.js
@@ -1,13 +1,11 @@
 import places from "places.js";
 
 const placesAutocomplete = (appId, apiKey) => {
+  
+  // User Form
   const addressInput = document.getElementById("user_address");
-  const latInput = document.getElementById("user_lat");
-  const lonInput = document.getElementById("user_lon");
-  const zipcodeInput = document.getElementById("user_zipcode");
-  const cityInput = document.getElementById("user_city");
   if (addressInput) {
-    let p = places({
+    places({
       container: addressInput,
       appId: appId,
       apiKey: apiKey,
@@ -15,32 +13,9 @@ const placesAutocomplete = (appId, apiKey) => {
       language: "fr",
       countries: ["fr"],
     });
-    p.on("change", function (e) {
-      let latlng = e.suggestion.latlng;
-      latInput.value = latlng["lat"];
-      lonInput.value = latlng["lng"];
-      zipcodeInput.value = e.suggestion.postcode;
-      cityInput.value = e.suggestion.city;
-    });
   }
-  const addressInputMap = document.getElementById("map_address");
-  const latInputMap = document.getElementById("map_lat");
-  const lonInputMap = document.getElementById("map_lon");
-  if (addressInputMap) {
-    let p = places({
-      container: addressInputMap,
-      appId: appId,
-      apiKey: apiKey,
-    }).configure({
-      language: "fr",
-      countries: ["fr"],
-    });
-    p.on("change", function (e) {
-      let latlng = e.suggestion.latlng;
-      latInputMap.value = latlng["lat"];
-      lonInputMap.value = latlng["lng"];
-    });
-  }
+
+  // Vaccination Center Signup Form
   const centerAddressInput = document.getElementById(
     "vaccination_center_address"
   );

--- a/app/javascript/plugins/places_autocomplete.js
+++ b/app/javascript/plugins/places_autocomplete.js
@@ -7,10 +7,10 @@ const placesAutocomplete = (appId, apiKey) => {
     places({
       container: addressInput,
       appId: appId,
-      apiKey: apiKey
+      apiKey: apiKey,
     }).configure({
       language: "fr",
-      countries: ["fr"]
+      countries: ["fr"],
     });
   }
 
@@ -24,12 +24,12 @@ const placesAutocomplete = (appId, apiKey) => {
     let p = places({
       container: centerAddressInput,
       appId: appId,
-      apiKey: apiKey
+      apiKey: apiKey,
     }).configure({
       language: "fr",
-      countries: ["fr"]
+      countries: ["fr"],
     });
-    p.on("change", function(e) {
+    p.on("change", function (e) {
       let latlng = e.suggestion.latlng;
       centerLatInput.value = latlng["lat"];
       centerLonInput.value = latlng["lng"];

--- a/app/javascript/plugins/places_autocomplete.js
+++ b/app/javascript/plugins/places_autocomplete.js
@@ -1,17 +1,16 @@
 import places from "places.js";
 
 const placesAutocomplete = (appId, apiKey) => {
-  
   // User Form
   const addressInput = document.getElementById("user_address");
   if (addressInput) {
     places({
       container: addressInput,
       appId: appId,
-      apiKey: apiKey,
+      apiKey: apiKey
     }).configure({
       language: "fr",
-      countries: ["fr"],
+      countries: ["fr"]
     });
   }
 
@@ -25,12 +24,12 @@ const placesAutocomplete = (appId, apiKey) => {
     let p = places({
       container: centerAddressInput,
       appId: appId,
-      apiKey: apiKey,
+      apiKey: apiKey
     }).configure({
       language: "fr",
-      countries: ["fr"],
+      countries: ["fr"]
     });
-    p.on("change", function (e) {
+    p.on("change", function(e) {
       let latlng = e.suggestion.latlng;
       centerLatInput.value = latlng["lat"];
       centerLonInput.value = latlng["lng"];

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -28,10 +28,6 @@
       <%= f.input :lastname, label: "Nom", error: "Nom requis", placeholder: "Dupont", required: true %>
       <%= f.input :birthdate, as: :date, label: "Date de naissance", start_year: Date.today.year - 90, end_year: Date.today.year - 18, order: [:day, :month, :year] %>
       <%= f.input :address, label: "Adresse", error: "Adresse requise", placeholder: "5 rue larue, 13600 Marseille", required: true %>
-      <%= f.input :lat, as: :hidden %>
-      <%= f.input :lon, as: :hidden %>
-      <%= f.input :zipcode, as: :hidden %>
-      <%= f.input :city, as: :hidden %>
       <%= f.input :phone_number, label: "Numéro de téléphone portable", error: "Numéro de téléphone invalide", placeholder: "06 06 06 06 06", required: true %>
       <%= f.input :email, label: "Email", error: f.error(:email), placeholder: "jean@dupont.com", hint: "Une adresse email ne peut être utilisée que par une seule personne. 2 personnes = 2 adresses email différentes.", required: true %>
       <%= f.input :password, required: true %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -40,10 +40,6 @@
         <%= f.input :address, label: "Adresse", error: "Adresse requise", placeholder: "5 rue larue, 13600 Marseille" %>
         <%= f.input :email, disabled: true, label: "Email", error: f.error(:email), placeholder: "jean@dupont.com" %>
         <%= f.input :phone_number, label: "Numéro de téléphone", error: "", placeholder: "06 06 06 06 06" %>
-        <%= f.input :lat, as: :hidden %>
-        <%= f.input :lon, as: :hidden %>
-        <%= f.input :zipcode, as: :hidden %>
-        <%= f.input :city, as: :hidden %>
         <%= f.input :statement, as: :boolean, label: "Je certifie sur l'honneur que les informations communiquées ci-dessus sont exactes.", error: "Vous devez cocher cette case pour modifier vos informations.", checked_value: true, unchecked_value: false, required: true %>
         <%= f.button :submit, "Je modifie mes informations", class: "btn btn-primary", data: { disable_with: "Validation..." } %>
       <% end %>


### PR DESCRIPTION
Comme chaque adresse est géocodée par l'api Data.gouv, il n'est pas nécessaire de récupérer lat/lon des résultats l'api places.js d'Algolia