### PR TITLE
Public pages (bénévoles/presse), Partner area improvements, International phone number support, Footer, Centers CSV order fix

### DIFF
--- a/app/controllers/admin/vaccination_centers_controller.rb
+++ b/app/controllers/admin/vaccination_centers_controller.rb
@@ -48,7 +48,7 @@ module Admin
         format.html {
           @pagy_vaccination_centers, @vaccination_centers = pagy(vaccination_centers.order(ActiveRecord::Base.sanitize_sql("#{sort_column} #{sort_direction}")))
         }
-        format.csv { send_data vaccination_centers.order("id asc").to_csv, filename: "vaccination_centers-#{Date.today}.csv" }
+        format.csv { send_data vaccination_centers.order(id: :asc).to_csv, filename: "vaccination_centers-#{Date.today}.csv" }
       end
     end
 

--- a/app/controllers/admin/vaccination_centers_controller.rb
+++ b/app/controllers/admin/vaccination_centers_controller.rb
@@ -48,7 +48,7 @@ module Admin
         format.html {
           @pagy_vaccination_centers, @vaccination_centers = pagy(vaccination_centers.order(ActiveRecord::Base.sanitize_sql("#{sort_column} #{sort_direction}")))
         }
-        format.csv { send_data vaccination_centers.to_csv, filename: "vaccination_centers-#{Date.today}.csv" }
+        format.csv { send_data vaccination_centers.order("id asc").to_csv, filename: "vaccination_centers-#{Date.today}.csv" }
       end
     end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,6 +9,12 @@ class PagesController < ApplicationController
     @faq_items = FaqItem.all
   end
 
+  def benevoles
+  end
+
+  def presse
+  end
+
   def robots
     render "pages/robots", layout: false, content_type: "text/plain"
   end

--- a/app/controllers/partners/vaccination_centers_controller.rb
+++ b/app/controllers/partners/vaccination_centers_controller.rb
@@ -16,6 +16,7 @@ module Partners
 
     def new
       @vaccination_center = VaccinationCenter.new
+      prepare_phone_number
     end
 
     def create
@@ -24,10 +25,15 @@ module Partners
       @partner_vaccination_center = PartnerVaccinationCenter.new(partner: current_partner,
                                                                  vaccination_center: @vaccination_center)
       @partner_vaccination_center.save
+      prepare_phone_number
       render action: :new
     end
 
     private
+
+    def prepare_phone_number
+      @vaccination_center.phone_number = @vaccination_center.human_friendly_phone_number_or_fallback
+    end
 
     def find_vaccination_center
       @vaccination_center = VaccinationCenter.find(params[:id])

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -6,15 +6,43 @@ class PartnersController < ApplicationController
     @partner = Partner.new
   end
 
+  def show
+    @partner = current_partner
+    prepare_phone_number
+  end
+
+  def update
+    @partner = current_partner
+    if @partner.update(partner_params)
+      flash.now[:success] = "Modifications enregistrées."
+    else
+      flash.now[:error] = "Impossible d'enregistrer vos modifications."
+    end
+    prepare_phone_number
+    render action: :show
+  end
+
   def create
     @partner = Partner.new(partner_params)
     # @partner.password = Devise.friendly_token.first(12)
     # @partner.skip_confirmation! if ENV["SKIP_EMAIL_CONFIRMATION"] == 'true'
     @partner.save
+    prepare_phone_number
     render action: :new
   end
 
+  def delete
+    @partner = current_partner
+    @partner.destroy
+    flash[:success] = "Votre compte a bien été supprimé."
+    redirect_to root_path
+  end
+
   private
+
+  def prepare_phone_number
+    @partner.phone_number = @partner.human_friendly_phone_number_or_fallback
+  end
 
   def partner_params
     params.require(:partner).permit(:name, :email, :password, :phone_number)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,6 +47,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     @user.save
+    prepare_phone_number
     render action: :new
   rescue ActiveRecord::RecordNotUnique
     flash.now[:error] = "Une erreur s’est produite."
@@ -63,8 +64,7 @@ class UsersController < ApplicationController
   private
 
   def prepare_phone_number
