### PR TITLE
Ne pas demander nom/prénom au moment de l'inscription mais lors de la confirmation du match

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ gem "devise_zxcvbn"
 
 group :development, :test do
   gem "dotenv-rails", "2.7.6"
+  gem "factory_bot_rails"
   gem "faker", git: "https://github.com/faker-ruby/faker.git", branch: "master"
   gem "pry-byebug"
   gem "pry-rails"
@@ -83,7 +84,6 @@ group :test do
   gem "codecov", require: false
   gem "cuprite"
   gem "database_cleaner-active_record"
-  gem "factory_bot_rails"
   gem "rails-controller-testing"
   gem "rspec-rails", "~> 4.0.0"
   gem "rspec-sidekiq"

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -1,11 +1,9 @@
 class MatchesController < ApplicationController
   before_action :set_match, only: [:show, :update, :destroy]
+  before_action :verify_age, only: [:show, :update]
+  before_action :verify_expiration, only: [:update]
 
   def show
-    if @match.age != @match.user.age
-      flash[:error] = "Désolé, votre âge a changé depuis l'envoi de la notification. Pas d'inquiétude, vous restez dans notre liste de volontaires ! Vous serez contacté dès qu'une dose est à nouveau disponible près de chez vous."
-      redirect_to root_path
-    end
   end
 
   def destroy
@@ -14,29 +12,48 @@ class MatchesController < ApplicationController
   end
 
   def update
-    if @match.age != @match.user.age
-      flash[:error] = "Désolé, votre âge a changé depuis l'envoi de la notification. Pas d'inquiétude, vous restez dans notre liste de volontaires ! Vous serez contacté dès qu'une dose est à nouveau disponible près de chez vous."
-      redirect_to root_path
-    end
-    if @match.expired?
-      flash[:error] = "Désolé, votre invitation a expiré."
-    else
-      @match.confirm!
-    end
-  rescue Match::AlreadyConfirmedError, Match::DoseOverbookingError => e
-    flash[:error] = e.message
+    form_match_params = match_params
+    @match.user.assign_attributes(
+      firstname: form_match_params[:firstname],
+      lastname: form_match_params[:lastname]
+    )
+    @match.confirm!
+  rescue Match::AlreadyConfirmedError, Match::DoseOverbookingError, Match::MissingNamesError, ActiveRecord::RecordInvalid => e
+    flash.now[:error] = e.message
   ensure
-    render action: "show"
+    render action: "show", status: flash[:error].present? ? :unprocessable_entity : :ok
   end
 
   private
 
+  def match_params
+    params.permit(:firstname, :lastname)
+  end
+
+  def verify_age
+    unless @match.age == @match.user.age
+      flash[:error] = "Désolé, votre âge a changé depuis l’envoi de la notification. Pas d’inquiétude, vous restez dans notre liste de volontaires ! Vous serez contacté dès qu’une dose est à nouveau disponible près de chez vous."
+      redirect_to root_path
+    end
+  end
+
+  def verify_expiration
+    if @match.expired?
+      flash.now[:error] = "Désolé, votre invitation a expiré."
+      render action: "show", status: :unprocessable_entity
+    end
+  end
+
   def set_match
     @match = Match.find_by(match_confirmation_token: params[:match_confirmation_token])
-    return unless @match.nil?
 
-    flash[:error] = "Désolé, ce lien d'invitation n'est pas valide."
-    redirect_to root_path
+    if @match.blank?
+      flash[:error] = "Désolé, ce lien d’invitation n’est pas valide."
+      redirect_to root_path
+    elsif @match.user.blank?
+      flash[:error] = "Désolé, ce lien d’invitation n’est pas plus valide. L’utilisateur a été supprimé."
+      redirect_to root_path
+    end
   end
 
   def skip_pundit?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,7 +76,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:firstname, :lastname, :email, :phone_number, :toc, :lat, :lon, :birthdate, :password, :statement)
+    params.require(:user).permit(:email, :phone_number, :toc, :lat, :lon, :birthdate, :password, :statement)
   end
 
   def sign_out_if_anonymized!

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -32,6 +32,7 @@ class Match < ApplicationRecord
     self.zipcode = user.zipcode
     self.geo_citycode = user.geo_citycode
     self.geo_context = user.geo_context
+    self
   end
 
   def confirmed?

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -35,6 +35,10 @@ class Partner < ApplicationRecord
     name
   end
 
