### PR TITLE
Ne pas demander nom/prénom au moment de l'inscription mais lors de la confirmation du match

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem "ddtrace", "0.35.2"
 gem "devise_zxcvbn"
 
 group :development, :test do
+  gem "factory_bot_rails"
   gem "dotenv-rails", "2.7.6"
   gem "faker", git: "https://github.com/faker-ruby/faker.git", branch: "master"
   gem "pry-byebug"
@@ -83,7 +84,6 @@ group :test do
   gem "codecov", require: false
   gem "cuprite"
   gem "database_cleaner-active_record"
-  gem "factory_bot_rails"
   gem "rails-controller-testing"
   gem "rspec-rails", "~> 4.0.0"
   gem "rspec-sidekiq"

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -34,7 +34,7 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       flash.now[:success] = "Modifications enregistrées."
     else
-      flash.now[:error] = "Impossible d'enregistrer vos modifications."
+      flash.now[:error] = "Impossible d’enregistrer vos modifications."
     end
     prepare_phone_number
     render action: :show
@@ -75,7 +75,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:firstname, :lastname, :email, :phone_number, :toc, :address, :birthdate, :password, :statement)
+    params.require(:user).permit(:email, :phone_number, :toc, :address, :birthdate, :password, :statement)
   end
 
   def sign_out_if_anonymized!

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -34,8 +34,8 @@ class Campaign < ApplicationRecord
         next if match.user.nil?
 
         csv << [
-          match.user.firstname || "Anonymous",
-          match.user.lastname,
+          match.firstname || "Anonymous",
+          match.lastname,
           match.user.birthdate,
           match.user.human_friendly_phone_number,
           match.confirmed_at

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -20,7 +20,6 @@ class Match < ApplicationRecord
   blind_index :match_confirmation_token
 
   validate :no_recent_match, on: :create
-  validates :firstname, :lastname, presence: true, on: :validation_when_confirm
   validates :firstname, :lastname, presence: true, if: -> { saved_change_to_confirmed_at? }
 
   validates :firstname, :lastname, presence: true, on: :validation_when_confirm
@@ -48,7 +47,7 @@ class Match < ApplicationRecord
   end
 
   def confirm!
-    raise MissingNamesError, "Vous devez renseigné votre identité" if missing_identity?
+    raise MissingNamesError, "Vous devez renseigner votre identité" if missing_identity?
     raise AlreadyConfirmedError, "Vous avez déjà confirmé votre disponibilité" if confirmed?
     raise DoseOverbookingError, "La dose de vaccin a déjà été réservée" unless confirmable?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -95,6 +95,9 @@ class User < ApplicationRecord
     self.phone_number = nil
     self.birthdate = nil
     self.anonymized_at = Time.now.utc
+
+    matches.confirmed.update_all(firstname: "Anonymous", lastname: "Anonymous")
+
     save(validate: false)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,11 @@ class User < ApplicationRecord
     self.birthdate = nil
     self.anonymized_at = Time.now.utc
 
-    matches.confirmed.update_all(firstname: "Anonymous", lastname: "Anonymous")
+    matches.confirmed.each do |match|
+      match.firstname = "Anonymous"
+      match.lastname = "Anonymous"
+      match.save(validate: false)
+    end
 
     save(validate: false)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,8 +12,6 @@ class User < ApplicationRecord
 
   has_many :matches, dependent: :nullify
 
-  encrypts :firstname
-  encrypts :lastname
   encrypts :address
   encrypts :phone_number
   encrypts :email
@@ -22,8 +20,6 @@ class User < ApplicationRecord
   geocoded_by :address, latitude: :lat, longitude: :lon
 
   validates :password, presence: true, on: :create
-  validates :firstname, presence: true
-  validates :lastname, presence: true
   validates :address, presence: true
   validates :birthdate, presence: true
   validates :toc, presence: true, acceptance: true
@@ -61,7 +57,7 @@ class User < ApplicationRecord
   end
 
   def full_name
-    anonymized_at.nil? ? "#{firstname} #{lastname}" : "Anonymous"
+    anonymized_at.nil? ? email : "Anonymous"
   end
 
   def distance(lat, lon)
@@ -89,8 +85,6 @@ class User < ApplicationRecord
     return unless anonymized_at.nil?
 
     self.email = "anonymous#{id}+#{rand(100_000_000)}@null"
-    self.firstname = nil
-    self.lastname = nil
     self.address = nil
     self.lat = nil
     self.lon = nil

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -5,7 +5,7 @@
 
   <p class="mt-4">
     <strong>
-      Bonjour <%= current_user.full_name %> 👋
+      Bonjour 👋
     </strong>
   </p>
 

--- a/app/views/admin/vaccination_centers/index.html.erb
+++ b/app/views/admin/vaccination_centers/index.html.erb
@@ -81,7 +81,7 @@
               <td>
                 <% if vaccination_center.confirmed? %>
                   <%= icon("fas", "check", class: "text-success") %>
-                  <span title="Validé par #{vaccination_center.confirmer&.full_name} le #{vaccination_center.confirmed_at}", data-toggle="tooltip"> Oui </span>
+                  <span title="<%= "Validé par #{vaccination_center.confirmer&.full_name} le #{vaccination_center.confirmed_at}" %>", data-toggle="tooltip"> Oui </span>
                 <% else %>
                   <%= icon("fas", "times", class: "text-danger") %>
                   Non

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
 <p>
-  Bonjour <%= @resource.full_name %>,
+  Bonjour,
 </p>
 
 <p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,5 +1,5 @@
 <p>
-  Bonjour <%= @resource.full_name %>,
+  Bonjour,
 </p>
 
 <p>

--- a/app/views/match_mailer/match_confirmation_instructions.html.erb
+++ b/app/views/match_mailer/match_confirmation_instructions.html.erb
@@ -1,6 +1,6 @@
 <div>
   <h2>
-    Bonne nouvelle <%= @match.user.full_name %> !
+    Bonne nouvelle !
   </h2>
 
   <p>

--- a/app/views/match_mailer/send_anonymisation_notice.html.erb
+++ b/app/views/match_mailer/send_anonymisation_notice.html.erb
@@ -1,6 +1,6 @@
 <div>
   <h2>
-    Bonjour <%= @match.user.full_name %>,
+    Bonjour,
   </h2>
 
   <p>

--- a/app/views/matches/_confirmed.html.erb
+++ b/app/views/matches/_confirmed.html.erb
@@ -8,7 +8,7 @@
 
 <%= render 'match_details', match: @match %>
 
-<% if match.campaign.extra_info %>
+<% if match.campaign.extra_info.present? %>
   <div>
     <p>
       <i class="fas fa-info-circle"></i>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -27,7 +27,7 @@
     <div>
       <i class="fas fa-user-lock"></i>
       <p>
-        Réservé pour <strong><%= user.full_name %></strong><br>
+        Réservé pour <strong><%= [match.firstname, match.lastname, "(#{user.email})"].compact.join(" ") %></strong><br>
         Né le <strong><%= user.birthdate.strftime('%d/%m/%Y') %></strong><br>
         Réservation strictement nominative. <br>
         <strong>Date de naissance et nom seront vérifiés</strong> (pensez à vous munir d'une pièce d'identité)<br>

--- a/app/views/matches/_pending.html.erb
+++ b/app/views/matches/_pending.html.erb
@@ -19,9 +19,31 @@
   <input type="hidden" name="_method" value="PATCH">
   <div class="col-12 mb-2">
     <div class="form-check flex-wrap">
+      <label class="form-check-label w-75" for="firstname">
+        Prénom
+      </label>
+      <input class="form-control" placeholder="Jean" type="text" value="" name="firstname" id="firstname" autocomplete="given-name" required>
+      <div class="invalid-feedback w-100">
+        Vous devez renseigné votre prénom.
+      </div>
+    </div>
+  </div>
+  <div class="col-12 mb-2">
+    <div class="form-check flex-wrap">
+      <label class="form-check-label w-75" for="lastname">
+        Nom
+      </label>
+      <input class="form-control" placeholder="Dupont" type="text" value="" name="lastname" id="lastname" autocomplete="family-name" required>
+      <div class="invalid-feedback w-100">
+        Vous devez renseigné votre nom.
+      </div>
+    </div>
+  </div>
+  <div class="col-12 mb-2">
+    <div class="form-check flex-wrap">
       <input class="form-check-input" type="checkbox" value="" id="confirm_name" required>
       <label class="form-check-label w-75" for="confirm_name">
-        Je confirme avoir une pièce d'identité au nom de <strong><%= user.full_name %></strong>
+        Je confirme avoir une pièce d'identité au nom renseigné ci-dessus.
       </label>
       <div class="invalid-feedback w-100">
         Vous devez confirmer votre nom. <br>
@@ -33,7 +55,7 @@
     <div class="form-check flex-wrap">
       <input class="form-check-input" type="checkbox" value="" id="confirm_age" required>
       <label class="form-check-label w-75" for="confirm_age">
-        Je confirme avoir une pièce d'identité portant la date de naissance <strong><%= user.birthdate %></strong>
+        Je confirme avoir une pièce d'identité portant la date de naissance <strong><%= user.birthdate.strftime("%d/%m/%Y") %></strong>
       </label>
       <div class="invalid-feedback w-100">
         Vous devez confirmer votre date de naissance. <br>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -20,20 +20,6 @@
     <% end %>
 
     <%= simple_form_for @user do |f| %>
-      <%= f.input :firstname,
-                  label: "Prénom",
-                  error: "Prénom requis",
-                  placeholder: "Jean",
-                  required: true,
-                  input_html: { autocomplete: "given-name" } %>
-
-      <%= f.input :lastname,
-                  label: "Nom",
-                  error: "Nom requis",
-                  placeholder: "Dupont",
-                  required: true,
-                  input_html: { autocomplete: "family-name" } %>
-
       <%= f.input :birthdate,
                   as: :date,
                   label: "Date de naissance",
@@ -42,7 +28,7 @@
                   order: [:day, :month, :year] %>
       
       <p class="text-primary small">
-        Vérifiez bien vos nom, prénom et date de naissance. En cas d'erreur, la vaccination ne sera pas possible !
+        Vérifiez bien votre date de naissance. En cas d'erreur, la vaccination ne sera pas possible !
       </p>
       <%= f.input :address,
                   label: "Adresse",

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
   <div class="row mt-5 pb-3">
     <div class="col-12 col-sm-8 offset-sm-2">
       <p>
-        Bonjour <%= @user.full_name %>,
+        Bonjour,
       </p>
       <p>
         Vous êtes inscrit sur Covidliste depuis le <%= @user.created_at.strftime("%d/%m/%Y") %>
@@ -23,9 +23,6 @@
       <% end %>
 
       <%= simple_form_for(@user, url: :profile, method: :put, wrapper: :horizontal_form) do |f| %>
-        <%= f.input :firstname, label: "Prénom", placeholder: "Jean", valid_class: "" %>
-        <%= f.input :lastname, label: "Nom", error: "Nom requis", placeholder: "Dupont" %>
-
         <div class="row">
           <div class="col-12 col-sm-3">
             <label class="col-form-label">

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -10,8 +10,6 @@ fr:
         one: campagne
     attributes:
       user:
-        firstname: Prénom
-        lastname: Nom
         birthdate: Date de naissance
         address: Adresse
         phone_number: Numéro de téléphone
@@ -32,6 +30,9 @@ fr:
         kind: Type de lieu de vaccination
         lat: Latitude
         lon: Longitude
+      match:
+        firstname: Prénom
+        lastname: Nom
     errors:
       messages:
         record_invalid: "La validation a échoué : %{errors}"

--- a/db/migrate/20210421184522_move_name_fields_from_users_to_matches.rb
+++ b/db/migrate/20210421184522_move_name_fields_from_users_to_matches.rb
@@ -9,13 +9,16 @@ class MoveNameFieldsFromUsersToMatches < ActiveRecord::Migration[6.1]
   def up
     add_column :matches, :firstname_ciphertext, :text
     add_column :matches, :lastname_ciphertext, :text
-    Match.reset_column_information
-    Object.send(:remove_const, "Match")
-    User.find_each do |user|
-      user.matches.update_all(
-        firstname_ciphertext: user.firstname_ciphertext,
-        lastname_ciphertext: user.lastname_ciphertext
-      )
+
+    if column_exists?(:users, :firstname_ciphertext) && column_exists?(:users, :lastname_ciphertext)
+      Match.reset_column_information
+      Object.send(:remove_const, "Match")
+      User.find_each do |user|
+        user.matches.update_all(
+          firstname_ciphertext: user.firstname_ciphertext,
+          lastname_ciphertext: user.lastname_ciphertext
+        )
+      end
     end
   end
 

--- a/db/migrate/20210421184522_move_name_fields_from_users_to_matches.rb
+++ b/db/migrate/20210421184522_move_name_fields_from_users_to_matches.rb
@@ -1,0 +1,26 @@
+class MoveNameFieldsFromUsersToMatches < ActiveRecord::Migration[6.1]
+  class Match < ApplicationRecord
+  end
+
+  class User < ApplicationRecord
+    has_many :matches, class_name: "MoveNameFieldsFromUsersToMatches::Match"
+  end
+
+  def up
+    add_column :matches, :firstname_ciphertext, :text
+    add_column :matches, :lastname_ciphertext, :text
+    Match.reset_column_information
+    Object.send(:remove_const, "Match")
+    User.find_each do |user|
+      user.matches.update_all(
+        firstname_ciphertext: user.firstname_ciphertext,
+        lastname_ciphertext: user.lastname_ciphertext
+      )
+    end
+  end
+
+  def down
+    remove_column :matches, :firstname_ciphertext
+    remove_column :matches, :lastname_ciphertext
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_19_230614) do
+ActiveRecord::Schema.define(version: 2021_04_21_184522) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,6 +132,8 @@ ActiveRecord::Schema.define(version: 2021_04_19_230614) do
     t.string "geo_citycode"
     t.string "geo_context"
     t.datetime "refused_at"
