### PR TITLE
Fix typo Guadeloupe

### DIFF
--- a/app/javascript/controllers/carte/map_controller.js
+++ b/app/javascript/controllers/carte/map_controller.js
@@ -25,7 +25,7 @@ const TERRITOIRES = {
     zoom: 6.0,
   },
   GUADELOUPE: {
-    label: "Gadeloupe",
+    label: "Guadeloupe",
     lon: -61.5,
     lat: 16.176021024448076,
     zoom: 8.5,


### PR DESCRIPTION
Tout est dans le titre.
Vu sur Twitter: https://twitter.com/FNarolles/status/1382688506686889984