### PR TITLE
Remove JS error on pages without password

### DIFF
--- a/app/javascript/components/toggle_password_visibility.js
+++ b/app/javascript/components/toggle_password_visibility.js
@@ -6,9 +6,12 @@ const togglePasswordVisibility = () => {
     "[data-behavior='toggle-password-visibility'] i"
   );
 
-  document
-    .querySelector("[data-behavior='toggle-password-visibility'] a")
-    .addEventListener("click", function (e) {
+  const passwordInput = document.querySelector(
+    "[data-behavior='toggle-password-visibility'] a"
+  );
+
+  if (passwordInput) {
+    passwordInput.addEventListener("click", function (e) {
       e.preventDefault();
       e.stopPropagation();
 
@@ -22,6 +25,7 @@ const togglePasswordVisibility = () => {
         icon.classList.remove("fa-eye-slash");
       }
     });
+  }
 };
 
 export { togglePasswordVisibility };


### PR DESCRIPTION
Ajoute un safe garde pour éviter d'avoir une erreur JS s'il n'y a pas de champs password sur la page