### PR TITLE
Ajout d'une validation de presence d'un code postale pour les adresse

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -42,16 +42,16 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
-    @user.ensure_lat_lon(params[:user][:address]) # fallback in case lat/lon are not returning from client
+    @user.ensure_lat_lon # fallback in case lat/lon are not returning from client
     @user.statement_accepted_at = Time.zone.now if @user.statement
     @user.toc_accepted_at = Time.zone.now if @user.toc
     authorize @user
-    @user.save
+    @user.save!
     prepare_phone_number
-    render action: :new
-  rescue ActiveRecord::RecordNotUnique
+    render action: :new, status: :ok
+  rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
     flash.now[:error] = "Une erreur s’est produite."
-    render action: :new
+    render action: :new, status: :unprocessable_entity
   end
 
   def delete
@@ -76,7 +76,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :phone_number, :toc, :lat, :lon, :birthdate, :password, :statement)
+    params.require(:user).permit(:email, :phone_number, :toc, :address, :lat, :lon, :birthdate, :password, :statement)
   end
 
   def sign_out_if_anonymized!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,7 @@ class User < ApplicationRecord
 
   blind_index :email
 
+  validates :address, presence: true, postal_address: {with_zipcode: true}, on: :create
   validates :lat, presence: true, unless: proc { |u| u.persisted? }
   validates :lon, presence: true, unless: proc { |u| u.persisted? }
   validates :birthdate, presence: true
@@ -49,7 +50,9 @@ class User < ApplicationRecord
     self.lon = results[:lon]
   end
 
-  def ensure_lat_lon(address)
+  def ensure_lat_lon
+    valid? # trigger validations
+    return if errors[:address].present?
     return unless lat.nil? || lon.nil?
     results = GeocodingService.new(address).call
     self.lat = results[:lat]

--- a/app/models/vaccination_center.rb
+++ b/app/models/vaccination_center.rb
@@ -17,6 +17,7 @@ class VaccinationCenter < ApplicationRecord
   validates :name, :address, :phone_number, presence: true
   validates :lat, :lon, presence: true, on: :validation_by_admin
   validates :kind, inclusion: {in: VaccinationCenter::Kinds::ALL}
+  validates :address, format: { with: /(?:[0-8]\d|9[0-8])\d{3}/, message: "doit être composé d’un code postale"}, on: :create
 
   has_many :partner_vaccination_centers
   has_many :partners, through: :partner_vaccination_centers

--- a/app/models/vaccination_center.rb
+++ b/app/models/vaccination_center.rb
@@ -17,7 +17,7 @@ class VaccinationCenter < ApplicationRecord
   validates :name, :address, :phone_number, presence: true
   validates :lat, :lon, presence: true, on: :validation_by_admin
   validates :kind, inclusion: {in: VaccinationCenter::Kinds::ALL}
-  validates :address, format: { with: /(?:[0-8]\d|9[0-8])\d{3}/, message: "doit être composé d’un code postale"}, on: :create
+  validates :address, postal_address: {with_zipcode: true}, on: :create
 
   has_many :partner_vaccination_centers
   has_many :partners, through: :partner_vaccination_centers

--- a/app/validators/postal_address_validator.rb
+++ b/app/validators/postal_address_validator.rb
@@ -19,10 +19,8 @@ class PostalAddressValidator < ActiveModel::EachValidator
   end
 
   def validate_each(record, attribute, value)
-    unless @with_zipcode.nil?
-      unless value.match?(REGEX_ZIPCODE)
-        record.errors.add(attribute, (options[:message] || I18n.t("errors.messages.missing_zipcode")))
-      end
+    unless @with_zipcode.nil? || value.match?(REGEX_ZIPCODE)
+      record.errors.add(attribute, (options[:message] || I18n.t("errors.messages.missing_zipcode")))
     end
   end
 end

--- a/app/validators/postal_address_validator.rb
+++ b/app/validators/postal_address_validator.rb
@@ -1,0 +1,28 @@
+class PostalAddressValidator < ActiveModel::EachValidator
+  REGEX_ZIPCODE = %r{
+    \d{2}[ ]?\d{3}  # France
+    |
+    973\d{2}        # Guyane
+    |
+    9[78][01]\d{2}  # Guadeloupe
+    |
+    9[78]4\d{2}     # La Réunion
+    |
+    9[78]2\d{2}     # Martinique
+    |
+    976\d{2}        # Mayotte
+  }x
+
+  def initialize(options)
+    @with_zipcode = !options[:with_zipcode].nil? ? options[:with_zipcode] : true
+    super
+  end
+
+  def validate_each(record, attribute, value)
+    unless @with_zipcode.nil?
+      unless value.match?(REGEX_ZIPCODE)
+        record.errors.add(attribute, (options[:message] || I18n.t("errors.messages.missing_zipcode")))
+      end
+    end
+  end
+end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -32,7 +32,7 @@
       </p>
       <%= f.input :address,
                   label: "Adresse",
-                  error: "Adresse requise",
+                  error: "Adresse complète requise",
                   placeholder: "5 rue Larue, 13600 Marseille",
                   required: true %>
       <%= f.input_field :lat, as: :hidden %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -146,6 +146,7 @@ fr:
   errors:
     format: "%{attribute} %{message}"
     messages:
+      missing_zipcode: doit comporter un code postal
       accepted: doit être accepté(e)
       blank: doit être rempli(e)
       confirmation: ne concorde pas avec %{attribute}

