### PR TITLE
Activation du zoom sur la carte avec affichage des coordonnées approximées des lieux de vaccination

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -10,6 +10,39 @@ class PagesController < ApplicationController
   def presse
   end
 
+  def carte
+    @vaccination_centers = VaccinationCenter.confirmed.map do |v|
+      if v.approximated_lon.present? && v.approximated_lat.present?
+        {
+          "name" => "Lieu de vaccination inscrit",
+          "description" => "La localisation est approximée à quelques kilomètres",
+          "coordinates" => [v.approximated_lon, v.approximated_lat]
+        }
+      end
+    end
+
+    @users_by_dept = {}
+    # @users_by_dept = Rails.cache.fetch("users_by_dept", expires_in: 1.hours) do
+    #   sql = "
+    #     select
+    #     case
+    #     when substring(geo_citycode, 1, 2) in ('2A', '2B') then substring(geo_citycode, 1, 2)
+    #     when substring(geo_citycode, 1, 2)::int <= 95
+    #     then substring(geo_citycode, 1, 2)
+    #     else substring(geo_citycode, 1, 3) end as key,
+    #     count(*) as value
+    #     from users
+    #     where
+    #     confirmed_at is not null
+    #     and geo_citycode is not null
+    #     group by 1
+    #     having count(*) > 100
+    #     order by 2 desc
+    #     "
+    #   Hash[User.connection.select_all(sql).map{ |row| row.values }]
+    # end
+  end
+
   def mentions_legales
   end
 

--- a/app/javascript/controllers/maps/map_controller.js
+++ b/app/javascript/controllers/maps/map_controller.js
@@ -59,6 +59,7 @@ const INITIAL_VIEW_STATE = {
   latitude: TERRITOIRES[INIT_TERRITOIRE].lat,
   longitude: TERRITOIRES[INIT_TERRITOIRE].lon,
   zoom: TERRITOIRES[INIT_TERRITOIRE].zoom,
+  maxZoom: 8,
   pitch: 0,
 };
 
@@ -83,6 +84,19 @@ export default class extends Controller {
       return { html };
     };
 
+    const getTooltip = (info) => {
+      if (info.object) {
+        if (info.layer && info.layer.id && info.layer.id === "departements") {
+          //return getDepartmentTooltip(info.object);
+        } else {
+          if (info.object.name) {
+            let html = `<b>${info.object.name}</b><br />${info.object.description}`;
+            return { html };
+          }
+        }
+      }
+    };
+
     const colorScale = scaleLinear()
       .domain([
         0,
@@ -95,12 +109,14 @@ export default class extends Controller {
       .unknown(UNKNOW_DEPT_COLOR);
 
     const departementsLayer = new GeoJsonLayer({
+      id: "departements",
       data: departements,
       pickable: true, // enable tooltip?
-      filled: true,
+      filled: false,
       stroked: true,
-      getFillColor: (d) => colorScale(getDepartmentValue(d.properties.code)),
-      getLineColor: [255, 255, 255],
+      getLineColor: (d) => colorScale(getDepartmentValue(d.properties.code)),
+      //getFillColor: (d) => colorScale(getDepartmentValue(d.properties.code)),
+      //getLineColor: [150, 150, 150],
       getLineWidth: 0.5,
       lineWidthUnits: "pixels",
     });
@@ -110,8 +126,9 @@ export default class extends Controller {
     };
 
     const iconLayer = new IconLayer({
+      id: "lieux-vaccination",
       data: data.vaccinationCenters,
-      pickable: false, // enable tooltip?
+      pickable: true, // enable tooltip?
       // iconAtlas and iconMapping are required
       // getIcon: return a string
       iconAtlas:
@@ -139,7 +156,7 @@ export default class extends Controller {
       mapStyle: null,
       canvas: "deck-canvas",
       initialViewState: INITIAL_VIEW_STATE,
-      controller: false,
+      controller: true,
       onViewStateChange: ({ viewState }) => {
         map.jumpTo({
           center: [viewState.longitude, viewState.latitude],
@@ -148,7 +165,7 @@ export default class extends Controller {
           pitch: viewState.pitch,
         });
       },
-      // getTooltip: ({ object }) => object && getDepartmentTooltip(object),
+      getTooltip: (object) => object && getTooltip(object),
       layers: layers,
     });
 
@@ -177,7 +194,5 @@ export default class extends Controller {
       };
       btnContainer.appendChild(el);
     });
-
-    console.log("Visualisation loaded");
   }
 }

--- a/app/models/vaccination_center.rb
+++ b/app/models/vaccination_center.rb
@@ -26,6 +26,9 @@ class VaccinationCenter < ApplicationRecord
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }
 