-    human_friendly_phone_number = @user.human_friendly_phone_number
-    @user.phone_number = human_friendly_phone_number unless human_friendly_phone_number.nil?
+    @user.phone_number = @user.human_friendly_phone_number_or_fallback
   end
 
   def user_params

--- a/app/models/concerns/has_phone_number_concern.rb
+++ b/app/models/concerns/has_phone_number_concern.rb
@@ -9,7 +9,21 @@ module HasPhoneNumberConcern
   end
 
   def human_friendly_phone_number
-    phone_number.gsub(/^33/, "0").match(/(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/)&.captures&.join(" ")
+    unless phone_number.nil?
+      if /^(33|0[1-9])/.match?(phone_number)
+        phone_number.gsub(/^\+?33/, "0").match(/^(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})$/)&.captures&.join(" ")
+      else
+        phone_number.gsub(/^00/, "+").gsub(/^(?!\+)/, "+")
+      end
+    end
+  end
+
+  def human_friendly_phone_number_or_fallback
+    if human_friendly_phone_number.nil?
+      phone_number
+    else
+      human_friendly_phone_number
+    end
   end
 
   private

--- a/app/models/concerns/has_phone_number_concern.rb
+++ b/app/models/concerns/has_phone_number_concern.rb
@@ -19,10 +19,7 @@ module HasPhoneNumberConcern
   end
 
   def human_friendly_phone_number_or_fallback
-    if human_friendly_phone_number.nil?
-      phone_number
-    else
-      human_friendly_phone_number
+    human_friendly_phone_number.presence || phone_number
     end
   end
 

--- a/app/views/admin/vaccination_centers/index.html.haml
+++ b/app/views/admin/vaccination_centers/index.html.haml
@@ -52,7 +52,7 @@
               #{vaccination_center.description}
             %td #{vaccination_center.kind}
             %td #{vaccination_center.address}
-            %td #{vaccination_center.phone_number}
+            %td #{vaccination_center.human_friendly_phone_number_or_fallback}
             %td
               - if vaccination_center.pfizer
                 %span.mr-1= Vaccine::Brands::PFIZER

--- a/app/views/admin/vaccination_centers/show.html.haml
+++ b/app/views/admin/vaccination_centers/show.html.haml
@@ -18,7 +18,7 @@
   %p.mb-2 #{@vaccination_center.address}
   %p.small.mb-2
     = icon("fas", "phone")
-    #{@vaccination_center.phone_number}
+    #{@vaccination_center.human_friendly_phone_number_or_fallback}
     \-
     Vaccins :
     - if @vaccination_center.pfizer
@@ -90,7 +90,7 @@
               %th.text-right= partner.id
               %td= partner.name
               %td= partner.email
-              %td= partner.phone_number
+              %td= partner.human_friendly_phone_number_or_fallback
               %td.text-center{title: partner.confirmed_at.present? ? "Confirmé le #{l(partner.confirmed_at)}" : ""}
                 = humanize_boolean partner.confirmed_at.present?
   - else

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,0 +1,47 @@
+<footer class="bg-light text-lg-start mt-5">
+  <div class="container p-4">
+    <div class="row">
+      <div class="col-lg-6 col-md-12 mb-4 mb-md-0">
+        <h5>Covidliste</h5>
+
+        <p>
+          Une initiative citoyenne portée par des<br />
+          <%= link_to "bénévoles", :benevoles %>
+          dant le but d'accélerer la<br />
+          compagne vaccinale contre la COVID-19<br />
+          #aucunedoseperdue
+        </p>
+      </div>
+
+      <div class="col-lg-3 col-md-6 mb-4 mb-md-0">
+        <ul class="list-unstyled mb-0 mt-4">
+          <li>
+            <%= link_to "Presse", :presse, class: "text-dark" %>
+          </li>
+          <li>
+            <%= link_to "Mentions légales", :mentions_legales, class: "text-dark" %>
+          </li>
+          <li>
+            <%= link_to "Protection des données", :privacy, class: "text-dark" %>
+          </li>
+          <li>
+            <%= link_to "Foire aux questions", :faq, class: "text-dark" %>
+          </li>
+        </ul>
+      </div>
+
+      <div class="col-lg-3 col-md-6 mb-4 mb-md-0">
+        <ul class="list-unstyled mt-4">
+          <li>
+            <%= icon("fab", "github") %>
+            <%= link_to "GitHub", "https://github.com/hostolab/covidliste", class: "text-dark", target: "_blank", rel: "noopener" %>
+          </li>
+          <li>
+            <%= icon("fab", "twitter", class: "text-info") %>
+            <%= link_to "Twitter", "https://twitter.com/covidliste", class: "text-dark", target: "_blank", rel: "noopener" %>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/app/views/layouts/_navbar.html.haml
+++ b/app/views/layouts/_navbar.html.haml
@@ -6,18 +6,18 @@
   #navbarNavDropdown.collapse.navbar-collapse
     %ul.navbar-nav.ml-auto
       - unless current_partner