--- a/spec/factories/sequence_factory.rb
+++ b/spec/factories/sequence_factory.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
   sequence(:company_name) { Faker::Company.name }
   sequence(:description) { Faker::Lorem.paragraph(sentence_count: 2) }
   sequence(:firstname) { Faker::Name.first_name }
-  sequence(:french_address) { Faker::Address.country_by_code(code: "FR") }
+  sequence(:french_address) { "#{Faker::Address.full_address} #{Faker::Address.country_by_code(code: "FR")}" }
   sequence(:lastname) { Faker::Name.last_name }
   sequence(:lat) { Faker::Address.latitude }
   sequence(:lon) { Faker::Address.longitude }

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -15,13 +15,13 @@ FactoryBot.define do
     toc { true }
 
     trait :from_lyon do
-      address { "21 Rue Bergère 75009 Paris" }
+      address { "21 Rue Bergère 75009 Paris France" }
       lat { "48.87242501471677" }
       lon { "2.344941896580627" }
     end
 
     trait :from_paris do
-      address { "7 Rue Auguste Comte 69002 Lyon" }
+      address { "7 Rue Auguste Comte 69002 Lyon France" }
       lat { "45.75620064462772" }
       lon { "4.8319385046869945" }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe User, type: :model do
       expect(user).to_not be_valid
     end
 
-    context "when he has incomplete address without zipcode" do
+    context "when the user has incomplete address without zipcode" do
       context "on persistent context" do
         it "is valid" do
           user.address = generate(:french_address)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe User, type: :model do
       user.email = nil
       expect(user).to_not be_valid
     end
+
+    context "when he has incomplete address without zipcode" do
+      context "on persistent context" do
+        it "is valid" do
+          user.address = generate(:french_address)
+          expect(user).to be_valid
+        end
+      end
+      context "on new context" do
+        it "is invalid" do
+          new_user = build(:user, address: "21 Rue Bergère")
+          expect(new_user).not_to be_valid
+          expect(new_user.errors[:address]).to include("doit être composé d’un code postale")
+        end
+      end
+    end
   end
 
   describe "Email format" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe User, type: :model do
         it "is invalid" do
           new_user = build(:user, address: "21 Rue Bergère")
           expect(new_user).not_to be_valid
-          expect(new_user.errors[:address]).to include("doit être composé d’un code postale")
+          expect(new_user.errors[:address]).to include(I18n.t("errors.messages.missing_zipcode"))
         end
       end
     end

--- a/spec/models/vaccination_center_spec.rb
+++ b/spec/models/vaccination_center_spec.rb
@@ -17,6 +17,21 @@ RSpec.describe VaccinationCenter, type: :model do
         end
       end
     end
+
+    context "when it has incomplete address without zipcode" do
+      context "on persistent context" do
+        it "is valid" do
+          expect(vaccination_center).to be_valid
+        end
+      end
+      context "on new context" do
+        it "is invalid" do
+          new_vaccination_center = build(:vaccination_center, address: "21 Rue Bergère")
+          expect(new_vaccination_center).not_to be_valid
+          expect(new_vaccination_center.errors[:address]).to include("doit être composé d’un code postale")
+        end
+      end
+    end
   end
 
   describe "#reachable_users_query" do

--- a/spec/models/vaccination_center_spec.rb
+++ b/spec/models/vaccination_center_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe VaccinationCenter, type: :model do
         it "is invalid" do
           new_vaccination_center = build(:vaccination_center, address: "21 Rue Bergère")
           expect(new_vaccination_center).not_to be_valid
-          expect(new_vaccination_center.errors[:address]).to include("doit être composé d’un code postale")
+          expect(new_vaccination_center.errors[:address]).to include(I18n.t("errors.messages.missing_zipcode"))
         end
       end
     end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -35,6 +35,19 @@ RSpec.describe "Users", type: :system do
       end.to change { User.count }.by(1)
     end
 
+    it "rejects sign up if address has no zipcode valid" do
+      user.save!
+
+      expect do
+        visit "/"
+        fill_valid_user
+        fill_in :user_address, with: "5 rue Larue, Marseille" # no zipcode
+        signup_submit
+      end.not_to change { User.count }
+
+      expect(page).to have_text("doit comporter un code postal")
+    end
+
     it "rejects sign up if email is not unique" do
       user.save!
 

--- a/spec/validators/postal_address_validator_spec.rb
+++ b/spec/validators/postal_address_validator_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe PostalAddressValidator do
+  subject do
+    Class.new do
+      include ActiveModel::Validations
+      attr_accessor :address
+      validates :address, postal_address: {with_zipcode: true, message: "invalid_message"}
+    end.new
+  end
+
+  context "when the postal address is valid" do
+    let(:address) { generate(:french_address) }
+
+    it "allows the input" do
+      subject.address = address
+      expect(subject).to be_valid
+    end
+  end
+
+  context "when the postal address is invalid" do
+    let(:invalid_message) { "invalid_message" }
+
+    it "invalidates the input" do
+      subject.address = "21 Rue Bergère"
+      expect(subject).not_to be_valid
+    end
+
+    it "alerts the consumer" do
+      subject.address = "address"
+      subject.valid?
+      expect(subject.errors[:address]).to include(invalid_message)
+    end
+  end
+end


### PR DESCRIPTION
Uniquement lors d'une création d'un utilisateur ou d'un centre, j'ai rajouté une validation pour être sûr d'avoir un code postale au minima dans l'adresse, ca nous assure entre guillemets qu'il est cliqué sur un des éléments proposé par Algolia.