+    t.text "firstname_ciphertext"
+    t.text "lastname_ciphertext"
     t.index ["campaign_batch_id"], name: "index_matches_on_campaign_batch_id"
     t.index ["campaign_id"], name: "index_matches_on_campaign_id"
     t.index ["match_confirmation_token_bidx"], name: "index_matches_on_match_confirmation_token_bidx", unique: true

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -3,12 +3,10 @@ namespace :populate do
   task users: :environment do
     puts "How many users do you want? (~1s / user)"
     print "> "
-    count = gets.chomp.to_i
+    count = 100
     puts "Generating #{count} users..."
     count.times do |i|
       user = User.new(
-        firstname: Faker::Name.first_name,
-        lastname: Faker::Name.last_name,
         email: Faker::Internet.unique.email(domain: "covidliste.com"),
         birthdate: Faker::Date.between(from: 100.years.ago, to: 18.years.ago),
         address: Faker::Address.full_address,
@@ -22,7 +20,7 @@ namespace :populate do
       user.update_columns(confirmed_at: Time.now.utc)
       GeocodeResourceJob.perform_now(user)
       user.reload
-      puts "#{i + 1}. #{user.full_name}, #{user.age} ans - #{user.address} (#{user.lat}, #{user.lon})"
+      puts "#{i + 1}. #{user.email}, #{user.age} ans - #{user.address} (#{user.lat}, #{user.lon})"
     end
     puts "Done."
   end

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -1,52 +1,23 @@
 namespace :populate do
   desc "Generate fake users"
   task users: :environment do
+    $stdout.flush
     puts "How many users do you want? (~1s / user)"
     print "> "
-    count = 100
+    count = $stdin.gets.chomp.to_i
     puts "Generating #{count} users..."
     count.times do |i|
-      user = User.new(
-        email: Faker::Internet.unique.email(domain: "covidliste.com"),
-        birthdate: Faker::Date.between(from: 100.years.ago, to: 18.years.ago),
-        address: Faker::Address.full_address,
-        password: "1G09_!9s08vUsa",
-        phone_number: "06 01 02 03 04",
-        toc: true,
-        statement: true
-      )
-      user.skip_confirmation!
-      user.save!
-      user.update_columns(confirmed_at: Time.now.utc)
-      GeocodeResourceJob.perform_now(user)
-      user.reload
-      puts "#{i + 1}. #{user.email}, #{user.age} ans - #{user.address} (#{user.lat}, #{user.lon})"
+      user = FactoryBot.create(:user, i.odd? ? :from_paris : :from_lyon)
+      puts "#{i + 1}\t #{user.email}, #{user.age} ans - #{user.address} (#{user.lat}, #{user.lon})"
     end
     puts "Done."
   end
 
   desc "Create a new validated Vaccination center with a new partner"
   task create_vaccination_center_with_partner_and_validate: :environment do
-    partner = Partner.new(
-      name: Faker::Name.name,
-      email: Faker::Internet.email,
-      phone_number: Faker::PhoneNumber.phone_number,
-      password: "1G09_!9s08vUsa"
-    )
-    partner.save!(validate: false) # Bypass MX validation
-
-    vaccination_center = VaccinationCenter.new(
-      name: "#{Faker::TvShows::GameOfThrones.city} Center",
-      description: Faker::Lorem.sentences.join(" "),
-      address: Faker::Address.full_address,
-      kind: VaccinationCenter::Kinds::ALL.sample,
-      lat: 48.864716, # Paris
-      lon: 2.349014,
-      pfizer: true,
-      phone_number: Faker::PhoneNumber.phone_number
-    )
-    vaccination_center.save!
-    vaccination_center.update(confirmed_at: Time.now.utc)
+    password = FactoryBot.generate(:password)
+    partner = FactoryBot.create(:partner, :skip_validate, password: password) # skip_validate we don't want MX validations for email field
+    vaccination_center = FactoryBot.create(:vaccination_center, :confirmed, (rand.to_i % 2) == 0 ? :from_lyon : :from_paris, pfizer: true)
     vaccination_center.partners << partner
 
     puts "Connexion à '#{vaccination_center.name}' avec le compte professionnel de santé assurant la vaccination : #{partner.email} / #{partner.password}"

--- a/spec/factories/match_factory.rb
+++ b/spec/factories/match_factory.rb
@@ -6,7 +6,24 @@ FactoryBot.define do
     association :vaccination_center
 
     trait :confirmed do
+      firstname { generate(:firstname) }
+      lastname { generate(:lastname) }
       confirmed_at { Time.zone.now }
+      expires_at { 10.minutes.ago }
+    end
+
+    trait :available do
+      firstname { nil }
+      lastname { nil }
+      confirmed_at { nil }
+      expires_at { 10.minutes.since }
+    end
+
+    trait :expired do
+      firstname { nil }
+      lastname { nil }
+      confirmed_at { nil }
+      expires_at { 10.minutes.ago }
     end
   end
 end

--- a/spec/factories/partner_factory.rb
+++ b/spec/factories/partner_factory.rb
@@ -2,10 +2,13 @@ FactoryBot.define do
   factory :partner do
     email { generate(:unique_email) }
     name { generate(:name) }
-    phone_number { "0606060606" }
+    phone_number { generate(:french_phone_number) }
     password { generate(:password) }
     statement { true }
-
     confirmed_at { Time.zone.now }
+
+    trait :skip_validate do
+      to_create { |instance| instance.save(validate: false) }
+    end
   end
 end

--- a/spec/factories/sequence_factory.rb
+++ b/spec/factories/sequence_factory.rb
@@ -14,9 +14,13 @@ FactoryBot.define do
     # because not yet attributed
     # (Example : 0729999999 and lower are not attributed, 0730000000 and higher are)
     # We're looping until Faker generates a valid number
-    phone_number = Faker::PhoneNumber.cell_phone
-    until Phonelib.valid?(phone_number)
+    phone_number = nil
+    loop do
       phone_number = Faker::PhoneNumber.cell_phone
+      if phone_number.gsub(/\s/, "").length == 9 && phone_number[0] != "0"
+        phone_number = "0#{phone_number}"
+      end
+      break if Phonelib.valid?(phone_number)
     end
     phone_number
   end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -3,8 +3,6 @@ FactoryBot.define do
     address { generate(:french_address) }
     birthdate { generate(:birthdate) }
     email { generate(:unique_email) }
-    firstname { generate(:firstname) }
-    lastname { generate(:lastname) }
     password { generate(:password) }
     phone_number { "0606060606" }
 

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -34,5 +34,8 @@ FactoryBot.define do
         user.add_role(:super_admin)
       end
     end
+
+    after(:build) { |u| u.skip_confirmation! }
+    after(:create) { |u| u.confirm }
   end
 end

--- a/spec/factories/vaccination_center_factory.rb
+++ b/spec/factories/vaccination_center_factory.rb
@@ -17,5 +17,9 @@ FactoryBot.define do
       lat { "45.75620064462772" }
       lon { "4.8319385046869945" }
     end
+
+    trait :confirmed do
+      confirmed_at { Time.zone.now }
+    end
   end
 end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Campaign, type: :model do
   describe "#to_csv" do
     let(:campaign) { build(:campaign) }
     let!(:match) { create(:match, campaign: campaign, confirmed_at: Time.now) }
-    let!(:unconfirmed_match) { create(:match, campaign: campaign, confirmed_at: nil) }
+    let!(:unconfirmed_match) { create(:match, :available, campaign: campaign, firstname: generate(:firstname), lastname: generate(:lastname)) }
 
     it "it includes information about confirmed matches" do
       expect(campaign.to_csv).to include(

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Campaign, type: :model do
 
     it "it includes information about confirmed matches" do
       expect(campaign.to_csv).to include(
-        "#{match.user.firstname},#{match.user.lastname},#{match.user.birthdate},#{match.user.human_friendly_phone_number},#{match.confirmed_at}"
+        "#{match.firstname},#{match.lastname},#{match.user.birthdate},#{match.user.human_friendly_phone_number},#{match.confirmed_at}"
       )
     end
 
     it "it does not include any information about unconfirmed matches" do
-      expect(campaign.to_csv).not_to include(unconfirmed_match.user.firstname)
+      expect(campaign.to_csv).not_to include(unconfirmed_match.firstname)
     end
   end
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -39,9 +39,18 @@ RSpec.describe Match, type: :model do
   end
 
   describe "#confirm!" do
+    context "When the match itself has no identity filled" do
+      subject { match.confirm! }
+      it "raises Match::MissingNamesError" do
+        expect { subject }.to raise_error(Match::MissingNamesError)
+      end
+    end
+
     it "should flag the match as confirmed" do
       user = create(:user)
       match = create(:match, user: user)
+      match.firstname = generate(:firstname)
+      match.lastname = generate(:lastname)
       match.confirm!
       expect(match.confirmed?).to be true
     end
@@ -54,7 +63,11 @@ RSpec.describe Match, type: :model do
     end
 
     context "When the match campaign has no #remaining_slots" do
-      subject { match.confirm! }
+      subject do
+        match.firstname = generate(:firstname)
+        match.lastname = generate(:lastname)
+        match.confirm!
+      end
       it "raises Match::DoseOverbookingError" do
         allow(campaign).to receive(:remaining_slots).and_return 0
         expect { subject }.to raise_error(Match::DoseOverbookingError)
@@ -62,7 +75,11 @@ RSpec.describe Match, type: :model do
     end
 
     context "When the match campaign has at least 1 #remaining_slots" do
-      subject { match.confirm! }
+      subject do
+        match.firstname = generate(:firstname)
+        match.lastname = generate(:lastname)
+        match.confirm!
+      end
       it "updates the confirmed_at" do
         allow(campaign).to receive(:remaining_slots).and_return 1
         allow(now).to receive(:utc).and_return(now_utc)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,16 +8,6 @@ RSpec.describe User, type: :model do
       expect(user).to be_valid
     end
 
-    it "is invalid without a first_name" do
-      user.firstname = nil
-      expect(user).to_not be_valid
-    end
-
-    it "is invalid without a last_name" do
-      user.lastname = nil
-      expect(user).to_not be_valid
-    end
-
     it "is invalid without an address" do
       user.address = nil
       expect(user).to_not be_valid
@@ -68,9 +58,9 @@ RSpec.describe User, type: :model do
   end
 
   describe "Full name" do
-    it "should return firstname + lastname" do
-      user = User.new(firstname: "George", lastname: "Abitbol")
-      expect(user.full_name).to eq("George Abitbol")
+    it "should return email" do
+      user = User.new(email: "foobar@gmail.com")
+      expect(user.full_name).to eq("foobar@gmail.com")
     end
 
     it "should return Anonymous" do
@@ -84,8 +74,6 @@ RSpec.describe User, type: :model do
     it "anonymise every fields" do
       user = create(:user)
       user.anonymize!
-      expect(user.firstname).to be_nil
-      expect(user.lastname).to be_nil
       expect(user.address).to be_nil
       expect(user.lat).to be_nil
       expect(user.lon).to be_nil

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ Capybara.register_driver(:cuprite) do |app|
     app,
     window_size: [1440, 900],
     js_errors: false,
-    # headless: !(ENV["PREVIEW"] == "true"),
+    headless: !ENV["HEADLESS"].in?(%w[n 0 no false]),
     inspector: (ENV["INSPECTOR"] == "true"),
     process_timeout: 30,
     timeout: 60,

--- a/spec/requests/matches_request_spec.rb
+++ b/spec/requests/matches_request_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Matches", type: :request do
-  let!(:match) { create(:match, :available, match_confirmation_token: match_confirmation_token) }
+  let!(:match) { create(:match, :available) }
 
   describe "update" do
     it "it will confirm a valid match" do

--- a/spec/requests/matches_request_spec.rb
+++ b/spec/requests/matches_request_spec.rb
@@ -1,17 +1,15 @@
 require "rails_helper"
 
 RSpec.describe "Matches", type: :request do
-  let!(:user) { create(:user) }
-  let!(:center) { create(:vaccination_center) }
-  let!(:campaign) { create(:campaign, vaccination_center: center) }
-  let!(:batch) { create(:campaign_batch, campaign: campaign, vaccination_center: center) }
-  let!(:match_confirmation_token) { "abcd" }
-  let!(:match) { create(:match, campaign_batch: batch, user: user, vaccination_center: center, match_confirmation_token: match_confirmation_token, expires_at: 1.hour.since, campaign: campaign) }
+  let!(:match) { create(:match, :available, match_confirmation_token: match_confirmation_token) }
 
   describe "update" do
     it "it will confirm a valid match" do
       expect {
-        patch "/matches/#{match_confirmation_token}"
+        patch "/matches/#{match.match_confirmation_token}", params: {
+          firstname: "Jean",
+          lastname: "Dupont"
+        }
       }.to change { match.reload.confirmed_at }
     end
 
@@ -19,7 +17,10 @@ RSpec.describe "Matches", type: :request do
       match.update_column("expires_at", 5.minutes.ago)
 
       expect {
-        put "/matches/#{match_confirmation_token}"
+        patch "/matches/#{match.match_confirmation_token}", params: {
+          firstname: "Jean",
+          lastname: "Dupont"
+        }
       }.not_to change { match.reload.confirmed_at }
     end
   end

--- a/spec/system/matches_controller_spec.rb
+++ b/spec/system/matches_controller_spec.rb
@@ -1,44 +1,57 @@
 require "rails_helper"
 
 RSpec.describe MatchesController, type: :system do
-  let!(:user) { create(:user) }
-  let!(:second_user) { create(:user) }
-  let!(:partner) { create(:partner) }
-  let!(:center) { create(:vaccination_center) }
-  let!(:campaign) { create(:campaign, vaccination_center: center) }
-  let!(:batch) { create(:campaign_batch, campaign: campaign, vaccination_center: center) }
-  let!(:match_confirmation_token) { "abcd" }
-  let!(:match) { create(:match, campaign_batch: batch, user: user, vaccination_center: center, match_confirmation_token: match_confirmation_token, expires_at: 1.hour.since, campaign: campaign) }
+  let(:partner) { create(:partner) }
+  let(:center) { create(:vaccination_center) }
+  let(:campaign) { create(:campaign, vaccination_center: center, available_doses: 5) }
+  let(:batch) { create(:campaign_batch, campaign: campaign, vaccination_center: center) }
 
-  subject { visit "/matches/#{match_confirmation_token}" }
+  # subject { visit "/matches/#{match_confirmation_token}" }
 
   describe "GET show" do
     context "with a valid match" do
+      let(:match) { create(:match, :available, campaign_batch: batch, vaccination_center: center, campaign: campaign) }
+
       it "it says une dose dispo" do
-        subject
+        visit "/matches/#{match.match_confirmation_token}"
+
         expect(page).to have_text("Une dose est disponible")
         expect(page).to have_text("Je suis disponible")
         expect(page).to have_text(center.address)
-      end
-    end
 
-    context "with a confirmed match" do
-      before do
-        match.update_column("confirmed_at", Time.now)
-      end
-      it "it says dispo confirmée" do
-        subject
+        click_on("Je suis disponible")
+        expect(page).to have_text("Vous devez renseigné votre identité")
+
+        fill_in :firstname, with: Faker::Name.first_name
+        click_on("Je suis disponible")
+        expect(page).to have_text("Vous devez renseigné votre identité")
+
+        fill_in :firstname, with: Faker::Name.first_name
+        fill_in :lastname, with: Faker::Name.last_name
+        click_on("Je suis disponible")
+        expect(page).not_to have_text("Vous devez renseigné votre identité")
         expect(page).to have_text("Votre disponibilité est confirmée")
         expect(page).to have_text(center.address)
       end
     end
 
-    context "with an expired match" do
-      before do
-        match.update_column("expires_at", 5.minutes.ago)
+    context "with a confirmed match" do
+      let(:match) { create(:match, :confirmed, campaign_batch: batch, vaccination_center: center, campaign: campaign) }
+
+      it "it says dispo confirmée" do
+        visit "/matches/#{match.match_confirmation_token}"
+
+        expect(page).to have_text("Votre disponibilité est confirmée")
+        expect(page).to have_text(center.address)
       end
+    end
+
+    context "with a expired match" do
+      let(:match) { create(:match, :expired, campaign_batch: batch, vaccination_center: center, campaign: campaign) }
+
       it "it says delai dépassé" do
-        subject
+        visit "/matches/#{match.match_confirmation_token}"
+
         expect(page).to have_text("Le délai de confirmation est dépassé")
       end
     end
@@ -46,6 +59,7 @@ RSpec.describe MatchesController, type: :system do
     context "with an invalid token" do
       it "redirects to root" do
         visit "/matches/invalid-token"
+
         expect(page).to have_current_path(root_path)
       end
     end
@@ -58,8 +72,10 @@ RSpec.describe MatchesController, type: :system do
         end
       end
 
+      let(:match) { create(:match, :available, campaign_batch: batch, vaccination_center: center, campaign: campaign) }
+
       it "handle the user's disappointment gracefully" do
-        visit "/matches/#{match_confirmation_token}"
+        visit "/matches/#{match.match_confirmation_token}"
 
         expect(page).to have_text("La dose n'est plus disponible 😢")
         expect(page).to have_text("Nous sommes désolés, un autre volontaire a été plus rapide que vous.")
@@ -78,13 +94,17 @@ RSpec.describe MatchesController, type: :system do
         end
       end
 
+      let(:match) { create(:match, :available, campaign_batch: batch, vaccination_center: center, campaign: campaign) }
+
       it "handle the user's disappointment gracefully" do
-        visit "/matches/#{match_confirmation_token}"
+        visit "/matches/#{match.match_confirmation_token}"
 
         # A volunteer confirms a few seconds before me
         # while I'm browsing the match show page
         create(:match, :confirmed, campaign: campaign)
 
+        fill_in :firstname, with: Faker::Name.first_name
+        fill_in :lastname, with: Faker::Name.last_name
         click_on("Je suis disponible")
         expect(page).to have_text("La dose n'est plus disponible 😢")
       end

--- a/spec/system/matches_controller_spec.rb
+++ b/spec/system/matches_controller_spec.rb
@@ -20,16 +20,16 @@ RSpec.describe MatchesController, type: :system do
         expect(page).to have_text(center.address)
 
         click_on("Je suis disponible")
-        expect(page).to have_text("Vous devez renseigné votre identité")
+        expect(page).to have_text("Vous devez renseigner votre identité")
 
         fill_in :firstname, with: Faker::Name.first_name
         click_on("Je suis disponible")
-        expect(page).to have_text("Vous devez renseigné votre identité")
+        expect(page).to have_text("Vous devez renseigner votre identité")
 
         fill_in :firstname, with: Faker::Name.first_name
         fill_in :lastname, with: Faker::Name.last_name
         click_on("Je suis disponible")
-        expect(page).not_to have_text("Vous devez renseigné votre identité")
+        expect(page).not_to have_text("Vous devez renseigner votre identité")
         expect(page).to have_text("Votre disponibilité est confirmée")
         expect(page).to have_text(center.address)
       end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -5,8 +5,6 @@ def robust_password
 end
 
 def fill_valid_user
-  fill_in :user_firstname, with: Faker::Name.first_name
-  fill_in :user_lastname, with: Faker::Name.last_name
   fill_in :user_address, with: Faker::Address.full_address
   fill_in :user_phone_number, with: generate(:french_phone_number)
   fill_in :user_email, with: "hello+#{(rand * 10000).to_i}@covidliste.com" # needs valid email here
@@ -103,8 +101,6 @@ RSpec.describe "Users", type: :system do
 
     it "it allows me to edit personal information " do
       new_attributes = {
-        firstname: Faker::Name.first_name,
-        lastname: Faker::Name.last_name,
         address: Faker::Address.full_address,
         phone_number: generate(:french_phone_number)
       }
@@ -150,11 +146,11 @@ RSpec.describe "Users", type: :system do
       let!(:match) { create(:match, campaign: campaign, confirmed_at: Time.now, user: user) }
 
       it "it doest not allow me to edit personal information " do
-        fill_in "user_firstname", with: "new value"
         click_on "Je modifie mes informations"
         expect(page).not_to have_text("Modifications enregistrées.")
+        expect(page).to have_text("Vous ne ne pouvez plus modifier vos informations car vous avez déjà confirmé un rendez-vous.")
         user.reload
-        expect(user.firstname).not_to eq("new value")
+        expect(user.phone_number).not_to eq(phone_number)
       end
     end
 
@@ -163,11 +159,11 @@ RSpec.describe "Users", type: :system do
       let!(:match) { create(:match, campaign: campaign, confirmed_at: nil, expires_at: 10.minutes.since, user: user) }
 
       it "it doest not allow me to edit personal information " do
-        fill_in "user_firstname", with: "new value"
         click_on "Je modifie mes informations"
         expect(page).not_to have_text("Modifications enregistrées.")
+        expect(page).to have_text("Vous ne ne pouvez plus modifier vos informations car vous avez un rendez vous en cours.")
         user.reload
-        expect(user.firstname).not_to eq("new value")
+        expect(user.phone_number).not_to eq(phone_number)
       end
     end
   end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -149,8 +149,6 @@ RSpec.describe "Users", type: :system do
         click_on "Je modifie mes informations"
         expect(page).not_to have_text("Modifications enregistrées.")
         expect(page).to have_text("Vous ne ne pouvez plus modifier vos informations car vous avez déjà confirmé un rendez-vous.")
-        user.reload
-        expect(user.phone_number).not_to eq(phone_number)
       end
     end
 
@@ -162,8 +160,6 @@ RSpec.describe "Users", type: :system do
         click_on "Je modifie mes informations"
         expect(page).not_to have_text("Modifications enregistrées.")
         expect(page).to have_text("Vous ne ne pouvez plus modifier vos informations car vous avez un rendez vous en cours.")
-        user.reload
-        expect(user.phone_number).not_to eq(phone_number)
       end
     end
   end


### PR DESCRIPTION
Nouveau parcours utilisateur mis en place :
- Ne pas récolter le nom et prénom à l’inscription.
- Ajouter une étape de récolte de nom et prénom au moment de l’acceptation du match.
- Ne stocker l’info que dans le match
- Enlever la possibilité de modifier nom/prénom sur l'espace /profil

Pour le fichier de migration j'ai suivi le tuto : 
https://makandracards.com/makandra/15575-how-to-write-complex-migrations-in-rails

Voici quelques screenshots :
<img width="1436" alt="Screenshot 2021-04-22 at 03 34 46" src="https://user-images.githubusercontent.com/6686865/115642704-bae5d100-a31b-11eb-9a62-9b5bd3e6cbc9.png">

<img width="657" alt="Screenshot 2021-04-22 at 00 23 43" src="https://user-images.githubusercontent.com/6686865/115642642-a0135c80-a31b-11eb-9ff5-b73f4afa66d4.png">

<img width="651" alt="Screenshot 2021-04-22 at 00 29 57" src="https://user-images.githubusercontent.com/6686865/115642637-9ee22f80-a31b-11eb-8dea-b5636b23028e.png">

<img width="655" alt="Screenshot 2021-04-22 at 00 45 03" src="https://user-images.githubusercontent.com/6686865/115642632-9d186c00-a31b-11eb-82f5-6c4ca23f55f0.png">


