### PR TITLE
Passwordless

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ gem "lograge"
 gem "logstash-event"
 gem "ddtrace", "0.35.2"
 gem "devise_zxcvbn"
+gem "devise-passwordless"
 
 group :development, :test do
   gem "dotenv-rails", "2.7.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-passwordless (0.5.0)
+      devise
     devise_zxcvbn (5.1.0)
       devise
       zxcvbn-js (~> 4.4.1)
@@ -488,6 +490,7 @@ DEPENDENCIES
   database_cleaner-active_record
   ddtrace (= 0.35.2)
   devise
+  devise-passwordless
   devise_zxcvbn
   dotenv-rails (= 2.7.6)
   factory_bot_rails

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -4,6 +4,10 @@ class ConfirmationsController < ::Devise::ConfirmationsController
     yield resource if block_given?
     if resource.errors.empty?
       set_flash_message!(:notice, :confirmed)
+
+      # PasswordLess specific behaviour after confirmation there is a direct sign in
+      sign_in(resource) if resource.is_a?(User)
+
       respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }
     elsif resource.confirmed?
       set_flash_message!(:notice, :already_confirmed)
@@ -17,9 +21,8 @@ class ConfirmationsController < ::Devise::ConfirmationsController
     if resource.is_a?(Partner)
       # NOTE(ssaunier): We already have a valid password at sign up
       partners_vaccination_centers_path
-    elsif resource.encrypted_password.blank?
-      token = resource.send(:set_reset_password_token)
-      edit_password_url(resource, reset_password_token: token)
+    elsif resource.is_a?(User)
+      profile_path
     else
       new_user_session_path
     end

--- a/app/controllers/devise/passwordless/magic_links_controller.rb
+++ b/app/controllers/devise/passwordless/magic_links_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Devise::Passwordless::MagicLinksController < DeviseController
+  prepend_before_action :require_no_authentication, only: :show
+  prepend_before_action :allow_params_authentication!, only: :show
+  prepend_before_action(only: [:show]) { request.env["devise.skip_timeout"] = true }
+
+  def show
+    self.resource = warden.authenticate!(auth_options)
+    set_flash_message!(:notice, :signed_in)
+    sign_in(resource_name, resource)
+    yield resource if block_given?
+    redirect_to after_sign_in_path_for(resource)
+  end
+
+  protected
+
+  def auth_options
+    {scope: resource_name, recall: "#{resource_name.to_s.pluralize}/sessions#new"}
+  end
+
+  def translation_scope
+    "devise.sessions"
+  end
+
+  private
+
+  def create_params
+    resource_params.permit(:email, :remember_me)
+  end
+end

--- a/app/controllers/devise/passwordless/sessions_controller.rb
+++ b/app/controllers/devise/passwordless/sessions_controller.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class Devise::Passwordless::SessionsController < Devise::SessionsController
+  def create
+    self.resource = resource_class.find_by(email: create_params[:email])
+    if resource
+      resource.send_magic_link(create_params[:remember_me])
+      set_flash_message(:notice, :magic_link_sent, now: true)
+    else
+      set_flash_message(:alert, :not_found_in_database, now: true)
+    end
+
+    self.resource = resource_class.new(create_params)
+    render :new
+  end
+
+  protected
+
+  def translation_scope
+    if action_name == "create"
+      "devise.passwordless"
+    else
+      super
+    end
+  end
+
+  private
+
+  def create_params
+    resource_params.permit(:email, :remember_me)
+  end
+end

--- a/app/controllers/devise/passwordless/sessions_controller.rb
+++ b/app/controllers/devise/passwordless/sessions_controller.rb
@@ -3,12 +3,12 @@
 class Devise::Passwordless::SessionsController < Devise::SessionsController
   def create
     self.resource = resource_class.find_by(email: create_params[:email])
-    if resource
-      resource.send_magic_link(create_params[:remember_me])
-      set_flash_message(:notice, :magic_link_sent, now: true)
-    else
-      set_flash_message(:alert, :not_found_in_database, now: true)
-    end
+
+    resource&.send_magic_link(create_params[:remember_me])
+
+    # always send a success message to prevent leaking information
+    # about the presence or not of a user in our database
+    set_flash_message(:notice, :magic_link_sent, now: true, email: create_params[:email])
 
     self.resource = resource_class.new(create_params)
     render :new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,12 +5,7 @@ class User < ApplicationRecord
 
   attr_accessor :address
 
-  devise :database_authenticatable,
-    :recoverable,
-    :rememberable,
-    :validatable,
-    :confirmable,
-    :zxcvbnable
+  devise :magic_link_authenticatable, :confirmable, :validatable
 
   has_many :matches, dependent: :nullify
 