-        %li{class: (action_name == 'mentions_legales' ? 'nav-item active' : 'nav-item')}
-          = link_to "Mentions légales", :mentions_legales, class: 'nav-link'
-        %li{class: (action_name == 'privacy' ? 'nav-item active' : 'nav-item')}
-          = link_to "Protection des données", :privacy, class: 'nav-link'
         %li{class: (action_name == 'faq' ? 'nav-item active' : 'nav-item')}
-          = link_to "FAQ", :faq, class: 'nav-link'
+          = link_to "Foire aux questions", :faq, class: 'nav-link'
+        %li{class: (action_name == 'benevoles' ? 'nav-item active' : 'nav-item')}
+          = link_to "Bénévoles", :benevoles, class: 'nav-link'
       - if current_partner
         %li.nav-item.dropdown
           %a#dropdown09.nav-link.dropdown-toggle{"aria-expanded" => "false", "aria-haspopup" => "true", "data-toggle" => "dropdown", :href => ""}
             =current_partner.name
             %span.badge.badge-primary Professionnel
           .dropdown-menu.dropdown-menu-right{"aria-labelledby" => "dropdown09"}
+            = link_to "Lieux de vaccination", partners_vaccination_centers_path, class: 'dropdown-item'
+            = link_to "Profil", partners_profile_path, class: 'dropdown-item'
             = link_to "Déconnexion", destroy_partner_session_path, :method => :delete, class: 'dropdown-item'
       - elsif current_user
         %li.nav-item.dropdown

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,5 +23,6 @@
         img:not([alt]), img[alt=""] {border: 5px dashed red;}
       </style>
     <% end %>
+    <%= render "layouts/footer" %>
   </body>
 </html>

--- a/app/views/pages/benevoles.html.erb
+++ b/app/views/pages/benevoles.html.erb
@@ -1,0 +1,63 @@
+<%= content_for(:append_to_head) do %>
+<meta content="index;follow" name="robots"/>
+<% end %>
+
+<div class="container my-5" id="faq">
+  <h1>Bénévoles</h1>
+
+  <p class="mt-4">
+    Covidliste est une initiative bénévole et citoyenne qui a vu le jour il y a quelques semaines pour accélérer la
+    campagne nationale de vaccination contre le Covid19 en distribuant les doses sur le point d'être jetées.
+  </p>
+
+  <p>
+    Nous avons besoin de bénévoles pour venir renforcer nos rangs 💪
+  </p>
+
+  <p class="my-4">
+    <%= link_to "Postuler pour devenir bénévole", "https://form.typeform.com/to/UlzdGjLV", class: "btn btn-primary", target: "_blank", rel: "noopener" %>
+  </p>
+
+  <strong>Exemples de missions :</strong>
+  <ul>
+    <li>
+      Contribuer au développement de la plateforme technologique
+    </li>
+    <li>
+      Travailler sur les interfaces pour que le produit soit utilisable facilement par tout le monde
+    </li>
+    <li>
+      Valider les nouveaux centres de vaccination partenaires
+    </li>
+    <li>
+      Faire connaître le service covidliste auprès de nouveaux centres
+    </li>
+    <li>
+      ...
+    </li>
+  </ul>
+
+  <strong>Voici des exemples d'engagements de certains de nos bénévoles :</strong>
+  <ul>
+    <li>
+      3h00 le mardi matin
+    </li>
+    <li>
+      1h00 le mercredi après-midi, jeudi après-midi et vendredi après-midi
+    </li>
+    <li>
+      tout le lundi après-midi
+    </li>
+    <li>
+      3 heures le dimanche matin
+    </li>
+    <li>
+      ....
+    </li>
+  </ul>
+
+  <p class="mt-5">
+    Si vous êtes développeur, vous pouvez également apporter votre aide en collaborant sur le
+    <%= link_to "GitHub du projet", "https://github.com/hostolab/covidliste", target: "_blank", rel: "noopener" %>.
+  </p>
+</div>

