### PR TITLE
Pre-select user birthdate year to 1961

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
     elsif current_user
       redirect_to profile_path
     else
-      @user = User.new
+      @user = User.new(birthdate: Date.today.change(year: 1961))
       @users_count = Rails.cache.fetch(:users_count, expires_in: 1.minute) do
         number_with_delimiter(User.count, locale: :fr).gsub(" ", "&nbsp;").html_safe
       end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -24,24 +24,50 @@
     <% end %>
 
     <%= simple_form_for @user do |f| %>
-      <%= f.input :firstname, label: "Prénom", error: "Prénom requis", placeholder: "Jean", required: true, input_html: {autocomplete: "given-name"} %>
-      <%= f.input :lastname, label: "Nom", error: "Nom requis", placeholder: "Dupont", required: true, input_html: {autocomplete: "family-name"} %>
-      <%= f.input :birthdate, as: :date, label: "Date de naissance", start_year: Date.today.year - 120, end_year: Date.today.year - 18, order: [:day, :month, :year] %>
-      <p class="text-primary small">Vérifiez bien vos nom, prénom et date de naissance. En cas d'erreur, la vaccination ne sera pas possible !</p>
-      <%= f.input :address, label: "Adresse", error: "Adresse requise", placeholder: "5 rue larue, 13600 Marseille", required: true %>
+      <%= f.input :firstname,
+                  label: "Prénom",
+                  error: "Prénom requis",
+                  placeholder: "Jean",
+                  required: true,
+                  input_html: { autocomplete: "given-name" } %>
+
+      <%= f.input :lastname,
+                  label: "Nom",
+                  error: "Nom requis",
+                  placeholder: "Dupont",
+                  required: true,
+                  input_html: { autocomplete: "family-name" } %>
+
+      <%= f.input :birthdate,
+                  as: :date,
+                  label: "Date de naissance",
+                  start_year: Date.today.year - 120,
+                  end_year: Date.today.year - 18,
+                  order: [:day, :month, :year] %>
+      
+      <p class="text-primary small">
+        Vérifiez bien vos nom, prénom et date de naissance. En cas d'erreur, la vaccination ne sera pas possible !
+      </p>
+      <%= f.input :address,
+                  label: "Adresse",
+                  error: "Adresse requise",
+                  placeholder: "5 rue Larue, 13600 Marseille",
+                  required: true %>
+
       <%= f.input :phone_number,
                   label: "Numéro de téléphone portable",
                   error: "Numéro de téléphone invalide",
                   placeholder: "06 06 06 06 06",
                   required: true,
                   input_html: { autocomplete: "tel" } %>
+
       <%= f.input :email,
                   label: "Email",
                   error: f.error(:email),
                   placeholder: "jean@dupont.com",
                   hint: "Une adresse email ne peut être utilisée que par une seule personne. 2 personnes = 2 adresses email différentes.",
                   required: true,
-                  input_html: {autocomplete: "email"} %>
+                  input_html: { autocomplete: "email" } %>
 
       <div class="form-group">
         <label for="user_password"> Mot de passe </label>
@@ -62,8 +88,21 @@
         <small class="form-text text-muted"> <%= Devise.password_length.min %> caractères minimum </small>
       </div>
 
-      <%= f.input :statement, as: :boolean, label: "Je certifie sur l'honneur que les informations communiquées ci-dessus sont exactes.", checked_value: true, unchecked_value: false, error: "Vous devez cocher cette case pour valider votre inscription", required: true %>
-      <%= f.input :toc, as: :boolean, label: "J’accepte que mes données soient partagées avec les centres de vaccination inscrits sur Covidliste.", checked_value: true, unchecked_value: false, error: "Vous devez cocher cette case pour valider votre inscription", required: true %>
+      <%= f.input :statement,
+                  as: :boolean,
+                  label: "Je certifie sur l'honneur que les informations communiquées ci-dessus sont exactes.",
+                  checked_value: true,
+                  unchecked_value: false,
+                  error: "Vous devez cocher cette case pour valider votre inscription",
+                  required: true %>
+
+      <%= f.input :toc,
+                  as: :boolean,
+                  label: "J’accepte que mes données soient partagées avec les centres de vaccination inscrits sur Covidliste.",
+                  checked_value: true,
+                  unchecked_value: false,
+                  error: "Vous devez cocher cette case pour valider votre inscription",
+                  required: true %>
       <%= f.invisible_captcha :subtitle %>
       <%= f.button :submit, "Je m’inscris", class: "btn btn-primary", data: { disable_with: "Inscription en cours..." } %>
     <% end %>


### PR DESCRIPTION
# Contexte

Dans le but de minimiser l'effort à l'inscription, ce changement vise à simplifier la saisie de la date de naissance de l'utilisateur.

| Avant | Après |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/20317297/115018741-89eb4380-9eb8-11eb-8693-279fe253a8fa.png) | ![image](https://user-images.githubusercontent.com/20317297/115018855-aab39900-9eb8-11eb-9e80-7b2a363bbe1d.png) |

### Pourquoi 1961 ?

C'est l'âge le plus répandu en France [d'après l'INSEE](https://www.insee.fr/fr/statistiques/3676587?sommaire=3696937).
![image](https://user-images.githubusercontent.com/20317297/115019061-f108f800-9eb8-11eb-9049-ac34b235bc90.png)

### Au passage

Retour à la ligne à chaque argument pour une meilleure lisibilité des développeurs/reviewers.