@@ -21,7 +16,6 @@ class User < ApplicationRecord
 
   blind_index :email
 
-  validates :password, presence: true, on: :create
   validates :lat, presence: true, unless: proc { |u| u.persisted? }
   validates :lon, presence: true, unless: proc { |u| u.persisted? }
   validates :birthdate, presence: true

--- a/app/views/devise/mailer/magic_link.html.erb
+++ b/app/views/devise/mailer/magic_link.html.erb
@@ -4,7 +4,7 @@
 
 <p>Vous pouvez vous connecter en utilisant le lien ci-dessous:</p>
 
-<p><%= link_to "Me connecter à mon compte", send("#{@scope_name.to_s.pluralize}_magic_link_url", Hash[@scope_name, {email: @resource.email, token: @token, remember_me: @remember_me}]) %></p>
+<p><%= link_to "Me connecter à mon compte", send("#{@scope_name.to_s.pluralize}_magic_link_url", Hash[@scope_name, {email: @resource.email, token: @token}]) %></p>
 
 <p>Ce lien est valable <%= Devise.passwordless_login_within.inspect %>.</p>
 

--- a/app/views/devise/mailer/magic_link.html.erb
+++ b/app/views/devise/mailer/magic_link.html.erb
@@ -1,0 +1,11 @@
+<p>
+  Bonjour <%= @resource %>,
+</p>
+
+<p>Vous pouvez vous connecter en utilisant le lien ci-dessous:</p>
+
+<p><%= link_to "Me connecter à mon compte", send("#{@scope_name.to_s.pluralize}_magic_link_url", Hash[@scope_name, {email: @resource.email, token: @token, remember_me: @remember_me}]) %></p>
+
+<p>Ce lien est valable <%= Devise.passwordless_login_within.inspect %>.</p>
+
+<%= render "mailer/footer" %>

--- a/app/views/devise/mailer/magic_link.html.erb
+++ b/app/views/devise/mailer/magic_link.html.erb
@@ -1,5 +1,5 @@
 <p>
-  Bonjour <%= @resource %>,
+  Bonjour,
 </p>
 
 <p>Vous pouvez vous connecter en utilisant le lien ci-dessous:</p>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -15,13 +15,6 @@
                 id: 'inputEmail',
                 placeholder: 'E-mail' %>
 
-          <% if devise_mapping.rememberable? %>
-            <p>
-              <%= f.check_box :remember_me %>
-              <%= f.label :remember_me %>
-            </p>
-          <% end %>
-
           <%= f.submit "Recevoir un lien de connexion", class: "btn btn-primary", id: :sign_in %>
 
           <% if devise_mapping.confirmable? && controller_name != "confirmations" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -22,7 +22,7 @@
             </p>
           <% end %>
 
-          <%= f.submit "Recevoir un lien de connexion", class: "btn btn-primary" %>
+          <%= f.submit "Recevoir un lien de connexion", class: "btn btn-primary", id: :sign_in %>
 
           <% if devise_mapping.confirmable? && controller_name != "confirmations" %>
             <p class="mt-3">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -24,8 +24,8 @@
 
           <%= f.submit "Recevoir un lien de connexion", class: "btn btn-primary" %>
 
-          <% if devise_mapping.confirmable? && controller_name != "confirmations" && !resource.is_a?(User) %>
-            <p>
+          <% if devise_mapping.confirmable? && controller_name != "confirmations" %>
+            <p class="mt-3">
               <%= link_to "Redemander l’email de confirmation", new_confirmation_path(resource_name) %>
             </p>
           <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -8,8 +8,12 @@
         </p>
 
         <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-          <%= f.input :email, autocomplete: 'off', autofocus: true, required: true, id: 'inputEmail', placeholder: 'E-mail' %>
-          <%= f.input :password, autocomplete: 'off', required: true, id: 'inputPassword', placeholder: 'Mot de passe' %>
+          <%= f.input :email,
+                autocomplete: 'off',
+                autofocus: true,
+                required: true,
+                id: 'inputEmail',
+                placeholder: 'E-mail' %>
 
           <% if devise_mapping.rememberable? %>
             <p>
@@ -18,22 +22,16 @@
             </p>
           <% end %>
 
-          <%= f.submit "Connexion", class: "btn btn-primary" %>
+          <%= f.submit "Recevoir un lien de connexion", class: "btn btn-primary" %>
 
