### PR TITLE
Restored links deleted during ERB migration

### DIFF
--- a/app/views/layouts/_admin_navbar.html.erb
+++ b/app/views/layouts/_admin_navbar.html.erb
@@ -21,6 +21,15 @@
         </li>
 
         <li class="nav-item dropdown">
+          <%= link_to "Outils supply", "", class: "nav-link dropdown-toggle", id: "dropdownSuper", "aria-expanded": "false", "aria-haspopup": "true", "data-toggle": "dropdown" %>
+
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownSuper">
+            <%= link_to "Lieux de vaccination", admin_vaccination_centers_path, class: "dropdown-item" %>
+            <%= link_to "Statistiques", admin_stats_path, class: "dropdown-item" %>
+          </div>
+        </li>
+
+        <li class="nav-item dropdown">
           <%= link_to "Outils DataScience", "", class: "nav-link dropdown-toggle", id: "dropdownData", "aria-expanded": "false", "aria-haspopup": "true", "data-toggle": "dropdown" %>
 
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownData">


### PR DESCRIPTION
Quelques liens de la navbar admin ont l'air d'avoir été perdus durant la migration HAML -> ERB (https://github.com/hostolab/covidliste/pull/398)

<img width="338" alt="image" src="https://user-images.githubusercontent.com/503432/114914980-4db9d380-9e23-11eb-8bce-4911600ae3c5.png">