--- a/app/views/pages/benevoles.html.erb
+++ b/app/views/pages/benevoles.html.erb
@@ -7,7 +7,7 @@
 
   <p class="mt-4">
     Covidliste est une initiative bénévole et citoyenne qui a vu le jour il y a quelques semaines pour accélérer la
-    campagne nationale de vaccination contre le Covid19 en distribuant les doses sur le point d'être jetées.
+    campagne nationale de vaccination contre la COVID-19 en distribuant les doses sur le point d'être jetées.
   </p>
 
   <p>

--- a/app/views/pages/benevoles.html.erb
+++ b/app/views/pages/benevoles.html.erb
@@ -30,7 +30,7 @@
       Valider les nouveaux centres de vaccination partenaires
     </li>
     <li>
-      Faire connaître le service covidliste auprès de nouveaux centres
+      Faire connaître le service Covidliste auprès de nouveaux centres
     </li>
     <li>
       ...

--- a/app/views/pages/presse.html.erb
+++ b/app/views/pages/presse.html.erb
@@ -1,0 +1,20 @@
+<%= content_for(:append_to_head) do %>
+<meta content="index;follow" name="robots"/>
+<% end %>
+
+<div class="container my-5" id="faq">
+  <h1>Presse</h1>
+
+  <p class="mt-4">
+    Si vous êtes journaliste et souhaitez réaliser une interview ou obtenir des informations<br />
+    nous vous invitons à contacter l'équipe presse sur <%= link_to "presse@covidliste.com", "mailto:presse@covidliste.com", rel: "noopener" %>.
+  </p>
+
+  <p>
+    Retrouvez ci-dessous l'accès à nos documents et communiqués de presse à destination des journalistes.
+  </p>
+
+  <p class="mt-4">
+    <%= link_to "Documents et communiqués de presse", "https://drive.google.com/drive/folders/1G0yXXJTtp8RaVpoz2lm7PbJLnS26-Gou?usp=sharing", class: "btn btn-primary", target: "_blank", rel: "noopener" %>
+  </p>
+</div>

--- a/app/views/partners/campaigns/show.html.haml
+++ b/app/views/partners/campaigns/show.html.haml
@@ -66,7 +66,7 @@
             %td -
           - else
             %td= user.full_name