-          <% if devise_mapping.recoverable? && controller_name != "passwords" && controller_name != "registrations"  %>
-            <p class="mt-3">
-              <%= link_to "Création du mot de passe / Mot de passe oublié ?", new_password_path(resource_name) %>
-            </p>
-          <% end %>
-
-          <% if devise_mapping.confirmable? && controller_name != "confirmations"  %>
+          <% if devise_mapping.confirmable? && controller_name != "confirmations" && !resource.is_a?(User) %>
             <p>
               <%= link_to "Redemander l’email de confirmation", new_confirmation_path(resource_name) %>
             </p>
           <% end %>
 
           <% if controller_name == "sessions"  %>
-            <p>
+            <p class="mt-3">
               <%= link_to "S’inscrire en tant que volontaire", users_path %>
             </p>
           <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -26,7 +26,7 @@
                   start_year: Date.today.year - 120,
                   end_year: Date.today.year - 18,
                   order: [:day, :month, :year] %>
-      
+
       <p class="text-primary small">
         Vérifiez bien votre date de naissance. En cas d'erreur, la vaccination ne sera pas possible !
       </p>
@@ -51,29 +51,6 @@
                   hint: "Une adresse email ne peut être utilisée que par une seule personne. 2 personnes = 2 adresses email différentes.",
                   required: true,
                   input_html: { autocomplete: "email" } %>
-
-      <div class="form-group" data-controller="password">
-        <label for="user_password"> Mot de passe </label>
-
-        <div class="input-group" data-behavior="toggle-password-visibility">
-          <%= f.input_field :password,
-                            type: :password,
-                            class: "form-control",
-                            required: true,
-                            input_html: { autocomplete: "new-password" },
-                            data: {password_target: 'password', action: 'input->password#check'} %>
-
-          <div class="input-group-append">
-            <span class="input-group-text"> <%= link_to icon("fas", "eye") %> </span>
-          </div>
-        </div>
-
-        <small class="form-text text-muted"> 
-          <%= "#{User::PASSWORD_HINT}" %>
-          <br/>
-          <%= content_tag :span, "", data: { password_target: "passwordCheck" }, class: "d-inline-block" %>
-        </small>
-      </div>
 
       <%= render partial: "input_statement", locals: {f: f, local_cgu_path: cgu_volontaires_path} %>
       <%= render partial: "input_toc", locals: {f: f}%>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -310,4 +310,24 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+
+  # ==> Configuration for :magic_link_authenticatable
+
+  # Need to use a custom Devise mailer in order to send magic links
+  require "devise/passwordless/mailer"
+  config.mailer = "Devise::Passwordless::Mailer"
+
+  # Time period after a magic login link is sent out that it will be valid for.
+  config.passwordless_login_within = 20.minutes
+
+  # The secret key used to generate passwordless login tokens. The default value
+  # is nil, which means defer to Devise's `secret_key` config value. Changing this
+  # key will render invalid all existing passwordless login tokens. You can
+  # generate your own secret value with e.g. `rake secret`
+  # config.passwordless_secret_key = nil
+
+  # When using the :trackable module, set to true to consider magic link tokens
+  # generated before the user's current sign in time to be expired. In other words,
+  # each time you sign in, all existing magic links will be considered invalid.
+  # config.passwordless_expire_old_tokens_on_sign_in = false
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,5 +1,4 @@
-# Additional translations at https://github.com/heartcombo/devise/wiki/I18n
-
+---
 en:
   devise:
     confirmations:
@@ -16,6 +15,7 @@ en:
       timeout: "Your session expired. Please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
+      magic_link_invalid: "Invalid or expired login link."
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"
@@ -27,6 +27,8 @@ en:
         subject: "Email Changed"
       password_change:
         subject: "Password Changed"
+      magic_link:
+        subject: "Here's your magic login link ✨"
     omniauth_callbacks:
       failure: 'Could not authenticate you from %{kind} because "%{reason}".'
       success: "Successfully authenticated from %{kind} account."
@@ -53,6 +55,9 @@ en:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
       send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
       unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+    passwordless:
+      not_found_in_database: "Could not find a user for that email address"
+      magic_link_sent: "A login link has been sent to your email address. Please follow the link to log in to your account."
   errors:
     messages:
       already_confirmed: "was already confirmed, please try signing in"

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -102,7 +102,7 @@ fr:
         message: Votre compte a été bloqué suite à un nombre d'essais de connexions manquées trop important.
         subject: Instructions pour déverrouiller le compte
       magic_link:
-        user_subject: Voici votre lien de connexion magique USER ✨
+        user_subject: Voici votre lien de connexion magique à Covidliste ✨
     omniauth_callbacks:
       failure: "Nous ne pouvons pas vous authentifier depuis %{kind} pour la raison suivante : '%{reason}'."
       success: Autorisé par votre compte %{kind}.

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -18,7 +18,6 @@ fr:
         password: Mot de passe
         password_confirmation: Confirmation du mot de passe
         remember_created_at: Mémorisé à
