### PR TITLE
Small improvements to partner signup 

### DIFF
--- a/app/views/partners/new.html.erb
+++ b/app/views/partners/new.html.erb
@@ -72,7 +72,6 @@
                                     type: :password,
                                     class: "form-control",
                                     required: true,
-                                    pattern: ".{" + Devise.password_length.min.to_s + ",}",
                                     input_html: { autocomplete: "new-password" } %>
 
                   <div class="input-group-append">

--- a/app/views/partners/new.html.erb
+++ b/app/views/partners/new.html.erb
@@ -61,8 +61,8 @@
             <p>Veuillez remplir le formulaire ci-dessous pour vous inscrire en tant que professionnel de santé.</p>
             <%= simple_form_for @partner do |f| %>
               <%= f.input :name, label: "Nom", error: "Nom requis", placeholder: "Prénom Nom" %>
-              <%= f.input :phone_number, label: "Téléphone portable", placeholder: "06 .... (votre téléphone professionnel)" %>
-              <%= f.input :email, required: true, placeholder: "votre_email@du_centre_de_vaccination.fr", input_html: { autocomplete: "email" } %>
+              <%= f.input :phone_number, label: "Téléphone portable", placeholder: "06 .... (votre téléphone professionnel - pas de ligne fixe)", hint: "Ce numéro ne sera jamais communiqué aux volontaires. " %>
+              <%= f.input :email, required: true, placeholder: "votre_email@du_centre_de_vaccination.fr", input_html: { autocomplete: "email" }, hint: "Cet email ne sera jamais communiqué aux volontaires." %>
 
               <div class="form-group">
                 <label for="partner_password"> Mot de passe </label>


### PR DESCRIPTION
3 very small changes based on recent user feedback
- disable front-end validation for password length because it blocked sending the form but did not show an error
- change placeholder to emphasise that it needs to be a mobile number
- add hints that the email/number will not be shared with volunteers


<img width="769" alt="Screenshot 2021-04-17 at 15 54 35" src="https://user-images.githubusercontent.com/6399865/115115821-c7260300-9f96-11eb-83e3-6c23804251e8.png">
 