+  def to_s
+    full_name
+  end
+
   def skip_password_complexity?
     !encrypted_password_changed?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,8 +67,16 @@ class User < ApplicationRecord
     ReverseGeocodeResourceJob.perform_later(self)
   end
 
-  def full_name
-    anonymized_at.nil? ? "#{firstname} #{lastname}" : "Anonymous"
+  def to_s
+    if anonymized_at.nil?
+      if missing_identity?
+        email
+      else
+        "#{firstname} #{lastname}"
+      end
+    else
+      "Anonymous"
+    end
   end
 
   def distance(lat, lon)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,8 +24,6 @@ class User < ApplicationRecord
   geocoded_by :address, latitude: :lat, longitude: :lon
 
   validates :password, presence: true, on: :create
-  validates :firstname, presence: true
-  validates :lastname, presence: true
   validates :lat, presence: true, unless: proc { |u| u.persisted? }
   validates :lon, presence: true, unless: proc { |u| u.persisted? }
   validates :birthdate, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,12 +67,20 @@ class User < ApplicationRecord
     ReverseGeocodeResourceJob.perform_later(self)
   end
 
+  def full_name
+    if anonymized_at.nil?
+      "#{firstname} #{lastname}"
+    else
+      "Anonymous"
+    end
+  end
+
   def to_s
     if anonymized_at.nil?
       if missing_identity?
         email
       else
-        "#{firstname} #{lastname}"
+        full_name
       end
     else
       "Anonymous"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,6 +86,10 @@ class User < ApplicationRecord
     confirmed_at.present?
   end
 
+  def missing_identity?
+    firstname.blank? || lastname.blank?
+  end
+
   def super_admin?
     has_role?(:super_admin)
   end

--- a/app/models/vaccination_center.rb
+++ b/app/models/vaccination_center.rb
@@ -88,7 +88,7 @@ class VaccinationCenter < ApplicationRecord
           confirmed
         ]
         if confirmed
-          line += [vaccination_center.confirmer&.full_name, vaccination_center.confirmed_at]
+          line += [vaccination_center.confirmer&.to_s, vaccination_center.confirmed_at].compact
         end
         csv << line
       end

--- a/app/views/admin/home/index.html.erb
+++ b/app/views/admin/home/index.html.erb
@@ -5,7 +5,7 @@
 
   <p class="mt-4">
     <strong>
-      Bonjour <%= current_user.full_name %> 👋
+      Bonjour <%= current_user %> 👋
     </strong>
   </p>
 

--- a/app/views/admin/vaccination_centers/index.html.erb
+++ b/app/views/admin/vaccination_centers/index.html.erb
@@ -81,7 +81,7 @@
               <td>
                 <% if vaccination_center.confirmed? %>
                   <%= icon("fas", "check", class: "text-success") %>
-                  <span title="Validé par #{vaccination_center.confirmer&.full_name} le #{vaccination_center.confirmed_at}", data-toggle="tooltip"> Oui </span>
+                  <span title="<%= "Validé par #{vaccination_center.confirmer&.full_name} le #{vaccination_center.confirmed_at}" %>", data-toggle="tooltip"> Oui </span>
                 <% else %>
                   <%= icon("fas", "times", class: "text-danger") %>
                   Non

--- a/app/views/admin/vaccination_centers/index.html.erb
+++ b/app/views/admin/vaccination_centers/index.html.erb
@@ -81,7 +81,7 @@
               <td>
                 <% if vaccination_center.confirmed? %>
                   <%= icon("fas", "check", class: "text-success") %>
-                  <span title="<%= "Validé par #{vaccination_center.confirmer&.full_name} le #{vaccination_center.confirmed_at}" %>", data-toggle="tooltip"> Oui </span>
+                  <span title="<%= "Validé par #{vaccination_center.confirmer} le #{vaccination_center.confirmed_at}" %>", data-toggle="tooltip"> Oui </span>
                 <% else %>
                   <%= icon("fas", "times", class: "text-danger") %>
                   Non

--- a/app/views/admin/vaccination_centers/show.html.erb
+++ b/app/views/admin/vaccination_centers/show.html.erb
@@ -14,7 +14,7 @@
     <% if @vaccination_center.confirmed? %>
       <%= icon("fas", "check", class: "text-success") %>
       Validé par
