### PR TITLE
[Algolia] Scoping sur FR + DOM/TOM, rajout de la region dans l'adresse

### DIFF
--- a/app/javascript/plugins/places_autocomplete.js
+++ b/app/javascript/plugins/places_autocomplete.js
@@ -36,7 +36,7 @@ const placesAutocomplete = (appId, apiKey) => {
       },
     }).configure({
       language: "fr",
-      countries: ["fr"],
+      countries: ["fr", "gy", "gp", "re", "mq", "yt"],
     });
   }
 };
@@ -44,9 +44,16 @@ const placesAutocomplete = (appId, apiKey) => {
 function formattedAdress(reponse) {
   // overide Algolia default address formating that includes French region but not the Zip code.
   // french region can confuse the address geocoding API
-  return [reponse.name, reponse.postcode, reponse.city, reponse.country]
-    .filter((e) => e !== "undefined")
-    .join(" ");
+  var addressParts = [reponse.name, reponse.postcode, reponse.city, reponse.administrative]
+
+  // We skipped country field if it's a DOM TOM as Algolia sent us France by default when it's one of them
+  var excludeCountryFilters = ["Guyane", "Guadeloupe", "La Réunion", "Martinique", "Mayotte"]
+  if (excludeCountryFilters.indexOf(reponse.administrative) == -1) {
+    addressParts.push(reponse.country)
+  }
+
+  var formattedString = addressParts.filter((e) => e !== "undefined").join(" ");
+  return formattedString;
 }
 
 export { placesAutocomplete };


### PR DESCRIPTION
Un soucis dans le country renvoyé par Algolia quand c'est une adresse DOM TOM.
J'ai rajouté un scope pour la recherche des adresses, et retirer le pays quand la région est le nom du DOM TOM.

<img width="744" alt="Screenshot 2021-04-21 at 16 31 57" src="https://user-images.githubusercontent.com/6686865/115583470-34ed6a00-a2ca-11eb-8a43-46fa05645e92.png">
<img width="752" alt="Screenshot 2021-04-21 at 16 31 42" src="https://user-images.githubusercontent.com/6686865/115583475-35860080-a2ca-11eb-982f-1c88f6b523bd.png">