### PR TITLE
Afficher les infos et les chiffres dans le formulaire d’édition

### DIFF
--- a/app/views/users/_about.html.erb
+++ b/app/views/users/_about.html.erb
@@ -1,4 +1,4 @@
-<div class="mt-md-3">
+<div class="bg-white px-3">
   <h3 class="h6 font-weight-bolder text-primary mb-3">Qu’est-ce que Covidliste ?</h3>
 
   <p>
@@ -66,11 +66,11 @@
   </p>
 
 
-  <p>
+  <p class="mb-0">
     Pour en savoir plus, n’hésitez pas à consulter notre
     <%= link_to 'FAQ', faq_path %>
     et suivez-nous sur
     <%= link_to "Twitter", "https://twitter.com/covidliste", target: "_blank", rel: "noopener" %>
-    pour ne rien rater de notre actualité !
+    pour ne rien rater de notre actualité !
   </p>
 </div>

--- a/app/views/users/_edit.html.erb
+++ b/app/views/users/_edit.html.erb
@@ -1,0 +1,83 @@
+<div class="bg-white px-3">
+  <p>
+    Bonjour <strong><%= @user %></strong> 👋🏽
+  </p>
+  <p>
+    Vous êtes inscrit sur Covidliste depuis le <strong><%= @user.created_at.strftime("%d/%m/%Y") %></strong>
+  </p>
+
+  <%= twitter_share %>
+
+  <p class="mt-3">
+    <strong>Vos informations</strong>
+  </p>
+
+  <% if @user.errors.any? %>
+    <div class="alert alert-danger" role="alert" style="position: inherit">
+      <% @user.errors.full_messages.each do |msg| %>
+        <%= msg %><br />
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= simple_form_for(@user, url: :profile, method: :put, wrapper: :vertical_form) do |f| %>
+
+    <label class="col-form-label">
+      Date de naissance
+    </label>
+    <%= f.input :birthdate, as: :date, label: false, start_year: Date.today.year - 120, end_year: Date.today.year - 18, order: [:day, :month, :year] %>
+
+    <label class="col-form-label">
+      Adresse
+    </label>
+    <%= f.input :address, label: false, error: "Adresse requise", placeholder: "Choisir une nouvelle adresse" %>
+
+    <small class="form-text text-muted mb-2"> 
+      Pour des raisons de protection des données personnelles, nous ne stockons pas votre adresse. Nous gardons seulement une représentation de votre adresse sous la forme d'une coordonnée GPS (latitude/longitude), randomisée à +/- 100 mètres.
+      <br/>
+      Si vous souhaitez modifier cette donnée, entrez une nouvelle adresse et cliquez sur "Je modifie mes informations".
+    </small>
+
+    <%- if @user.lat.nil? || @user.lon.nil? %>
+      <div class="alert alert-danger mb-4 small" role="alert" style="position: inherit">
+        Nous n'avons pas pu géolocaliser l'adresse que vous avez renseignée lors de votre inscription.
+        Sans cette information, il nous sera impossible de vous mettre en relation avec l'un de nos centres partenaires à proximité.
+        Merci de renseigner votre addresse une nouvelle fois.
+      </div>
+    <% else %>
+      <div class="mt-4 mb-4" 
+          id="user_map" 
+          style="height: 250px;" 
+          data-lat="<%= @user.lat %>" 
+          data-lon="<%= @user.lon %>"
+          >
+      </div>
+    <% end %>
+
+    <%= f.input_field :lat, as: :hidden %>
+    <%= f.input_field :lon, as: :hidden %>
+    <%= f.input :email, disabled: true, label: "Email", error: f.error(:email), placeholder: "jean@dupont.com" %>
+    <%= f.input :phone_number, label: "Numéro de téléphone", error: "", placeholder: "06 06 06 06 06" %>
+    <%= render partial: "input_statement", locals: {f: f, local_cgu_path: cgu_volontaires_path} %>
+
+    <%= f.button :submit, "Je modifie mes informations", class: "btn btn-primary", data: { disable_with: "Validation..." } %>
+  <% end %>
+  <%= render partial: "mentions" %>
+
+  <p class="mt-4">
+    Vous souhaitez vérifier vos données personnelles ?
+    <%= link_to "Télécharger mes données (CSV)", user_path(format: :csv) %>
+  </p>
+
+  <p class="mt-4">
+    Vous souhaitez supprimer votre compte ?
+    <%= button_to "Supprimer mon compte", :delete_user, method: :delete, class: "btn btn-danger",
+                data: { confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr ?" } %>
+  </p>
+
+  <hr/>
+
+  <div class="mb-3">
+    <%= button_to "Se déconnecter", destroy_user_session_path, method: :delete, class: "btn btn-warning" %>
+  </div>
+</div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,4 +1,4 @@
-<div class="mb-4 mb-md-0 bg-white py-3 px-3">
+<div class="bg-white px-3">
   <h2 class="h6 font-weight-bolder text-primary mb-3">Inscription en tant que volontaire à la vaccination</h2>
 
   <% if @user.persisted? %>

--- a/app/views/users/_mentions.html.erb
+++ b/app/views/users/_mentions.html.erb
@@ -1,4 +1,4 @@
-<p class="mt-3">
+<p class="mt-3 mb-0">
     Hostolab traite les données recueillies pour vous mettre en relation avec un établissement de vaccination.
     Toutes les informations demandées sont nécessaires à la mise en relation.
     <br>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,87 +1,11 @@
 <div class="container">
   <div class="row mt-5 pb-3">
-    <div class="col-12 col-sm-8 offset-sm-2">
-      <p>
-        Bonjour <%= @user %>,
-      </p>
-      <p>
-        Vous êtes inscrit sur Covidliste depuis le <%= @user.created_at.strftime("%d/%m/%Y") %>
-      </p>
+    <div class="col-12 col-md-6 col-lg-5">
+      <%= render "edit" %>
+    </div>
 
-      <%= twitter_share %>
-
-      <p class="mt-3">
-        <strong>Vos informations</strong>
-      </p>
-
-      <% if @user.errors.any? %>
-        <div class="alert alert-danger" role="alert" style="position: inherit">
-          <% @user.errors.full_messages.each do |msg| %>
-            <%= msg %><br />
-          <% end %>
-        </div>
-      <% end %>
-
-      <%= simple_form_for(@user, url: :profile, method: :put, wrapper: :horizontal_form) do |f| %>
-        <div class="row">
-          <div class="col-12 col-sm-3">
-            <label class="col-form-label">
-              Date de naissance
-            </label>
-          </div>
-          <div class="col-12 col-sm-9">
-            <%= f.input :birthdate, as: :date, label: false, start_year: Date.today.year - 120, end_year: Date.today.year - 18, order: [:day, :month, :year] %>
-          </div>
-        </div>
-
-        <%= f.input :address, label: "Adresse", error: "Adresse requise", placeholder: "Choisir une nouvelle adresse" %>
-      
-        <small class="form-text text-muted mb-2"> 
-          Pour des raisons de protection des données personnelles, nous ne stockons pas votre adresse. Nous gardons seulement une représentation de votre adresse sous la forme d'une coordonnée GPS (latitude/longitude), randomisée à +/- 100 mètres.
-          <br/>
-          Si vous souhaitez modifier cette donnée, entrez une nouvelle adresse et cliquez sur "Je modifie mes informations".
-        </small>
-
-        <%- if @user.lat.nil? || @user.lon.nil? %>
-          <div class="alert alert-danger mb-4 small" role="alert" style="position: inherit">
-            Nous n'avons pas pu géolocaliser l'adresse que vous avez renseignée lors de votre inscription.
-            Sans cette information, il nous sera impossible de vous mettre en relation avec l'un de nos centres partenaires à proximité.
-            Merci de renseigner votre addresse une nouvelle fois.
-          </div>
-        <% else %>
-          <div class="mt-4 mb-4" 
-              id="user_map" 
-              style="height: 250px;" 
-              data-lat="<%= @user.lat %>" 
-              data-lon="<%= @user.lon %>"
-              >
-          </div>
-        <% end %>
-
-        <%= f.input_field :lat, as: :hidden %>
-        <%= f.input_field :lon, as: :hidden %>
-        <%= f.input :email, disabled: true, label: "Email", error: f.error(:email), placeholder: "jean@dupont.com" %>
-        <%= f.input :phone_number, label: "Numéro de téléphone", error: "", placeholder: "06 06 06 06 06" %>
-        <%= render partial: "input_statement", locals: {f: f, local_cgu_path: cgu_volontaires_path} %>
-
-        <%= f.button :submit, "Je modifie mes informations", class: "btn btn-primary", data: { disable_with: "Validation..." } %>
-      <% end %>
-      <%= render partial: "mentions" %>
-
-      <p class="mt-4">
-        Vous souhaitez vérifier vos données personnelles ?
-        <%= link_to "Télécharger mes données (CSV)", user_path(format: :csv) %>
-      </p>
-
-      <p class="mt-4">
-        Vous souhaitez supprimer votre compte ?
-        <%= button_to "Supprimer mon compte", :delete_user, method: :delete, class: "btn btn-danger",
-                    data: { confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr ?" } %>
-      </p>
-
-      <hr/>
-
-      <%= button_to "Se déconnecter", destroy_user_session_path, method: :delete, class: "btn btn-warning" %>
+    <div class="col-12 col-md-6 col-lg-7">
+      <%= render "about" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Reprendre les infos à droite du formulaire d’inscription et les mettre à l’identique à droite du formulaire d’édition.
J'ai profité pour corriger quelques margin pour bien aligner tout.

![screencapture-localhost-3000-2021-04-22-20_39_24](https://user-images.githubusercontent.com/6686865/115769049-668a3200-a3ab-11eb-8c0d-93f3db97948a.png)
![screencapture-localhost-3000-profile-2021-04-22-20_38_48](https://user-images.githubusercontent.com/6686865/115769070-6b4ee600-a3ab-11eb-802b-fa465225881b.png)
