### PR TITLE
Expliquer que les extra infos ne sont visibles qu'après confirmation des volontaires

### DIFF
--- a/app/views/partners/campaigns/new.html.haml
+++ b/app/views/partners/campaigns/new.html.haml
@@ -26,7 +26,7 @@
             = f.input :starts_at, as: :time, label: "Début"
           .col.col-6
             = f.input :ends_at, as: :time, label: "Fin"
-        = f.input :extra_info, label: "Informations supplémentaires pour les volontaires", hint: "Accès, modalités... Les volontaires verront cette information avant de confirmer leur rendez-vous."
+        = f.input :extra_info, label: "Informations supplémentaires pour les volontaires", hint: "Accès, modalités... Les volontaires ne verront cette information qu'après avoir confirmé leur rendez-vous."
 
         %h5 Critères de sélection des volontaires
 


### PR DESCRIPTION
* Alignement des informations affichées au partenaire sur ce qui se passe en réalité
* Permet d'éviter certains abus sur le champ extra_infos (préselection des volontaires etc...)
* Discuté dans [ce long thread slack](https://covidliste.slack.com/archives/C01T48BHRCL/p1618448211440400)

|Before|After|
|-|-|
|<img width="885" alt="image" src="https://user-images.githubusercontent.com/5511564/114831681-f4738500-9dcd-11eb-9b32-34676626552d.png">|<img width="859" alt="image" src="https://user-images.githubusercontent.com/5511564/114831741-02c1a100-9dce-11eb-9a91-4f6566d5900a.png">|