### PR TITLE
Format the Algolia suggestion with the zip code and without the region

### DIFF
--- a/app/javascript/plugins/places_autocomplete.js
+++ b/app/javascript/plugins/places_autocomplete.js
@@ -8,11 +8,19 @@ const placesAutocomplete = (appId, apiKey) => {
       container: addressInput,
       appId: appId,
       apiKey: apiKey,
+      templates: {
+        value: (suggestion) => {
+          // overide Algolia default address formating that includes French region but not the Zip code.
+          // french region can confuse the address geocoding API
+          return `${suggestion.name}, ${suggestion.postcode} ${suggestion.city}, ${suggestion.country}`;
+        },
+      },
     }).configure({
       language: "fr",
       countries: ["fr"],
     });
   }
+  // 3 Rue de la Paix, 75002 Paris 2e Arrondissement, undefined
 
   // Vaccination Center Signup Form
   const centerAddressInput = document.getElementById(
@@ -25,11 +33,19 @@ const placesAutocomplete = (appId, apiKey) => {
       container: centerAddressInput,
       appId: appId,
       apiKey: apiKey,
+      templates: {
+        value: (suggestion) => {
+          // overide Algolia default address formating that includes French region but not the Zip code.
+          // french region can confuse the address geocoding API
+          return `${suggestion.name}, ${suggestion.postcode} ${suggestion.city}, ${suggestion.country}`;
+        },
+      },
     }).configure({
       language: "fr",
       countries: ["fr"],
     });
     p.on("change", function (e) {
+      console.log(e.suggestion);
       let latlng = e.suggestion.latlng;
       centerLatInput.value = latlng["lat"];
       centerLonInput.value = latlng["lng"];

--- a/app/javascript/plugins/places_autocomplete.js
+++ b/app/javascript/plugins/places_autocomplete.js
@@ -45,7 +45,6 @@ const placesAutocomplete = (appId, apiKey) => {
       countries: ["fr"],
     });
     p.on("change", function (e) {
-      console.log(e.suggestion);
       let latlng = e.suggestion.latlng;
       centerLatInput.value = latlng["lat"];
       centerLonInput.value = latlng["lng"];

--- a/app/javascript/plugins/places_autocomplete.js
+++ b/app/javascript/plugins/places_autocomplete.js
@@ -9,11 +9,8 @@ const placesAutocomplete = (appId, apiKey) => {
       appId: appId,
       apiKey: apiKey,
       templates: {
-        value: (suggestion) => {
-          // overide Algolia default address formating that includes French region but not the Zip code.
-          // french region can confuse the address geocoding API
-          return `${suggestion.name}, ${suggestion.postcode} ${suggestion.city}, ${suggestion.country}`;
-        },
+        value: formattedValue,
+        suggestion: formattedSuggestion,
       },
     }).configure({
       language: "fr",
@@ -34,11 +31,8 @@ const placesAutocomplete = (appId, apiKey) => {
       appId: appId,
       apiKey: apiKey,
       templates: {
-        value: (suggestion) => {
-          // overide Algolia default address formating that includes French region but not the Zip code.
-          // french region can confuse the address geocoding API
-          return `${suggestion.name}, ${suggestion.postcode} ${suggestion.city}, ${suggestion.country}`;
-        },
+        value: formattedValue,
+        suggestion: formattedSuggestion,
       },
     }).configure({
       language: "fr",
@@ -51,5 +45,18 @@ const placesAutocomplete = (appId, apiKey) => {
     });
   }
 };
+
+function formattedValue(reponse) {
+  // overide Algolia default address formating that includes French region but not the Zip code.
+  // french region can confuse the address geocoding API
+  return `${reponse.name}, ${reponse.postcode} ${reponse.city}, ${reponse.country}`;
+}
+
+function formattedSuggestion(reponse) {
+  // overide Algolia default address formating suggestion that includes French region but not the Zip code.
+  return [reponse.name, reponse.postcode, reponse.city, reponse.country]
+    .filter((e) => e !== "undefined")
+    .join(" ");
+}
 
 export { placesAutocomplete };


### PR DESCRIPTION
Résout  https://covidliste.slack.com/archives/C01T48BHRCL/p1618522339043300 pour les nouveaux inscris

Par défaut Algolia format l'adresse avec le nom de la région et pas le code postal. 

Le nom de la région n'est pas utilisé par l'API etalab `addresse` et du coup il y a des confusions entre certaines villes présentent dans plusieurs régions.

Cette PR change le formatage de l'autocomplete afin de supprimer la région et ajouter le code postal de la ville.

|avant|après|
|----|---|
|![Capture d’écran 2021-04-16 à 6 59 42 AM](https://user-images.githubusercontent.com/7847244/114973925-b172e980-9e81-11eb-915c-a6af5a801746.jpg)|![Capture d’écran 2021-04-16 à 6 58 20 AM](https://user-images.githubusercontent.com/7847244/114973915-acae3580-9e81-11eb-81fb-f9c3cd04f974.jpg)|