-      <strong><%= @vaccination_center.confirmer&.full_name %></strong>
+      <strong><%= @vaccination_center.confirmer %></strong>
       le <%= l @vaccination_center.confirmed_at %>
 
     <% else %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
 <p>
-  Bonjour <%= @resource.full_name %>,
+  Bonjour <%= @resource %>,
 </p>
 
 <p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,5 +1,5 @@
 <p>
-  Bonjour <%= @resource.full_name %>,
+  Bonjour <%= @resource %>,
 </p>
 
 <p>

--- a/app/views/layouts/_admin_navbar.html.erb
+++ b/app/views/layouts/_admin_navbar.html.erb
@@ -55,7 +55,7 @@
       <% if current_user %>
         <li class="nav-item dropdown">
           <%= link_to "", class: "nav-link text-white font-weight-bold dropdown-toggle", id: "dropdownProfil", "aria-expanded": "false", "aria-haspopup": "true", "data-toggle": "dropdown" do %>
-            <%= current_user.full_name %>
+            <%= current_user %>
             <span class="badge badge-danger"> Admin </span>
           <% end %>
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -44,7 +44,7 @@
       <% elsif current_user %>
         <li class="nav-item dropdown">
           <%= link_to "", class: "nav-link text-white font-weight-bold dropdown-toggle", id: "dropdown09", "aria-expanded": "false", "aria-haspopup": "true", "data-toggle": "dropdown" do %>
-            <%= current_user.full_name %>
+            <%= current_user %>
           <% end %>
 
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdown09">

--- a/app/views/match_mailer/match_confirmation_instructions.html.erb
+++ b/app/views/match_mailer/match_confirmation_instructions.html.erb
@@ -1,6 +1,6 @@
 <div>
   <h2>
-    Bonne nouvelle <%= @match.user.full_name %> !
+    Bonne nouvelle <%= @match.user %> !
   </h2>
 
   <p>

--- a/app/views/match_mailer/send_anonymisation_notice.html.erb
+++ b/app/views/match_mailer/send_anonymisation_notice.html.erb
@@ -1,6 +1,6 @@
 <div>
   <h2>
-    Bonjour <%= @match.user.full_name %>,
+    Bonjour <%= @match.user %>,
   </h2>
 
   <p>

--- a/app/views/matches/_confirmed.html.erb
+++ b/app/views/matches/_confirmed.html.erb
@@ -8,7 +8,7 @@
 
 <%= render 'match_details', match: @match %>
 
-<% if match.campaign.extra_info %>
+<% if match.campaign.extra_info.present? %>
   <div>
     <p>
       <i class="fas fa-info-circle"></i>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -27,7 +27,7 @@
     <div>
       <i class="fas fa-user-lock"></i>
       <p>
-        Réservé pour <strong><%= user.full_name %></strong><br>
+        Réservé pour <strong><%= user %></strong><br>
         Né le <strong><%= user.birthdate.strftime('%d/%m/%Y') %></strong><br>
         Réservation strictement nominative. <br>
         <strong>Date de naissance et nom seront vérifiés</strong> (pensez à vous munir d'une pièce d'identité)<br>

--- a/app/views/matches/_pending.html.erb
+++ b/app/views/matches/_pending.html.erb
@@ -24,7 +24,7 @@
       </label>
       <input class="form-control" placeholder="Jean" type="text" value="" name="firstname" id="firstname" autocomplete="given-name" required>
       <div class="invalid-feedback w-100">
-        Vous devez renseigné votre prénom.
+        Vous devez renseigner votre prénom.
       </div>
     </div>
   </div>

--- a/app/views/matches/_pending.html.erb
+++ b/app/views/matches/_pending.html.erb
@@ -35,7 +35,7 @@
       </label>
       <input class="form-control" placeholder="Dupont" type="text" value="" name="lastname" id="lastname" autocomplete="family-name" required>
       <div class="invalid-feedback w-100">
-        Vous devez renseigné votre nom.
+        Vous devez renseigner votre nom.
       </div>
     </div>
   </div>

--- a/app/views/matches/_pending.html.erb
+++ b/app/views/matches/_pending.html.erb
@@ -22,7 +22,7 @@
       <label class="form-check-label w-75" for="firstname">
         Prénom
       </label>
