### PR TITLE
Re-organizing navbar for easier usage for partners and users + fix adblock blocked link on benevoles page

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -10,7 +10,7 @@
 
   <div class="collapse navbar-collapse" id="navbarNavDropdown">
     <ul class="navbar-nav ml-auto">
-      <li class="<% action_name == "carte" ? "nav-item active" : "nav-item" %>">
+      <li class="<%= action_name == "carte" ? "nav-item active" : "nav-item" %>">
         <%= link_to "Carte", :carte, class: "nav-link" %>
       </li>
       <% if !current_partner %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -20,7 +20,7 @@
         <li class="<% action_name == "partenaires" ? "nav-item active" : "nav-item" %>">
           <%= link_to "Professionnels de santé", :partenaires, class: "nav-link" %>
         </li>
-        <li class="<% action_name == "benevoles" ? "nav-item active" : "nav-item" %>">
+        <li class="<%= action_name == "benevoles" ? "nav-item active" : "nav-item" %>">
           <%= link_to "Bénévoles", :benevoles, class: "nav-link" %>
         </li>
       <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,6 +1,7 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light">
   <%= link_to root_path, class: "navbar-brand" do %>
     <%= image_tag "covidliste.png", height: 40, width: 40, alt: "logo covidliste" %>
+    Covidliste
   <% end %>
 
   <button class="navbar-toggler" type="button" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation" data-target="#navbarNavDropdown" data-toggle="collapse">
@@ -12,10 +13,12 @@
       <li class="<% action_name == "carte" ? "nav-item active" : "nav-item" %>">
         <%= link_to "Carte", :carte, class: "nav-link" %>
       </li>
-
       <% if !current_partner %>
         <li class="<% action_name == "faq" ? "nav-item active" : "nav-item" %>">
           <%= link_to "Foire aux questions", :faq, class: "nav-link" %>
+        </li>
+        <li class="<% action_name == "partenaires" ? "nav-item active" : "nav-item" %>">
+          <%= link_to "Professionnels de santé", :partenaires, class: "nav-link" %>
         </li>
         <li class="<% action_name == "benevoles" ? "nav-item active" : "nav-item" %>">
           <%= link_to "Bénévoles", :benevoles, class: "nav-link" %>
@@ -50,18 +53,13 @@
           </div>
         </li>
       <% else %>
-        <li class="<% controller_name == "sessions" && resource_name.to_s == "partner" ? "nav-item active" : "nav-item" %>">
-          <%= link_to "Espace professionnels", new_partner_session_path, class: "nav-link" %>
-        </li>
-
-        <li class="<% controller_name == "sessions" && resource_name.to_s == "user" ? "nav-item active" : "nav-item" %>">
-          <%= link_to "Espace personnel", new_user_session_path, class: "nav-link" %>
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown09">
-            <%= link_to "Profil", profile_path, class: "dropdown-item" %>
-            <% if current_user&.has_role?(:super_admin) %>
-              <%= link_to "Admin", admin_path, class: "dropdown-item" %>
-            <% end %>
-            <%= link_to "Déconnexion", destroy_partner_session_path, method: :delete, class: "dropdown-item" %>
+        <li class="nav-item dropdown">
+          <%= link_to "", class: "nav-link dropdown-toggle", id: "dropdown11", "aria-expanded": "false", "aria-haspopup": "true", "data-toggle": "dropdown" do %>
+            Se connecter
+          <% end %>
+          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown11">
+            <%= link_to "Volontaires à la vaccination", new_user_session_path, class: "dropdown-item" %>
+            <%= link_to "Professionnels de santé", new_partner_session_path, class: "dropdown-item" %>
           </div>
         </li>
       <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -17,7 +17,7 @@
         <li class="<% action_name == "faq" ? "nav-item active" : "nav-item" %>">
           <%= link_to "Foire aux questions", :faq, class: "nav-link" %>
         </li>
-        <li class="<% action_name == "partenaires" ? "nav-item active" : "nav-item" %>">
+        <li class="<%= action_name == "partenaires" ? "nav-item active" : "nav-item" %>">
           <%= link_to "Professionnels de santé", :partenaires, class: "nav-link" %>
         </li>
         <li class="<%= action_name == "benevoles" ? "nav-item active" : "nav-item" %>">

--- a/app/views/pages/benevoles.html.erb
+++ b/app/views/pages/benevoles.html.erb
@@ -10,7 +10,7 @@
   <p>Nous avons besoin de bénévoles pour venir renforcer nos rangs 💪</p>
 
   <p class="my-4">
-    <%= link_to "Postuler pour devenir bénévole", "https://form.typeform.com/to/UlzdGjLV", class: "btn btn-primary", target: "_blank", rel: "noopener" %>
+    <%= link_to "Postuler pour devenir bénévole", "https://bit.ly/recrutement-covidliste", class: "btn btn-primary", target: "_blank", rel: "noopener" %>
   </p>
 
   <p>Exemples de missions :</p>


### PR DESCRIPTION
Fixes #456

Répond au problème que les professionnels ne trouvent pas comment s'inscrire.
Il auront maintenant un bouton dédié dans la navbar, à côté de la FAQ.

<img width="1058" alt="Capture d’écran 2021-04-17 à 03 07 00" src="https://user-images.githubusercontent.com/666182/115097962-96f64a00-9f2d-11eb-965a-2285a001b9cb.png">