-        remember_me: Se souvenir de moi
         reset_password_sent_at: Clé de réinitialisation créée à
         reset_password_token: Clé de réinitialisation du mot de passe
         sign_in_count: Nombre des connexions

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -167,7 +167,7 @@ fr:
     passwordless:
       user:
         not_found_in_database: Impossible de trouver un utilisateur pour cette adresse e-mail
-        magic_link_sent: Un lien de connexion a été envoyé à votre adresse e-mail. Veuillez suivre le lien pour vous connecter à votre compte.
+        magic_link_sent: Si vous êtes inscrit, un lien de connexion a été envoyé à %{email}. Veuillez suivre le lien pour vous connecter à votre compte.
   errors:
     messages:
       already_confirmed: a déjà été confirmé(e)

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -70,6 +70,9 @@ fr:
       timeout: Votre session est expirée, veuillez vous reconnecter pour continuer.
       unauthenticated: Vous devez vous connecter ou vous enregistrer pour continuer.
       unconfirmed: Vous devez confirmer votre compte par email.
+      user:
+        magic_link_invalid: Lien de connexion invalide ou expiré.
+        already_authenticated: Vous êtes déjà connecté(e).
     mailer:
       confirmation_instructions:
         action: Confirmer mon email
@@ -98,6 +101,8 @@ fr:
         instruction: "Suivez ce lien pour débloquer votre compte :"
         message: Votre compte a été bloqué suite à un nombre d'essais de connexions manquées trop important.
         subject: Instructions pour déverrouiller le compte
+      magic_link:
+        user_subject: Voici votre lien de connexion magique USER ✨
     omniauth_callbacks:
       failure: "Nous ne pouvons pas vous authentifier depuis %{kind} pour la raison suivante : '%{reason}'."
       success: Autorisé par votre compte %{kind}.
@@ -159,6 +164,10 @@ fr:
       send_instructions: Vous allez recevoir sous quelques minutes un email comportant des instructions pour déverrouiller votre compte.
       send_paranoid_instructions: Si votre email existe sur notre base de données, vous recevrez sous quelques minutes un message avec des instructions pour déverrouiller votre compte.
       unlocked: Votre compte a bien été déverrouillé. Veuillez vous connecter.
+    passwordless:
+      user:
+        not_found_in_database: Impossible de trouver un utilisateur pour cette adresse e-mail
+        magic_link_sent: Un lien de connexion a été envoyé à votre adresse e-mail. Veuillez suivre le lien pour vous connecter à votre compte.
   errors:
     messages:
       already_confirmed: a déjà été confirmé(e)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,16 +42,16 @@ Rails.application.routes.draw do
   ## devise users
   devise_for :users,
     path_names: {sign_in: "login", sign_out: "logout"},
-    skip: %i[sessions registrations],
+    path: "",
+    skip: %i[registrations],
     controllers: {
+      sessions: "devise/passwordless/sessions",
       confirmations: "confirmations"
     }
 
   # TODO FIXME Legacy hardcoced login/logout routes, we should use the routes from devise instead
   devise_scope :user do
-    get "login", to: "devise/sessions#new", as: :new_user_session
-    post "login", to: "devise/sessions#create", as: :user_session
-    delete "logout", to: "devise/sessions#destroy", as: :destroy_user_session
+    get "/users/magic_link", to: "devise/passwordless/magic_links#show", as: "users_magic_link"
   end
 
   ## devise partners

--- a/db/frozen_records/faq_items.yml
+++ b/db/frozen_records/faq_items.yml
@@ -8,9 +8,7 @@
     Vérifiez que le mail n’est pas présent dans vos courriers indésirables, ou boîte _SPAM_.
 
     S’il n’est pas présent, vous pouvez faire une nouvelle demande
-    <%= link_to "d’email de confirmation", new_user_confirmation_path %>
-    ou de
-    <%= link_to "changement de mot de passe", new_user_password_path %>.
+    <%= link_to "d’email de confirmation", new_user_confirmation_path %>.
 
     Attendez quelques minutes, vérifiez vos courriers indésirables ou boîte _SPAM_.
 

--- a/db/frozen_records/faq_items.yml
+++ b/db/frozen_records/faq_items.yml
@@ -166,6 +166,13 @@
     Afin de vous désinscrire, connectez-vous sur votre
     <%= link_to "espace personnel", :new_user_session %>
     puis cliquez sur « Supprimer mon compte ».