-      <input class="form-control" placeholder="Jean" type="text" value="" name="firstname" id="firstname" autocomplete="given-name" required>
+      <input class="form-control" placeholder="Jean" type="text" value="<%= user.firstname %>" name="firstname" id="firstname" autocomplete="given-name" required>
       <div class="invalid-feedback w-100">
         Vous devez renseigner votre prénom.
       </div>
@@ -33,7 +33,7 @@
       <label class="form-check-label w-75" for="lastname">
         Nom
       </label>
-      <input class="form-control" placeholder="Dupont" type="text" value="" name="lastname" id="lastname" autocomplete="family-name" required>
+      <input class="form-control" placeholder="Dupont" type="text" value="<%= user.lastname %>" name="lastname" id="lastname" autocomplete="family-name" required>
       <div class="invalid-feedback w-100">
         Vous devez renseigner votre nom.
       </div>

--- a/app/views/matches/_pending.html.erb
+++ b/app/views/matches/_pending.html.erb
@@ -19,9 +19,31 @@
   <input type="hidden" name="_method" value="PATCH">
   <div class="col-12 mb-2">
     <div class="form-check flex-wrap">
+      <label class="form-check-label w-75" for="firstname">
+        Prénom
+      </label>
+      <input class="form-control" placeholder="Jean" type="text" value="" name="firstname" id="firstname" autocomplete="given-name" required>
+      <div class="invalid-feedback w-100">
+        Vous devez renseigné votre prénom.
+      </div>
+    </div>
+  </div>
+  <div class="col-12 mb-2">
+    <div class="form-check flex-wrap">
+      <label class="form-check-label w-75" for="lastname">
+        Nom
+      </label>
+      <input class="form-control" placeholder="Dupont" type="text" value="" name="lastname" id="lastname" autocomplete="family-name" required>
+      <div class="invalid-feedback w-100">
+        Vous devez renseigné votre nom.
+      </div>
+    </div>
+  </div>
+  <div class="col-12 mb-2">
+    <div class="form-check flex-wrap">
       <input class="form-check-input" type="checkbox" value="" id="confirm_name" required>
       <label class="form-check-label w-75" for="confirm_name">
-        Je confirme avoir une pièce d'identité au nom de <strong><%= user.full_name %></strong>
+        Je confirme avoir une pièce d'identité au nom renseigné ci-dessus.
       </label>
       <div class="invalid-feedback w-100">
         Vous devez confirmer votre nom. <br>
@@ -33,7 +55,7 @@
     <div class="form-check flex-wrap">
       <input class="form-check-input" type="checkbox" value="" id="confirm_age" required>
       <label class="form-check-label w-75" for="confirm_age">
-        Je confirme avoir une pièce d'identité portant la date de naissance <strong><%= user.birthdate %></strong>
+        Je confirme avoir une pièce d'identité portant la date de naissance <strong><%= user.birthdate.strftime("%d/%m/%Y") %></strong>
       </label>
       <div class="invalid-feedback w-100">
         Vous devez confirmer votre date de naissance. <br>

--- a/app/views/partners/campaigns/show.html.erb
+++ b/app/views/partners/campaigns/show.html.erb
@@ -132,7 +132,7 @@
                 <td> - </td>
                 <td> - </td>
               <% else %>
-                <td> <%= user.full_name %> </td>
+                <td> <%= user %> </td>
                 <td> <%= user.human_friendly_phone_number %> </td>
                 <td> <%= user.birthdate.strftime("%d/%m/%Y") %> </td>
               <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -20,20 +20,6 @@
     <% end %>
 
     <%= simple_form_for @user do |f| %>
-      <%= f.input :firstname,
-                  label: "Prénom",
-                  error: "Prénom requis",
-                  placeholder: "Jean",
-                  required: true,
-                  input_html: { autocomplete: "given-name" } %>
-
-      <%= f.input :lastname,
-                  label: "Nom",
-                  error: "Nom requis",
-                  placeholder: "Dupont",
-                  required: true,
-                  input_html: { autocomplete: "family-name" } %>
-
       <%= f.input :birthdate,
                   as: :date,
                   label: "Date de naissance",
@@ -42,7 +28,7 @@
                   order: [:day, :month, :year] %>
       
       <p class="text-primary small">
-        Vérifiez bien vos nom, prénom et date de naissance. En cas d'erreur, la vaccination ne sera pas possible !
+        Vérifiez bien votre date de naissance. En cas d'erreur, la vaccination ne sera pas possible !
       </p>
       <%= f.input :address,
                   label: "Adresse",

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,9 +23,6 @@
       <% end %>
 
       <%= simple_form_for(@user, url: :profile, method: :put, wrapper: :horizontal_form) do |f| %>
