### PR TITLE
Update phone_number to human-readable format

### DIFF
--- a/app/controllers/partners/vaccination_centers_controller.rb
+++ b/app/controllers/partners/vaccination_centers_controller.rb
@@ -24,7 +24,12 @@ module Partners
       @partner_vaccination_center = PartnerVaccinationCenter.new(partner: current_partner,
                                                                  vaccination_center: @vaccination_center)
       @partner_vaccination_center.save
+      prepare_phone_number
       render action: :new
+    end
+
+    def prepare_phone_number
+      @vaccination_center.phone_number = @vaccination_center.human_friendly_phone_number
     end
 
     private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -45,6 +45,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     authorize @user
     @user.save
+    prepare_phone_number
     render action: :new
   rescue ActiveRecord::RecordNotUnique
     flash.now[:error] = "Une erreur s’est produite."
@@ -77,8 +78,7 @@ class UsersController < ApplicationController
   end
 
   def prepare_phone_number
-    human_friendly_phone_number = @user.human_friendly_phone_number
-    @user.phone_number = human_friendly_phone_number unless human_friendly_phone_number.nil?
+    @user.phone_number = @user.human_friendly_phone_number
   end
 
   def user_params

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -32,7 +32,7 @@ class Campaign < ApplicationRecord
           match.user.firstname || "Anonymous",
           match.user.lastname,
           match.user.birthdate,
-          match.user.phone_number,
+          match.user.human_friendly_phone_number,
           match.confirmed_at
         ]
       end

--- a/app/models/concerns/has_phone_number_concern.rb
+++ b/app/models/concerns/has_phone_number_concern.rb
@@ -5,10 +5,16 @@ module HasPhoneNumberConcern
 
   included do
     before_validation :format_phone_number, if: :phone_number?
-    validates :phone_number, phone: {
-      types: %i[mobile],
-      allow_blank: false
-    }
+  end
+
+  class_methods do
+    def has_phone_number_types(types)
+      phone_params = {
+        types: types,
+        allow_blank: false
+      }
+      validates :phone_number, phone: phone_params
+    end
   end
 
   def human_friendly_phone_number

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -1,5 +1,6 @@
 class Partner < ApplicationRecord
   include HasPhoneNumberConcern
+  has_phone_number_types %i[mobile]
 
   devise :database_authenticatable,
     :recoverable,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   include HasPhoneNumberConcern
+  has_phone_number_types %i[mobile]
   rolify
 
   devise :database_authenticatable,

--- a/app/models/vaccination_center.rb
+++ b/app/models/vaccination_center.rb
@@ -1,4 +1,6 @@
 class VaccinationCenter < ApplicationRecord
+  include HasPhoneNumberConcern
+  has_phone_number_types %i[fixed_line mobile voip]
   module Kinds
     CABINET_MEDICAL = "Cabinet médical"
     CENTRE_VACCINATION = "Centre de vaccination"
@@ -78,11 +80,11 @@ class VaccinationCenter < ApplicationRecord
           vaccination_center.name,
           vaccination_center.kind,
           vaccination_center.address,
-          vaccination_center.phone_number,
+          vaccination_center.human_friendly_phone_number,
           vaccin_types,
           vaccination_center.partners&.first&.name,
           vaccination_center.partners&.first&.email,
-          vaccination_center.partners&.first&.phone_number,
+          vaccination_center.partners&.first&.human_friendly_phone_number,
           confirmed
         ]
         if confirmed

--- a/app/views/admin/vaccination_centers/index.html.erb
+++ b/app/views/admin/vaccination_centers/index.html.erb
@@ -63,7 +63,7 @@
               </td>
               <td><%= vaccination_center.kind %></td>
               <td><%= vaccination_center.address %></td>
-              <td><%= vaccination_center.phone_number %></td>
+              <td><%= vaccination_center.human_friendly_phone_number %></td>
               <td>
                 <% if vaccination_center.pfizer %>
                   <span class="mr-1"><%= Vaccine::Brands::PFIZER.capitalize %></span>

--- a/app/views/admin/vaccination_centers/show.html.erb
+++ b/app/views/admin/vaccination_centers/show.html.erb
@@ -55,7 +55,7 @@
   </p>
 
   <p class="mb-2">
-    <%= icon("fas", "phone", @vaccination_center.phone_number) %>
+    <%= icon("fas", "phone", @vaccination_center.human_friendly_phone_number) %>
   </p>
 
   <p>
@@ -155,7 +155,7 @@
               <td class="text-right"> <%= partner.id %> </td>
               <td> <%= partner.name %> </td>
               <td> <%= partner.email %> </td>
-              <td> <%= partner.phone_number %> </td>
+              <td> <%= partner.human_friendly_phone_number %> </td>
               <td class="text-center" title="<%= partner.confirmed_at.present? ? "Confirmé le #{l(partner.confirmed_at)}" : "" %>">
                 <%= humanize_boolean partner.confirmed_at.present? %>
               </td>

--- a/app/views/partners/vaccination_centers/index.html.erb
+++ b/app/views/partners/vaccination_centers/index.html.erb
@@ -43,7 +43,7 @@
               </td>
 
               <td>
-                <%= icon("fas", "phone", vaccination_center.phone_number) %>
+                <%= icon("fas", "phone", vaccination_center.human_friendly_phone_number) %>
                 <br>
                 <%= vaccination_center.address %>
               </td>
@@ -103,7 +103,7 @@
             </td>
 
             <td>
-              <%= icon("fas", "phone", vaccination_center.phone_number) %>
+              <%= icon("fas", "phone", vaccination_center.human_friendly_phone_number) %>
               <br>
               <%= vaccination_center.address %>
             </td>

--- a/app/views/partners/vaccination_centers/show.html.erb
+++ b/app/views/partners/vaccination_centers/show.html.erb
@@ -19,7 +19,7 @@
       </p>
 
       <p class="mb-2 small">
-        <%= icon("fas", "phone", @vaccination_center.phone_number) %>
+        <%= icon("fas", "phone", @vaccination_center.human_friendly_phone_number) %>
       </p>
 
       <p>

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Campaign, type: :model do
 
     it "it includes information about confirmed matches" do
       expect(campaign.to_csv).to include(
-        "#{match.user.firstname},#{match.user.lastname},#{match.user.birthdate},#{match.user.phone_number},#{match.confirmed_at}"
+        "#{match.user.firstname},#{match.user.lastname},#{match.user.birthdate},#{match.user.human_friendly_phone_number},#{match.confirmed_at}"
       )
     end
 


### PR DESCRIPTION
Fixes #452

Passage du format classique du numéro de téléphone au format human_readable partout.

Espace admin
<img width="985" alt="Capture d’écran 2021-04-17 à 04 55 42" src="https://user-images.githubusercontent.com/666182/115099883-2c4b0b80-9f39-11eb-8ff1-67bae93afa56.png">

Dans les exports CSV 
<img width="218" alt="Capture d’écran 2021-04-17 à 04 55 31" src="https://user-images.githubusercontent.com/666182/115099890-353bdd00-9f39-11eb-82c7-2cb1332df7d2.png">

Espace partenaire 
<img width="630" alt="Capture d’écran 2021-04-17 à 04 53 59" src="https://user-images.githubusercontent.com/666182/115099892-3836cd80-9f39-11eb-8884-7fbb90a5eadc.png">
