### PR TITLE
Fixed addons config for review apps

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -24,12 +24,10 @@
   },
   "addons": [
     {
-      "addon_provider_id": "postgresql",
-      "plan_id": "postgresql-sandbox"
+      "plan": "postgresql:postgresql-sandbox"
     },
     {
-      "addon_provider_id": "redis",
-      "plan_id": "redis-sandbox"
+      "plan": "redis:redis-sandbox"
     }
   ],
   "formation": {


### PR DESCRIPTION
Updated the config for review apps that were starting without the addons.

After asking the support, they explained the format was not the correct one. The correct doc for the format is [here](https://doc.scalingo.com/platform/app/app-manifest).

If you want to check the available plans: `scalingo addons-plans redis`