-        <%= f.input :firstname, label: "Prénom", placeholder: "Jean", valid_class: "" %>
-        <%= f.input :lastname, label: "Nom", error: "Nom requis", placeholder: "Dupont" %>
-
         <div class="row">
           <div class="col-12 col-sm-3">
             <label class="col-form-label">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,7 +2,7 @@
   <div class="row mt-5 pb-3">
     <div class="col-12 col-sm-8 offset-sm-2">
       <p>
-        Bonjour <%= @user.full_name %>,
+        Bonjour <%= @user %>,
       </p>
       <p>
         Vous êtes inscrit sur Covidliste depuis le <%= @user.created_at.strftime("%d/%m/%Y") %>

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -22,7 +22,7 @@ namespace :populate do
       user.update_columns(confirmed_at: Time.now.utc)
       GeocodeResourceJob.perform_now(user)
       user.reload
-      puts "#{i + 1}. #{user.full_name}, #{user.age} ans - #{user.address} (#{user.lat}, #{user.lon})"
+      puts "#{i + 1}. #{user}, #{user.age} ans - #{user.address} (#{user.lat}, #{user.lon})"
     end
     puts "Done."
   end

--- a/spec/factories/match_factory.rb
+++ b/spec/factories/match_factory.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     trait :confirmed do
       confirmed_at { Time.zone.now }
     end
+
+    trait :available do
+      expires_at { 1.hours.from_now }
+    end
   end
 end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Partner, type: :model do
+  describe "Full name" do
+    it "should return name" do
+      partner = Partner.new(name: "Pharmacie de Marseille")
+      expect(partner.full_name).to eq("Pharmacie de Marseille")
+    end
+  end
+
+  describe "to_s" do
+    it "should return name" do
+      partner = Partner.new(name: "Pharmacie de Marseille")
+      expect(partner.to_s).to eq("Pharmacie de Marseille")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -70,13 +70,31 @@ RSpec.describe User, type: :model do
   describe "Full name" do
     it "should return firstname + lastname" do
       user = User.new(firstname: "George", lastname: "Abitbol")
-      expect(user).to eq("George Abitbol")
+      expect(user.full_name).to eq("George Abitbol")
     end
 
     it "should return Anonymous" do
       user = create(:user)
       user.anonymize!
-      expect(user).to eq("Anonymous")
+      expect(user.full_name).to eq("Anonymous")
+    end
+  end
+
+  describe "to_s" do
+    it "should return email" do
+      user = User.new(email: "test@coviliste.com")
+      expect(user.to_s).to eq("test@coviliste.com")
+    end
+
+    it "should return firstname + lastname" do
+      user = User.new(firstname: "George", lastname: "Abitbol")
+      expect(user.to_s).to eq("George Abitbol")
+    end
+
+    it "should return Anonymous" do
+      user = create(:user)
+      user.anonymize!
+      expect(user.to_s).to eq("Anonymous")
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -70,13 +70,13 @@ RSpec.describe User, type: :model do
   describe "Full name" do
     it "should return firstname + lastname" do
       user = User.new(firstname: "George", lastname: "Abitbol")
-      expect(user.full_name).to eq("George Abitbol")
+      expect(user).to eq("George Abitbol")
     end
 
     it "should return Anonymous" do
       user = create(:user)
       user.anonymize!
-      expect(user.full_name).to eq("Anonymous")
+      expect(user).to eq("Anonymous")
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe User, type: :model do
 
     it "is invalid without a first_name" do
       user.firstname = nil
-      expect(user).to_not be_valid
+      expect(user).to be_valid
     end
 
     it "is invalid without a last_name" do
       user.lastname = nil
-      expect(user).to_not be_valid
+      expect(user).to be_valid
     end
 
     it "is invalid without lat or lon" do

--- a/spec/requests/matches_request_spec.rb
+++ b/spec/requests/matches_request_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe "Matches", type: :request do
   describe "update" do
     it "it will confirm a valid match" do
       expect {
-        patch "/matches/#{match_confirmation_token}"
+        patch "/matches/#{match_confirmation_token}", params: {
+          firstname: "Jean",
+          lastname: "Dupont"
+        }
       }.to change { match.reload.confirmed_at }
     end
 