+- title: Pourquoi ne puis-je plus me connecter avec le mot de passe choisi, en tant que volontaire non-vacciné ?
+  category: Fonctionnement
+  body_md_erb: |
+    Toujours sensible à améliorer le niveau de sécurité de notre application, nous avons fait le choix de basculer la connexion des volontaires non-vaccinés sur un mode de connexion dit « PasswordLess ».
+    Ce mode se base sur l’envoi d’un e-mail sécurisé sur votre adresse personnelle. Cet e-mail contient un lien avec un code unique infalsifiable qui vous permettra, en le suivant, de vous connecter à l’application.
+
+    Ce mode nous permet de déléguer la sécurité de votre connexion au fournisseur de mails dans lequel vous avez déjà placé votre confiance.
 
 ###########
 # VACCINS #

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -7,7 +7,6 @@ FactoryBot.define do
     email { generate(:unique_email) }
     firstname { generate(:firstname) }
     lastname { generate(:lastname) }
-    password { generate(:password) }
     phone_number { "0606060606" }
 
     confirmed_at { Time.zone.now }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -136,21 +136,4 @@ RSpec.describe User, type: :model do
       expect(user.age).to eq(20)
     end
   end
-
-  describe "password" do
-    it "is invalid if length below 8" do
-      user.password = "1234"
-      expect(user).to_not be_valid
-    end
-
-    it "is too weak" do
-      user.password = "123456789"
-      expect(user).to_not be_valid
-    end
-
-    it "is valid" do
-      user.password = "snipe.HACKSAW.fish"
-      expect(user).to be_valid
-    end
-  end
 end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -8,7 +8,6 @@ def fill_valid_user
   fill_in :user_address, with: generate(:french_address)
   fill_in :user_phone_number, with: generate(:french_phone_number)
   fill_in :user_email, with: "hello+#{(rand * 10000).to_i}@covidliste.com" # needs valid email here
-  fill_in :user_password, with: robust_password
   check :user_statement
   check :user_toc
 end
@@ -97,10 +96,8 @@ RSpec.describe "Users", type: :system do
     before do
       user.save!
 
-      visit "/login"
-      fill_in :user_email, with: user.email
-      fill_in :user_password, with: user.password
-      click_on "Connexion"
+      token = Devise::Passwordless::LoginToken.encode(user)
+      visit users_magic_link_url(Hash["user", {email: user.email, token: token}])
 
       expect(page).to have_text("Connecté(e).")
       expect(page).to have_text("Vos informations")


### PR DESCRIPTION
close #512 

Voici une première version du signup/in Passwordless. Cette PR utilise la Gem https://github.com/abevoelker/devise-passwordless.
Le password less est utilisé uniquement pour les volontaires. Il me semble avoir compris que pour les partenaires on garde de l'email/password classique (à confirmer).
Cela supprime pas mal de stratégie de Devise, je vous laisse regarder qu'on est bien ok sur toutes ces suppressions

### Todo

- [x] Mettre à jour les tests
- [x] Go/NoGo pour les partenaires ?
- [x] On garde le remember me?
- [x] Vérifier que l'on a bien Rack attack sur le login
- [x] Ne pas retourner de message indiquant que l'email n'est pas dans la base

# Screen captures

## Sign up

![Capture d’écran 2021-04-23 à 8 37 16 AM](https://user-images.githubusercontent.com/7847244/115829317-2492d780-a40f-11eb-9f3d-b69651e48e7a.jpg)

## Ecran confirmation

![Capture d’écran 2021-04-23 à 8 36 53 AM](https://user-images.githubusercontent.com/7847244/115829462-5441df80-a40f-11eb-9f18-62da2e90ef7c.jpg)


## Email confirmation

![Capture d’écran 2021-04-23 à 8 38 11 AM](https://user-images.githubusercontent.com/7847244/115829400-3eccb580-a40f-11eb-8591-1f5d44c85701.jpg)

## login après confirmation

![Capture d’écran 2021-04-23 à 8 40 01 AM](https://user-images.githubusercontent.com/7847244/115829628-7fc4ca00-a40f-11eb-9a3f-227201c28239.jpg)


## Page sign in 

relates to #541 
![Capture d’écran 2021-04-23 à 8 40 33 AM](https://user-images.githubusercontent.com/7847244/115829750-a08d1f80-a40f-11eb-94eb-c68806dbf323.jpg)

## Email login

![Capture d’écran 2021-04-23 à 8 41 58 AM](https://user-images.githubusercontent.com/7847244/115829864-c6b2bf80-a40f-11eb-9f39-53eddd950a9f.jpg)

