### PR TITLE
Fix CSP headers for the map

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,10 +9,12 @@ class ApplicationController < ActionController::Base
     content_security_policy do |policy|
       policy.default_src :self, :https
       policy.font_src :self, :data, :https
-      policy.img_src :self, :data, :https
+      policy.img_src :self, :data, :https, :blob
       policy.object_src :none
       policy.script_src :strict_dynamic
       policy.style_src :self, :https, :unsafe_inline
+      policy.worker_src :blob
+      policy.child_src :blob
     end
   end
 


### PR DESCRIPTION
La page "Carte" ne fonctionne pas sous safari/iPhone car il manque des permissions CSP