@@ -19,7 +22,10 @@ RSpec.describe "Matches", type: :request do
       match.update_column("expires_at", 5.minutes.ago)
 
       expect {
-        put "/matches/#{match_confirmation_token}"
+        patch "/matches/#{match_confirmation_token}", params: {
+          firstname: "Jean",
+          lastname: "Dupont"
+        }
       }.not_to change { match.reload.confirmed_at }
     end
   end

--- a/spec/system/matches_controller_spec.rb
+++ b/spec/system/matches_controller_spec.rb
@@ -19,6 +19,24 @@ RSpec.describe MatchesController, type: :system do
         expect(page).to have_text("Une dose est disponible")
         expect(page).to have_text("Je suis disponible")
         expect(page).to have_text(center.address)
+
+        click_on("Je suis disponible")
+        expect(page).to have_text("Vous devez renseigner votre identité")
+
+        fill_in :firstname, with: generate(:firstname)
+        click_on("Je suis disponible")
+        expect(page).to have_text("Vous devez renseigner votre identité")
+
+        fill_in :lastname, with: generate(:lastname)
+        click_on("Je suis disponible")
+        expect(page).to have_text("Vous devez renseigner votre identité")
+
+        fill_in :firstname, with: generate(:firstname)
+        fill_in :lastname, with: generate(:lastname)
+        click_on("Je suis disponible")
+        expect(page).not_to have_text("Vous devez renseigner votre identité")
+        expect(page).to have_text("Votre disponibilité est confirmée")
+        expect(page).to have_text(center.address)
       end
     end
 
@@ -85,6 +103,8 @@ RSpec.describe MatchesController, type: :system do
         # while I'm browsing the match show page
         create(:match, :confirmed, campaign: campaign)
 
+        fill_in :firstname, with: generate(:firstname)
+        fill_in :lastname, with: generate(:lastname)
         click_on("Je suis disponible")
         expect(page).to have_text("La dose n'est plus disponible 😢")
       end

--- a/spec/system/matches_controller_spec.rb
+++ b/spec/system/matches_controller_spec.rb
@@ -19,20 +19,21 @@ RSpec.describe MatchesController, type: :system do
         expect(page).to have_text("Une dose est disponible")
         expect(page).to have_text("Je suis disponible")
         expect(page).to have_text(center.address)
+        expect(page).to have_field("firstname", with: user.firstname)
+        expect(page).to have_field("lastname", with: user.lastname)
 
+        fill_in :firstname, with: user.firstname
+        fill_in :lastname, with: ""
         click_on("Je suis disponible")
         expect(page).to have_text("Vous devez renseigner votre identité")
 
-        fill_in :firstname, with: generate(:firstname)
+        fill_in :firstname, with: ""
+        fill_in :lastname, with: user.lastname
         click_on("Je suis disponible")
         expect(page).to have_text("Vous devez renseigner votre identité")
 
-        fill_in :lastname, with: generate(:lastname)
-        click_on("Je suis disponible")
-        expect(page).to have_text("Vous devez renseigner votre identité")
-
-        fill_in :firstname, with: generate(:firstname)
-        fill_in :lastname, with: generate(:lastname)
+        fill_in :firstname, with: user.firstname
+        fill_in :lastname, with: user.lastname
         click_on("Je suis disponible")
         expect(page).not_to have_text("Vous devez renseigner votre identité")
         expect(page).to have_text("Votre disponibilité est confirmée")

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -5,9 +5,7 @@ def robust_password
 end
 
 def fill_valid_user
-  fill_in :user_firstname, with: Faker::Name.first_name
-  fill_in :user_lastname, with: Faker::Name.last_name
-  fill_in :user_address, with: Faker::Address.full_address
+  fill_in :user_address, with: generate(:french_address)
   fill_in :user_phone_number, with: generate(:french_phone_number)
   fill_in :user_email, with: "hello+#{(rand * 10000).to_i}@covidliste.com" # needs valid email here
   fill_in :user_password, with: robust_password

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -108,8 +108,6 @@ RSpec.describe "Users", type: :system do
 
     it "it allows me to edit personal information " do
       new_attributes = {
-        firstname: Faker::Name.first_name,
-        lastname: Faker::Name.last_name,
         phone_number: generate(:french_phone_number)
       }
 
