### PR TITLE
fix: Make validation on lat lon contextual for VaccinationCenter

### DIFF
--- a/app/controllers/admin/vaccination_centers_controller.rb
+++ b/app/controllers/admin/vaccination_centers_controller.rb
@@ -61,7 +61,7 @@ module Admin
 
     def create
       @vaccination_center = VaccinationCenter.new(vaccination_center_params)
-      @vaccination_center.save(context: :validation_by_admin)
+      @vaccination_center.save
       render action: :new
     end
 

--- a/app/controllers/admin/vaccination_centers_controller.rb
+++ b/app/controllers/admin/vaccination_centers_controller.rb
@@ -61,13 +61,15 @@ module Admin
 
     def create
       @vaccination_center = VaccinationCenter.new(vaccination_center_params)
-      @vaccination_center.save
+      @vaccination_center.save(context: :validation_by_admin)
       render action: :new
     end
 
     def validate
       if @vaccination_center.confirmed_at.nil?
-        if @vaccination_center.update(confirmed_at: Time.now.utc, confirmer: current_user)
+        @vaccination_center.confirmed_at = Time.now.utc
+        @vaccination_center.confirmer = current_user
+        if @vaccination_center.save(context: :validation_by_admin)
           flash[:success] = "Ce centre a bien été validé"
         else
           flash[:alert] = "Une erreur est survenue : #{@vaccination_center.errors.full_messages.join(", ")}"

--- a/app/models/vaccination_center.rb
+++ b/app/models/vaccination_center.rb
@@ -12,7 +12,8 @@ class VaccinationCenter < ApplicationRecord
   include PgSearch::Model
   pg_search_scope :global_search, against: [:name, :description, :kind, :address]
 
-  validates_presence_of :name, :address, :lat, :lon, :phone_number
+  validates :name, :address, :phone_number, presence: true
+  validates :lat, :lon, presence: true, on: :validation_by_admin
   validates :kind, inclusion: {in: VaccinationCenter::Kinds::ALL}
 
   has_many :partner_vaccination_centers

--- a/spec/models/vaccination_center_spec.rb
+++ b/spec/models/vaccination_center_spec.rb
@@ -2,6 +2,22 @@ require "rails_helper"
 
 RSpec.describe VaccinationCenter, type: :model do
   let(:vaccination_center) { create(:vaccination_center, lat: 42, lon: 2) }
+  describe "validations" do
+    context "when vaccination center has no lat neither lon" do
+      subject { build(:vaccination_center, lat: nil, lon: nil) }
+
+      context "on default context" do
+        it "is valid" do
+          expect(subject.valid?).to be true
+        end
+      end
+      context "on validation_by_admin context" do
+        it "is invalid" do
+          expect(subject.invalid?(:validation_by_admin)).to be true
+        end
+      end
+    end
+  end
 
   describe "#reachable_users_query" do
     it "should not re-match someone who was matched less than a day ago" do


### PR DESCRIPTION
This is an attempt to make validation required on lat and lon only if an admin validates or creates a VaccinationCenter.
This has not been tested yet. I will definitely add tests if you believe I went towards the right direction.
Happy to discuss.
Partially Fixes #324