### PR TITLE
Prompt user to check Age & Name when matched

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
+*.tmp
 
 # Ignore pidfiles, but keep the directory.
 /tmp/pids/*

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -2,6 +2,10 @@ class MatchesController < ApplicationController
   before_action :set_match, only: [:show, :update]
 
   def show
+    if @match.age != @match.user.age
+      flash[:error] = "Désolé, votre âge a changé depuis l'envoi de la notification. Pas d'inquiétude, vous restez dans notre liste de volontaires ! Vous serez contacté dès qu'une dose est à nouveau disponible près de chez vous."
+      redirect_to root_path
+    end
   end
 
   def update

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -7,7 +7,7 @@
         <p>
           Une initiative citoyenne portée par des<br />
           <%= link_to "bénévoles", :benevoles %>
-          dant le but d'accélerer la<br />
+          dans le but d'accélerer la<br />
           compagne vaccinale contre la COVID-19<br />
           #aucunedoseperdue
         </p>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -24,9 +24,9 @@
       <i class="fas fa-user-lock"></i>
       <p>
         Réservé pour <strong><%= user.full_name %></strong><br>
-        Agé(e) de <strong><%= match.age %> ans</strong><br>
+        Né le <strong><%= user.birthdate %></strong><br>
         Réservation strictement nominative. <br>
-        <strong>Âge et nom seront vérifiés.</strong>        
+        <strong>Âge et nom seront vérifiés.</strong>   
       </p>
     </div>
   <% end %>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -23,9 +23,10 @@
     <div>
       <i class="fas fa-user-lock"></i>
       <p>
-        Réservé pour <%= user.full_name %><br>
-        Né le <%= user.birthdate %><br>
-        Réservation strictement nominative.
+        Réservé pour <strong><%= user.full_name %></strong><br>
+        Agé(e) de <strong><%= match.age %> ans</strong><br>
+        Réservation strictement nominative. <br>
+        <strong>Âge et nom seront vérifiés.</strong>        
       </p>
     </div>
   <% end %>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -26,7 +26,7 @@
         Réservé pour <strong><%= user.full_name %></strong><br>
         Né le <strong><%= user.birthdate %></strong><br>
         Réservation strictement nominative. <br>
-        <strong>Âge et nom seront vérifiés.</strong>   
+        <strong>Date de naissance et nom seront vérifiés.</strong>   
       </p>
     </div>
   <% end %>
@@ -37,4 +37,3 @@
     <p><%= match.campaign.vaccine_type.capitalize %></p>
   </div>
 </div>
-

--- a/app/views/matches/_pending.html.erb
+++ b/app/views/matches/_pending.html.erb
@@ -45,7 +45,7 @@
     <p>
       <small>
         Si ces informations sont inexactes, le practicien ne pourra pas vous vacciner. <br>
-        Vous pourrez bénéficier d'une prochaine dose disponible en les modifiant sur <a href="https://www.covidliste.com/login">www.covidliste.com/login</a>
+        Vous pourrez bénéficier d'une prochaine dose disponible en les modifiant sur <%= link_to "votre profil", profile_path %>
       </small>
     </p>
   </div>

--- a/app/views/matches/_pending.html.erb
+++ b/app/views/matches/_pending.html.erb
@@ -8,18 +8,72 @@
 </p>
 
 <%= render 'match_details', match: @match %>
+<% user = match.user %>
 
 <div class="alert alert-primary" role="alert">
   Merci de confirmer votre présence <strong>uniquement</strong> si vous pouvez vous rendre au centre de vaccination à
   l'horaire communiqué.
 </div>
 
-<div class="btn btn-primary m-2">
-  <%= link_to 'Je suis disponible' , match_path(match_confirmation_token: @match.match_confirmation_token), method: :patch, class: 'btn btn-primary btn-block' %>
-</div>
+<form action="<%= match_path(match_confirmation_token: @match.match_confirmation_token) %>" method="POST" class="needs-validation row" novalidate>
+  <input type="hidden" name="_method" value="PATCH">
+  <div class="col-12 mb-2">
+    <div class="form-check flex-wrap">
+      <input class="form-check-input" type="checkbox" value="" id="confirm_name" required>
+      <label class="form-check-label w-75" for="confirm_name">
+        Je confirme avoir une pièce d'identitée au nom de <strong><%= user.full_name %></strong>
+      </label>
+      <div class="invalid-feedback w-100">
+        Vous devez confirmer votre nom. <br>
+        S'il est inexact, le practicien ne pourra pas vous vacciner.
+      </div>
+    </div>
+  </div>
+  <div class="col-12 mb-2">
+    <div class="form-check flex-wrap">
+      <input class="form-check-input" type="checkbox" value="" id="confirm_age" required>
+      <label class="form-check-label w-75" for="confirm_age">
+        Je confirme que mon âge est de <strong><%= match.age %> ans</strong>
+      </label>
+      <div class="invalid-feedback w-100">
+        Vous devez confirmer votre date de naissance. <br>
+        Si elle est inexacte, le practicien ne pourra pas vous vacciner.
+      </div>
+    </div>
+  </div>
+  <div class="col-12">
+    <p>
+      <small>
+        Si ces informations sont inexactes, le practicien ne pourra pas vous vacciner. <br>
+        Vous pourrez bénéficier d'une prochaine dose disponible en les modifiant sur <a href="https://www.covidliste.com/login">www.covidliste.com/login</a>
+      </small>
+    </p>
+  </div>
+  <div class="col-12 mb-2">
+    <button class="btn btn-primary" type="submit">Je suis disponible</button>
+  </div>
+</form>
 
 <p>
   <small>
-    Une fois votre présence confirmée, vos coordonnées sont transmises au centre de vaccination. Votre compte et vos informations seront alors définitivement supprimés de Covidliste sous 24h, et vous ne recevrez plus de notifications.
+    Une fois votre présence confirmée, vos coordonnées sont transmises au centre de vaccination. Votre compte et vos informations seront alors définitivement supprimés de Covidliste sous 7 jours, et vous ne recevrez plus de notifications.
   </small>
 </p>
+
+<script>
+// Script from https://getbootstrap.com/docs/5.0/forms/validation/
+(function () {
+  var forms = document.querySelectorAll('.needs-validation')
+  Array.prototype.slice.call(forms)
+    .forEach(function (form) {
+      form.addEventListener('submit', function (event) {
+        if (!form.checkValidity()) {
+          event.preventDefault()
+          event.stopPropagation()
+        }
+
+        form.classList.add('was-validated')
+      }, false)
+    })
+})()
+</script>

--- a/app/views/matches/_pending.html.erb
+++ b/app/views/matches/_pending.html.erb
@@ -45,7 +45,7 @@
     <p>
       <small>
         Si ces informations sont inexactes, le practicien ne pourra pas vous vacciner. <br>
-        Vous pourrez bénéficier d'une prochaine dose disponible en les modifiant sur <%= link_to "votre profil", profile_path %>
+        Vous pouvez les modifier sur <%= link_to "votre profil", profile_path %>, dans ce cas vous bénéficierez d'une prochaine dose disponible.
       </small>
     </p>
   </div>

--- a/app/views/matches/_pending.html.erb
+++ b/app/views/matches/_pending.html.erb
@@ -33,7 +33,7 @@
     <div class="form-check flex-wrap">
       <input class="form-check-input" type="checkbox" value="" id="confirm_age" required>
       <label class="form-check-label w-75" for="confirm_age">
-        Je confirme que mon âge est de <strong><%= match.age %> ans</strong>
+        Je confirme avoir une pièce d'identitée portant la date de naissance <strong><%= user.birthdate %></strong>
       </label>
       <div class="invalid-feedback w-100">
         Vous devez confirmer votre date de naissance. <br>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1,15 +1,17 @@
-<div class="row">
-  <div class="col-sm-12 col-md-8 col-lg-8">
-    <div class="text-left mt-4">
-      <% if @match.confirmed? %>
-        <%= render 'confirmed', match: @match %>
-      <% elsif @match.expired? %>
-        <%= render 'expired', match: @match %>
-      <% elsif !@match.confirmable? %>
-        <%= render 'overbooked', match: @match %>
-      <% elsif !@match.expired? %>
-        <%= render 'pending', match: @match %>
-      <% end %>
+<div class="container">
+  <div class="row">
+    <div class="col-sm-12 col-md-8 col-lg-8">
+      <div class="text-left mt-4">
+        <% if @match.confirmed? %>
+          <%= render 'confirmed', match: @match %>
+        <% elsif @match.expired? %>
+          <%= render 'expired', match: @match %>
+        <% elsif !@match.confirmable? %>
+          <%= render 'overbooked', match: @match %>
+        <% elsif !@match.expired? %>
+          <%= render 'pending', match: @match %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Résouds l'issue https://github.com/hostolab/covidliste/issues/372

* Demande à l'utilisateur de confirmer son nom avant de valider un match
* Demande à l'utilisateur de confirmer sa date de naissance avant de valider un match
* Précise que ces informations seront vérifiées
* Vérifie que l'utilisateur n'a pas modifié sa date de naissance depuis la création du match

|Flow| Erreur suite à modification d'âge|
|-|-|
|<video src="https://user-images.githubusercontent.com/5511564/114713241-3995a980-9d31-11eb-908b-ea31801c2821.mov"></video>|<img width="1600" alt="image" src="https://user-images.githubusercontent.com/5511564/114714659-99408480-9d32-11eb-914d-aff4421e1440.png">|

(Quelques modifications de wording ont été faites depuis la vidéo)