+  after_initialize :approximated_lat_lon
+  attr_reader :approximated_lat, :approximated_lon
+
   after_commit :push_to_slack, on: :create
   after_commit :geocode_address, if: -> { saved_change_to_address? }
 
@@ -96,6 +99,13 @@ class VaccinationCenter < ApplicationRecord
   end
 
   private
+
+  def approximated_lat_lon
+    return if lat.nil? || lon.nil?
+    results = ::RandomizeCoordinatesService.new(lat, lon, 5000).call
+    @approximated_lat = results[:lat]
+    @approximated_lon = results[:lon]
+  end
 
   def push_to_slack
     return unless Rails.env.production?

--- a/app/services/randomize_coordinates_service.rb
+++ b/app/services/randomize_coordinates_service.rb
@@ -1,15 +1,15 @@
 class RandomizeCoordinatesService
   EARTH_RADIUS = 6378.137
-  METERS_RANGE = 100 # randomize within +/- METERS
 
-  def initialize(lat, lon)
+  def initialize(lat, lon, meters_range = 100)
     @lat = lat
     @lon = lon
+    @meters_range = meters_range # randomize within +/- METERS
   end
 
   def call
-    dy = rand(-METERS_RANGE..METERS_RANGE) / 1000.0
-    dx = rand(-METERS_RANGE..METERS_RANGE) / 1000.0
+    dy = rand(-@meters_range..@meters_range) / 1000.0
+    dx = rand(-@meters_range..@meters_range) / 1000.0
 
     new_lat = @lat + (dy / EARTH_RADIUS) * (180 / Math::PI)
     new_lon = @lon + (dx / EARTH_RADIUS) * (180 / Math::PI) / Math.cos(@lat * Math::PI / 180)

--- a/app/views/pages/carte.erb
+++ b/app/views/pages/carte.erb
@@ -19,44 +19,16 @@
   }
 </style>
 
-<%
-vaccination_centers = VaccinationCenter.all.filter { |v| v.confirmed? }.map do |v|
-  {
-    'coordinates' => [v.lon, v.lat],
-  }
-end
-users_by_dept = {}
-# users_by_dept = Rails.cache.fetch("users_by_dept", expires_in: 1.hours) do
-#   sql = "
-#     select
-#     case
-#     when substring(geo_citycode, 1, 2) in ('2A', '2B') then substring(geo_citycode, 1, 2)
-#     when substring(geo_citycode, 1, 2)::int <= 95
-#     then substring(geo_citycode, 1, 2)
-#     else substring(geo_citycode, 1, 3) end as key,
-#     count(*) as value
-#     from users
-#     where
-#     confirmed_at is not null
-#     and geo_citycode is not null
-#     group by 1
-#     having count(*) > 100
-#     order by 2 desc
-#     "
-#   Hash[User.connection.select_all(sql).map{ |row| row.values }]
-# end
-%>
-
 <div class="container my-5">
   <h1>Carte des lieux de vaccination inscrits sur Covidliste</h1>
-  <p><%= vaccination_centers.count %> lieux de vaccination sur Covidliste et des volontaires dans tous les d&eacute;partements</p>
+  <p><%= @vaccination_centers.count %> lieux de vaccination sur Covidliste et des volontaires dans tous les départements</p>
 
   <div
     data-controller="map"
     data-map='<%=
       objects = {
-        'vaccinationCenters' => vaccination_centers,
-        'usersByDept' => users_by_dept
+        'vaccinationCenters' => @vaccination_centers,
+        'usersByDept' => @users_by_dept
       }
       objects.to_json
     %>'


### PR DESCRIPTION
Permet de zoomer sur la carte mais pas trop pour éviter les erreurs d'interprétation liées aux approximations mais assez pour voir un département facilement.
Première étape en attendant #473
Désactivation (pour l'instant) du "remplissage" des départements pour voir les noms des villes.
Passage de la partie chargement des données dans le contrôleur.

Zoom maximum : 
<img width="994" alt="Capture d’écran 2021-04-22 à 06 49 25" src="https://user-images.githubusercontent.com/666182/115657273-e2966280-a336-11eb-80fa-14271bc921dc.png">