-            %td= user.phone_number
+            %td= user.human_friendly_phone_number_or_fallback
             %td= user.birthdate.strftime("%d/%m/%Y")
 
           %td= l match.confirmed_at

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -1,0 +1,42 @@
+<div class="container">
+  <div class="row mt-4 pb-3">
+    <div class="col-12 col-sm-8 offset-sm-2">
+      <h2>Espace professionnels de santé</h2>
+      <p class="mt-3">
+        Bonjour <%= @partner.name %>,
+      </p>
+      <p>
+        Vous êtes inscrit sur Covidliste depuis le <%= @partner.created_at.strftime("%d/%m/%Y") %>
+      </p>
+
+      <p class="mt-3">
+        <strong>Vos informations</strong>
+      </p>
+
+      <% if @partner.errors.any? %>
+        <div class="alert alert-danger" role="alert" style="position: inherit">
+          <% @partner.errors.full_messages.each do |msg| %>
+            <%= msg %><br />
+          <% end %>
+        </div>
+      <% end %>
+
+      <%= simple_form_for(@partner, url: :partners_profile, method: :put, wrapper: :horizontal_form) do |f| %>
+        <%= f.input :name, label: "Nom", error: "Nom requis", placeholder: "Jean Dupont" %>
+        <%= f.input :email, disabled: true, label: "Email", error: f.error(:email), placeholder: "jean@dupont.com" %>
+        <%= f.input :phone_number, label: "Numéro de téléphone", error: "", placeholder: "06 06 06 06 06" %>
+        <%= f.button :submit, "Je modifie mes informations", class: "btn btn-primary", data: { disable_with: "Validation..." } %>
+      <% end %>
+
+      <p class="mt-4">
+        Vous souhaitez supprimer votre compte ?
+        <%= button_to "Supprimer mon compte", partners_profile_path, method: :delete, class: "btn btn-danger",
+                    data: { confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr ?" } %>
+      </p>
+
+      <hr/>
+
+      <%= button_to "Se déconnecter", destroy_partner_session_path, method: :delete, class: "btn btn-warning" %>
+    </div>
+  </div>
+</div>

--- a/app/views/partners/vaccination_centers/index.html.haml
+++ b/app/views/partners/vaccination_centers/index.html.haml
@@ -40,7 +40,7 @@
               = icon("fas", "phone")
               = vaccination_center.human_friendly_phone_number_or_fallback
               %br
-              #{vaccination_center.address}
+              = vaccination_center.address
             %td
               - if vaccination_center.pfizer
                 %span.mr-1= Vaccine::Brands::PFIZER

--- a/app/views/partners/vaccination_centers/index.html.haml
+++ b/app/views/partners/vaccination_centers/index.html.haml
@@ -38,7 +38,7 @@
               #{vaccination_center.description}
             %td
               = icon("fas", "phone")
-              #{vaccination_center.human_friendly_phone_number_or_fallback}
+              = vaccination_center.human_friendly_phone_number_or_fallback
               %br
               #{vaccination_center.address}
             %td

--- a/app/views/partners/vaccination_centers/index.html.haml
+++ b/app/views/partners/vaccination_centers/index.html.haml
@@ -1,12 +1,21 @@
 .container
   %h2.mt-4 Espace professionnels de santé
-  %p.mt-3
+  %p.mt-4.mb-1
     %strong Bonjour #{current_partner.name}
+  %p.small
+    = icon("fas", "phone")
+    = current_partner.human_friendly_phone_number_or_fallback
+    %br/
+    Informations incorrectes ?
+    = link_to "Modifiez votre profil", partners_profile_path
   %p
     Bienvenue dans l'espace
     %strong réservé aux professionnels de santé assurant la vaccination.
     %br/
     Merci de nous avoir rejoint et merci pour ce que vous faites pour aider à la vaccination du plus grand nombre !
+    %br/
+    Un problème, une question ? Contactez-nous sur
+    = link_to "partenaires@covidliste.com", "mailto:partenaires@covidliste.com"
 
   - if @vaccination_centers.any?
     %p.mt-4 Vous avez accès aux lieux de vaccination suivants :
@@ -16,6 +25,7 @@
           %th Nom
           %th Coordonnées
           %th Vaccins
+          %th Collaborateurs
           %th Actions
         - @vaccination_centers.each do |vaccination_center|
           %tr
@@ -28,7 +38,7 @@
               #{vaccination_center.description}
             %td
               = icon("fas", "phone")
-              #{vaccination_center.phone_number}
+              #{vaccination_center.human_friendly_phone_number_or_fallback}
               %br
               #{vaccination_center.address}
             %td
@@ -41,10 +51,31 @@
               - if vaccination_center.janssen
                 %span.mr-1= Vaccine::Brands::JANSSEN
             %td
+              - vaccination_center.partners.each do |partner|
+                = partner.name
+                %br
+            %td
               = link_to "Voir / Gérer les campagnes", partners_vaccination_center_path(vaccination_center.id)
+    %p.small
+      Besoin de donner l'accès à un lieu de vaccination à un collaborateur/collègue ? Contactez-nous sur
+      = link_to "partenaires@covidliste.com", "mailto:partenaires@covidliste.com"
+  - else
+    %p.mt-4
+      Vous n’avez actuellement accès à aucun lieu de vaccination.
 
   - if @unconfirmed_vaccination_centers.any?
-    %p.mt-4 Vos lieux de vaccination en attente de validation :
+    %p.mt-4
+      Vos lieux de vaccination en attente de validation
+      %br/
+      .alert.alert-primary{:role => "alert", style: "position: inherit"}
+        Nous allons vous contacter dans les prochaines heures ou les prochains jours pour valider vos lieux de vaccination en attente.
+        %br/
+        Vérifiez vos informations, et particulièrement votre numéro de téléphone portable :
+        %strong
+          = current_partner.human_friendly_phone_number_or_fallback
+        %br/
+        Numéro incorrect ?
+        = link_to "Modifiez-le sur votre page profil", partners_profile_path
     .table-responsive
       %table.table.table-striped.table-bordered.table-sm.small
         %tr
@@ -62,7 +93,7 @@
               #{vaccination_center.description}
             %td
               = icon("fas", "phone")
-              #{vaccination_center.phone_number}
+              #{vaccination_center.human_friendly_phone_number_or_fallback}
               %br
               #{vaccination_center.address}
             %td
@@ -76,16 +107,63 @@
                 %span.mr-1= Vaccine::Brands::JANSSEN
             %td En attente de validation
 
+
   %p.mt-4
-    Vous n’avez actuellement accès à aucun lieu de vaccination.
-  %p
     = link_to "Demander la création d’un nouveau lieu de vaccination", new_partners_vaccination_center_path, class: "btn btn-primary btn-sm"
 
   %p.mt-4
     .small
       Si vous souhaitez rejoindre un centre déjà existant sur Covidliste,
       contactez-nous sur
-      = link_to "hello@covidliste.com", "mailto:hello@covidliste.com"
+      = link_to "partenaires@covidliste.com", "mailto:partenaires@covidliste.com"
+
+  - if @vaccination_centers.any?
+    .mt-5.mb-5
+      %p
+        Êtes-vous satisfait de Covidliste ?
+        %button.btn.btn-sm.btn-success.mx-3{type: "button", "data-toggle" => "collapse", "data-target" => "#collapseRecommend", "aria-expanded" => "false", "aria-controls" => "collapseRecommend"}
+          Recommandez le service à un confrère
+      #collapseRecommend.collapse
+        .mt-4
+          .row
+            .col-12.col-lg-6
+              %p.mt-4
+                Si vous êtes satisfait de Covidliste, nous avons préparé pour vous un exemple de mail simple et
+                prêt à l'emploi pour recommander le service à un confrère en un clic :
+              %p
+                = link_to icon("fas", "envelope") + " Recommander par mail", "mailto:?cc=partenaires@covidliste.com&subject=Je%20vous%20recommande%20Covidliste%20pour%20trouver%20des%20volontaires%20%C3%A0%20la%20vaccination&body=Cher%20confr%C3%A8re%2C%0D%0A%0D%0AJe%20souhaite%20vous%20faire%20part%20de%20l'existence%20de%20Covidliste%2C%20une%20plateforme%20sur%20laquelle%20je%20suis%20inscrit%2C%20qui%20permet%20aux%20professionnels%20de%20sant%C3%A9%20de%20trouver%20des%20volontaires%20%C3%A0%20la%20vaccination%20en%20cas%20de%20doses%20de%20vaccin%20surnum%C3%A9raires.%0D%0A%0D%0AVoici%20l'adresse%20pour%20s'inscrire%20en%20tant%20que%20professionnel%20%3A%20https%3A%2F%2Fwww.covidliste.com%2Fpartenaires%2F%0D%0A%0D%0AL'%C3%A9quipe%20de%20Covidliste%20est%20en%20copie%20de%20ce%20mail%20pour%20toute%20question%20ou%20besoin%20d'accompagnement.%0D%0A%0D%0ACordialement", class: "btn btn-sm btn-outline-primary", target: "_blank", rel: "noopener"
+              %p.text-center.text-muted.font-italic.my-4 ou
+              %p
+                Nous mettons à votre disposition ci-contre un exemple de contenu mail utilisable pour
+                recommander Covisdliste à un confrère
+
+            .col-12.col-lg-6
+              .card
+                .card-body.small
+                  %p
+                    Cc :
+                    %em
+                      = link_to "partenaires@covidliste.com", "mailto:partenaires@covidliste.com"
+                    %br/
+                    Sujet :
+                    %em
+                      Je vous recommande Covidliste pour trouver des volontaires à la vaccination
+                  Cher confrère,
+                  %br/
+                  %br/
+                  Je souhaite vous faire part de l'existence de Covidliste, une plateforme sur laquelle je suis
+                  inscrit, qui permet aux professionnels de santé de trouver des volontaires à la vaccination
+                  en cas de doses de vaccin surnuméraires.
+                  %br/
+                  %br/
+                  Voici l'adresse pour s'inscrire en tant que professionnel : https://www.covidliste.com/partenaires/
+                  %br/
+                  %br/
+                  L'équipe de Covidliste est en copie de ce mail pour toute question ou besoin d'accompagnement.
+                  %br/
+                  %br/
+                  Cordialement
+
 
   %hr
   = link_to "Se déconnecter", destroy_partner_session_path, method: :delete, class: "btn btn-warning"

--- a/app/views/partners/vaccination_centers/index.html.haml
+++ b/app/views/partners/vaccination_centers/index.html.haml
@@ -135,7 +135,7 @@
               %p.text-center.text-muted.font-italic.my-4 ou
               %p
                 Nous mettons à votre disposition ci-contre un exemple de contenu mail utilisable pour
-                recommander Covisdliste à un confrère
+                recommander Covidliste à un confrère
 
             .col-12.col-lg-6
               .card

--- a/app/views/partners/vaccination_centers/new.html.haml
+++ b/app/views/partners/vaccination_centers/new.html.haml
@@ -7,6 +7,8 @@
     Cet de création d'un nouveau lieu de vaccination est
     %strong réservé aux professionnels de santé assurant la vaccination :
     membre d’un centre de vaccination, cabinet de médecine libérale, hôpital, pharmacie...
+  %p
+    Nous prendrons contact avec vous pour valider la création du lieu.
   - if @vaccination_center.persisted?
     .row.mtop2
       .alert.alert-success{:role => "alert", style: "position: inherit"}
@@ -15,7 +17,7 @@
         Votre demande est en attente de validation par l'équipe Covidliste.
         %br
         Vous pourrez suivre l’état de la demande sur votre
-        = link_to "profil professionnel de santé assurant la vaccination", partners_vaccination_centers_path
+        = link_to "espace professionnel de santé assurant la vaccination", partners_vaccination_centers_path
   - else
     - if @vaccination_center.errors.any?
       .alert.alert-danger{:role => "alert", style: "position: inherit"}
@@ -26,6 +28,12 @@
       = f.input :name, label: "Nom du lieu de vaccination", error: "Nom requis", placeholder: "Centre de vaccination Marseille"
       = f.input :description, label: "Description", error: "Description requise", placeholder: "Description du lieu de vaccination"
       = f.input :kind, label: "Type de lieu de vaccination", collection: VaccinationCenter::Kinds::ALL
+      %p.small.text-primary
+        = icon("fas", "info-circle", class: "text-secondary")
+        Vous ne trouvez pas le type de lieu de vaccination qui vous correspond ?
+        %br/
+        Choisissez la valeur qui s'en approche le plus et ajoutez vore type de lieu comme préfixe dans le champ "Nom" ou "Description" ci-dessus.
+
       %p.mtop2
         Type(s) de vaccins disponibles
       = f.input :pfizer, as: :boolean, label: Vaccine::Brands::PFIZER, checked_value: true, unchecked_value: false, class: "form-check-inline"

--- a/app/views/partners/vaccination_centers/show.html.haml
+++ b/app/views/partners/vaccination_centers/show.html.haml
@@ -9,7 +9,7 @@
       %p.mb-2 #{@vaccination_center.address}
       %p.small.mb-2
         = icon("fas", "phone")
-        = @vaccination_center.phone_number
+        = @vaccination_center.human_friendly_phone_number_or_fallback
         \-
         Vaccins :
         - if @vaccination_center.pfizer

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,8 +61,10 @@ Rails.application.routes.draw do
   get "/users" => "users#new"
 
   ## Partners
-
   resources :partners, only: [:new, :create]
+  get "/partners/profile" => "partners#show", :as => :partners_profile
+  put "/partners/profile" => "partners#update", :as => ""
+  delete "/partners/profile" => "users#delete", :as => ""
   get "/partenaires", to: redirect("/partenaires/inscription", status: 302)
   get "/partenaires/inscription" => "partners#new", :as => :partenaires_inscription
 
@@ -82,6 +84,8 @@ Rails.application.routes.draw do
   get "/mentions_legales" => "pages#mentions_legales", :as => :mentions_legales
   get "/privacy" => "pages#privacy", :as => :privacy
   get "/faq" => "pages#faq", :as => :faq
+  get "/presse" => "pages#presse", :as => :presse
+  get "/benevoles" => "pages#benevoles", :as => :benevoles
 
   ## robots.txt
   get "/robots.txt", to: "pages#robots"

--- a/db/frozen_records/faq_items.yml
+++ b/db/frozen_records/faq_items.yml
@@ -351,12 +351,9 @@
   body_md_erb: |
     Merci beaucoup de vous proposer, cela nous fait très plaisir de voir que vous souhaitez nous apporter votre soutien !
 
-    Pour l’instant nous avons une solide équipe de bénévoles et nous n’avons pas besoin d’aide supplémentaire.
+    Nous vous invitons à consulter la <%= link_to "page dédiée aux bénévoles", :benevoles %>.
 
-    Si nous avons un besoin précis, nous communiquerons probablement sur
-    <%= link_to "Twitter", "https://twitter.com/covidliste", target: "_blank", rel: "noopener" %>.
-
-    Si vous êtes développeur, vous pouvez apporter votre aide en collaborant sur
+    Si vous êtes développeur, vous pouvez également apporter votre aide en collaborant sur le
     <%= link_to "GitHub du projet", "https://github.com/hostolab/covidliste", target: "_blank", rel: "noopener" %>.
 
 - title: Je représente une entreprise ou une association et nous voulons vous aider.


### PR DESCRIPTION
Fixes #328 #326 #324 #323 #285

Pas mal de features là d'dans

Gestion des numéros de téléphone français et  internationaux partout.
- Français : format 01 23 45 67 89
- International : format +1234556789

Nouvelle page bénévoles
![Capture d’écran 2021-04-12 233330](https://user-images.githubusercontent.com/666182/114466454-cd0f9300-9be8-11eb-92ec-be0754646588.png)

Nouvelle page presse
![Capture d’écran 2021-04-12 233344](https://user-images.githubusercontent.com/666182/114466463-d0a31a00-9be8-11eb-9e0c-14fc5a145c44.png)

Mise à jour de la page pro gestion des centres (informations perso rappelées, information de validation, affichage des personnes ayant accès, message de recommandation à un confrère)
![screencapture-covidliste-carsso-dev-partners-vaccination-centers-2021-04-12-23_34_13](https://user-images.githubusercontent.com/666182/114466462-d00a8380-9be8-11eb-841f-9b1a238172c8.png)

Mise à jour de la page de création d'un centre (petit message concernant le type de lieu de vaccination, geocoding auto côté serveur si algolia n'a pas trouvé la geoloc / n'a pas été utilisé)
![Capture d’écran 2021-04-12 234855](https://user-images.githubusercontent.com/666182/114467092-a9991800-9be9-11eb-81dd-c6189dbff235.png)

Nouvelle page de profil permettant de modifier ses infos/supprimer son compte en tant que pro
![Capture d’écran 2021-04-12 233608](https://user-images.githubusercontent.com/666182/114466464-d0a31a00-9be8-11eb-9bf0-4f4cc8a8d30e.png)
