### PR TITLE
Afficher les informations suppl sur Slack

### DIFF
--- a/app/jobs/push_new_campaign_to_slack_job.rb
+++ b/app/jobs/push_new_campaign_to_slack_job.rb
@@ -45,6 +45,10 @@ class PushNewCampaignToSlackJob < ApplicationJob
             value: campaign.vaccination_center.address
           },
           {
+            title: "Informations",
+            value: campaign.extra_info
+          },
+          {
             title: "Horaires",
             value: "#{campaign.starts_at.strftime("%Hh%M")} - #{campaign.ends_at.strftime("%Hh%M")}",
             short: true


### PR DESCRIPTION
* L'objectif est de détecter d'éventuels abus sur ce champ
* Discuté dans ce [long thread slack](https://covidliste.slack.com/archives/C01T48BHRCL/p1618448211440400)