@@ -154,11 +152,9 @@ RSpec.describe "Users", type: :system do
       let!(:match) { create(:match, campaign: campaign, confirmed_at: Time.now, user: user) }
 
       it "it doest not allow me to edit personal information " do
-        fill_in "user_firstname", with: "new value"
         click_on "Je modifie mes informations"
         expect(page).not_to have_text("Modifications enregistrées.")
-        user.reload
-        expect(user.firstname).not_to eq("new value")
+        expect(page).to have_text("Vous ne ne pouvez plus modifier vos informations car vous avez déjà confirmé un rendez-vous.")
       end
     end
 
@@ -167,11 +163,9 @@ RSpec.describe "Users", type: :system do
       let!(:match) { create(:match, campaign: campaign, confirmed_at: nil, expires_at: 10.minutes.since, user: user) }
 
       it "it doest not allow me to edit personal information " do
-        fill_in "user_firstname", with: "new value"
         click_on "Je modifie mes informations"
         expect(page).not_to have_text("Modifications enregistrées.")
-        user.reload
-        expect(user.firstname).not_to eq("new value")
+        expect(page).to have_text("Vous ne ne pouvez plus modifier vos informations car vous avez un rendez vous en cours.")
       end
     end
   end

--- a/test/mailers/previews/match_mailer_preview.rb
+++ b/test/mailers/previews/match_mailer_preview.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class MatchMailerPreview < ActionMailer::Preview
+  def match_confirmation_instructions
+    match = FactoryBot.create(:match, :available)
+    MatchMailer.with(match: match).match_confirmation_instructions.deliver_now
+  end
+
+  def send_anonymisation_notice
+    match = FactoryBot.create(:match, :confirmed)
+    MatchMailer.with(match: match).send_anonymisation_notice.deliver_now
+  end
+end


### PR DESCRIPTION
L'idée est de ne pas demander `nom/prenom` au moment de l'inscription permet de réduire notre surface d'attaque, à la fois temporelle (un volontaire matché n'aura son nom/prénom en base qu'entre la confirmation du match et son anonyimisation 3 jours plus tard) et spatiale (on ne connaitra jamais les nom/prénom des volontaires qui n'auront jamais confirmé de rdv.)

Tâches effectués:

- Retrait des champs prénom et nom de la homepage
- Retrait des champs prénom et nom de la page d'édition de profil
- Rajout des champs prénom et nom dans la page de confirmation issue du lien envoyé par mail quand l'utilisateur a été matché.
- Ajout des mailer previews de Rails pour tester le rendu des emails de matching
- Ajout de la gem 'factory_bot_rails' dans le group ':development, :test' afin de pouvoir créer des matchs facilement dans les previews mailers
- Ajout d'une méthode to_s dans les models User et Partner pour une question de lisibilité
- Ajout de 'accepts_nested_attributes_for :user' dans le model match pour trigger la sauvegarde de l'utilisateur quand on assigne les champs prénom nom lors de la confirmation du match.
- Rajout d'un 'self' dans 'def save_user_info' du model Match de sorte que le retour de la fonction retourne l'objet et pas juste la derniere ligne qui est geo_context.

Pour tester le workflow de la page d'inscription volontaire, vous pouvez y accéder via :
http://localhost:3000

Pour tester le workflow de la page de matching où on demande le prénom et nom à présent, vous pouvez y accéder via le previsualisateur de mail de Rails :
http://localhost:3000/rails/mailers/match_mailer/match_confirmation_instructions

Puis vous cliquez sur le lien de confirmation de réservation du vaccin qui possède le token de confirmation.
Vous pouvez voir ci-dessou des screenshots :

https://user-images.githubusercontent.com/6686865/115740610-48163d80-a38f-11eb-8cd3-8719bf03293c.mp4

<img width="1434" alt="Screenshot 2021-04-22 at 16 36 38" src="https://user-images.githubusercontent.com/6686865/115740564-3b91e500-a38f-11eb-8470-c7176e67b652.png">

# Post merge

Reste à savoir ce que l'on fait des users existants (question qui peut se traiter après la PR)

1. on efface leur nom/prenom et ils devront le renseigner au moment d'un match éventuel -> ça risque de soulever quelques interrogations.
2. on garde et au moment du match, on pré-rempli les champs nom/prénoms -> on ne réduit pas notre risque de données perso sur les personnes déjà inscrites

cc @rchampourlier

