### PR TITLE
Always show campaign extra info

### DIFF
--- a/app/views/matches/_confirmed.html.erb
+++ b/app/views/matches/_confirmed.html.erb
@@ -6,12 +6,3 @@
 </p>
 
 <%= render 'match_details', match: @match %>
-
-<% if match.campaign.extra_info %>
-  <div>
-    <p>
-      <i class="fas fa-info-circle"></i>
-      <%= match.campaign.extra_info %>
-    </p>
-  </div>
-<% end %>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -36,4 +36,12 @@
     <strong>Type de vaccin</strong>
     <p><%= match.campaign.vaccine_type.capitalize %></p>
   </div>
+  <% if match.campaign.extra_info %>
+    <div>
+      <p>
+        <i class="fas fa-info-circle"></i>
+        <%= match.campaign.extra_info %>
+      </p>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
**Currently being discussed**

* Fixes bug where campaign extra info was not shown before the match was accepted.
* Il faut montrer les extra infos car elles peuvent contenir des informations importantes pour décider d'accepter ou non le match.
* [Discussion slack](https://covidliste.slack.com/archives/C01T48BHRCL/p1618448211440400)

|Before|After|
|-|-|
|<img width="1570" alt="image" src="https://user-images.githubusercontent.com/5511564/114825435-84153580-9dc6-11eb-9a05-d713b52abc6d.png">|<img width="1570" alt="image" src="https://user-images.githubusercontent.com/5511564/114825294-4f08e300-9dc6-11eb-9883-bbf94ba5a67f.png">|

