### PR TITLE
Opt out from the Google FLoC

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,10 @@ module Covidliste
       app.routes.default_url_options = app.config.action_mailer.default_url_options
     end
 
+    config.action_dispatch.default_headers = {
+      "Permissions-Policy" => "interest-cohort=()"
+    }
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
Google rolling out FLoC tracking protocol for Google Chrome users. By
default browser and website are opt in in this new tracking protocol.