### PR TITLE
Remove checked_value and uncheck_value from input with as: :boolean

### DIFF
--- a/app/views/admin/vaccination_centers/edit.html.erb
+++ b/app/views/admin/vaccination_centers/edit.html.erb
@@ -12,10 +12,10 @@
     <p class="mt-3">
       Type(s) de vaccins disponibles
     </p>
-    <%= f.input :pfizer, as: :boolean, label: Vaccine::Brands::PFIZER.capitalize, checked_value: true, unchecked_value: false, class: 'form-check-inline' %>
-    <%= f.input :moderna, as: :boolean, label: Vaccine::Brands::MODERNA.capitalize, checked_value: true, unchecked_value: false, class: 'form-check-inline' %>
-    <%= f.input :astrazeneca, as: :boolean, label: Vaccine::Brands::ASTRAZENECA.capitalize, checked_value: true, unchecked_value: false, class: 'form-check-inline' %>
-    <%= f.input :janssen, as: :boolean, label: Vaccine::Brands::JANSSEN.capitalize, checked_value: true, unchecked_value: false %>
+    <%= f.input :pfizer, as: :boolean, label: Vaccine::Brands::PFIZER.capitalize, class: 'form-check-inline' %>
+    <%= f.input :moderna, as: :boolean, label: Vaccine::Brands::MODERNA.capitalize, class: 'form-check-inline' %>
+    <%= f.input :astrazeneca, as: :boolean, label: Vaccine::Brands::ASTRAZENECA.capitalize, class: 'form-check-inline' %>
+    <%= f.input :janssen, as: :boolean, label: Vaccine::Brands::JANSSEN.capitalize %>
     <%= f.input :address, label: 'Adresse', error: 'Adresse requise', placeholder: '5 rue larue, 13600 Marseille' %>
     <%= f.input :lat, :as => :hidden %>
     <%= f.input :lon, :as => :hidden %>

--- a/app/views/admin/vaccination_centers/new.html.erb
+++ b/app/views/admin/vaccination_centers/new.html.erb
@@ -21,10 +21,10 @@
       <p class="mt-3">
         Type(s) de vaccins disponibles
       </p>
-      <%= f.input :pfizer, as: :boolean, label: Vaccine::Brands::PFIZER.capitalize, checked_value: true, unchecked_value: false, class: 'form-check-inline' %>
-      <%= f.input :moderna, as: :boolean, label: Vaccine::Brands::MODERNA.capitalize, checked_value: true, unchecked_value: false, class: 'form-check-inline' %>
-      <%= f.input :astrazeneca, as: :boolean, label: Vaccine::Brands::ASTRAZENECA.capitalize, checked_value: true, unchecked_value: false, class: 'form-check-inline' %>
-      <%= f.input :janssen, as: :boolean, label: Vaccine::Brands::JANSSEN.capitalize, checked_value: true, unchecked_value: false %>
+      <%= f.input :pfizer, as: :boolean, label: Vaccine::Brands::PFIZER.capitalize, class: 'form-check-inline' %>
+      <%= f.input :moderna, as: :boolean, label: Vaccine::Brands::MODERNA.capitalize, class: 'form-check-inline' %>
+      <%= f.input :astrazeneca, as: :boolean, label: Vaccine::Brands::ASTRAZENECA.capitalize, class: 'form-check-inline' %>
+      <%= f.input :janssen, as: :boolean, label: Vaccine::Brands::JANSSEN.capitalize %>
       <%= f.input :address, label: 'Adresse', error: 'Adresse requise', placeholder: '5 rue larue, 13600 Marseille' %>
       <%= f.input :lat, :as => :hidden %>
       <%= f.input :lon, :as => :hidden %>

--- a/app/views/partners/vaccination_centers/new.html.erb
+++ b/app/views/partners/vaccination_centers/new.html.erb
@@ -56,10 +56,10 @@
             Type(s) de vaccins disponibles
           </p>
 
-          <%= f.input :pfizer, as: :boolean, label: Vaccine::Brands::PFIZER.capitalize, checked_value: true, unchecked_value: false, class: "form-check-inline" %>
-          <%= f.input :moderna, as: :boolean, label: Vaccine::Brands::MODERNA.capitalize, checked_value: true, unchecked_value: false, class: "form-check-inline" %>
-          <%= f.input :astrazeneca, as: :boolean, label: Vaccine::Brands::ASTRAZENECA.capitalize, checked_value: true, unchecked_value: false, class: "form-check-inline" %>
-          <%= f.input :janssen, as: :boolean, label: Vaccine::Brands::JANSSEN.capitalize, checked_value: true, unchecked_value: false %>
+          <%= f.input :pfizer, as: :boolean, label: Vaccine::Brands::PFIZER.capitalize, class: "form-check-inline" %>
+          <%= f.input :moderna, as: :boolean, label: Vaccine::Brands::MODERNA.capitalize, class: "form-check-inline" %>
+          <%= f.input :astrazeneca, as: :boolean, label: Vaccine::Brands::ASTRAZENECA.capitalize, class: "form-check-inline" %>
+          <%= f.input :janssen, as: :boolean, label: Vaccine::Brands::JANSSEN.capitalize %>
           <%= f.input :address, label: "Adresse", error: "Adresse requise", placeholder: "5 rue Larue, 13600 Marseille", required: true %>
           <%= f.input :phone_number, label: "Numéro de téléphone", error: "Numéro de téléphone requis", placeholder: "06 06 06 06 06", required: true %>
           <%= f.button :submit, "Envoyer la demande", class: "btn btn-primary", data: { disable_with: "Validation..." } %>

--- a/app/views/users/_input_statement.html.erb
+++ b/app/views/users/_input_statement.html.erb
@@ -1,8 +1,6 @@
 <%= f.input :statement,
   as: :boolean,
   label: "J’accepte sans réserve les #{link_to "CGU", local_cgu_path} et, notamment, certifie sur l’honneur que les informations communiquées ci-dessus sont exactes.".html_safe,
-  checked_value: true,
-  unchecked_value: false,
   error: "Vous devez cocher cette case pour valider votre inscription",
   required: true 
 %>

--- a/app/views/users/_input_toc.html.erb
+++ b/app/views/users/_input_toc.html.erb
@@ -1,8 +1,6 @@
 <%= f.input :toc,
   as: :boolean,
   label: "J’accepte que mes données soient traitées aux fins de la mise en relation avec les établissements de vaccination Covid-19 participant à l’initiative Covidliste.",
-  checked_value: true,
-  unchecked_value: false,
   error: "Vous devez cocher cette case pour valider votre inscription",
   required: true 
 %>


### PR DESCRIPTION
J'ai retiré les champs checked_value et uncheck_value des simple_form input qui avait le type as: :boolean, car lorsque le formulaire d'édition est submit, et que la checkbox vaut false, l'information n'est pas envoyé dans les params et du coup le champ n'est pas mis à jour, alors qu'en retirant ces deux élements, le as: :boolean met lui même "0" et "1" comme string, qui eux sont correctement transmis aux params, et correctement auto interprété par Rails comme true/false.
J'en ai profité pour le faire pour le formulaire concernant les checkbox :toc, et :statement.