### PR TITLE
Rewording matches + Bugfix URL emails

### DIFF
--- a/app/jobs/send_match_sms_job.rb
+++ b/app/jobs/send_match_sms_job.rb
@@ -14,7 +14,7 @@ class SendMatchSmsJob < ApplicationJob
     client.messages.create(
       from: "COVIDLISTE",
       to: match.user.phone_number,
-      body: "Bonne nouvelle ! Un vaccin #{match.campaign_batch.campaign.vaccine_type} est disponible. Réservez-le avant #{match.expires_at.strftime("%Hh%M")} en cliquant ici : #{cta_url(match)}"
+      body: "Un vaccin est disponible près de chez vous. Pour le réserver, suivez les instructions avant #{match.expires_at.strftime("%Hh%M")} : #{cta_url(match)}"
     )
     match.update(sms_sent_at: Time.now.utc)
   end

--- a/app/views/match_mailer/match_confirmation_instructions.html.erb
+++ b/app/views/match_mailer/match_confirmation_instructions.html.erb
@@ -6,7 +6,7 @@
   <p>
     Un vaccin est disponible près de chez vous. <br>
     Pour le réserver, suivez les instructions avant <%= @match.expires_at.strftime("%Hh%M") %> en cliquant sur ce lien :
-    <%= link_to "Vaccin disponible", match_url(@match, match_confirmation_token: @match_confirmation_token, source: 'email') %>
+    <%= link_to "Vaccin disponible", match_url(match_confirmation_token: @match_confirmation_token, source: 'email') %>
   </p>
   <p>
     Si vous ne le réservez pas avant <%= @match.expires_at.strftime("%Hh%M") %>,
@@ -16,7 +16,7 @@
   </p>
   <p>
     Si le lien ne fonctionne pas, copiez et collez l’adresse suivante dans votre navigateur : <br>
-    <%= match_url(@match, match_confirmation_token: @match_confirmation_token, source: 'email') %>
+    <%= match_url(match_confirmation_token: @match_confirmation_token, source: 'email') %>
   </p>
 
   <%= render "mailer/footer" %>

--- a/app/views/match_mailer/match_confirmation_instructions.html.erb
+++ b/app/views/match_mailer/match_confirmation_instructions.html.erb
@@ -1,13 +1,21 @@
 <div>
   <h2>
-    Bonne nouvelle <%= @match.user %> !
+    Vaccin disponible près de chez vous.
   </h2>
 
   <p>
-    Un vaccin <%= @match.campaign.vaccine_type  %> est disponible. Réservez-le avant <%= @match.expires_at.strftime("%Hh%M") %> en cliquant sur le lien suivant :
-    <%= link_to "Je réserve mon vaccin", match_url(@match, match_confirmation_token: @match_confirmation_token) %>
-    <br>
-    Si le lien ne fonctionne pas, copiez et collez l’adresse suivante dans votre navigateur :
+    Un vaccin est disponible près de chez vous. <br>
+    Pour le réserver, suivez les instructions avant <%= @match.expires_at.strftime("%Hh%M") %> en cliquant sur ce lien :
+    <%= link_to "Vaccin disponible", match_url(@match, match_confirmation_token: @match_confirmation_token, source: 'email') %>
+  </p>
+  <p>
+    Si vous ne le réservez pas avant <%= @match.expires_at.strftime("%Hh%M") %>,
+    <strong>le vaccin sera attribué à un autre
+      volontaire.</strong><br>
+    Dans ce cas, nous vous recontacterons dès qu'un vaccin sera à nouveau disponible.
+  </p>
+  <p>
+    Si le lien ne fonctionne pas, copiez et collez l’adresse suivante dans votre navigateur : <br>
     <%= match_url(@match, match_confirmation_token: @match_confirmation_token, source: 'email') %>
   </p>
 

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -10,8 +10,9 @@
     <strong> Créneau horaire </strong>
     <% starts_at = match.campaign.starts_at %>
     <% ends_at = match.campaign.ends_at %>
-    <p> 
-      <%= l(starts_at, format: '%A %e %B %Y') %> entre <%= l(starts_at, format: '%Hh%M') %> et <%= l(ends_at, format: '%Hh%M') %>
+    <p>
+      <%= l(starts_at, format: '%A %e %B %Y').capitalize %> entre <%= l(starts_at, format: '%Hh%M') %>
+      et <%= l(ends_at, format: '%Hh%M') %>
     </p>
   </div>
 
@@ -22,16 +23,16 @@
       <i class="fas fa-minus-circle"></i>
       <p>L’utilisateur a supprimé son compte.</p>
     </div>
-  <%# elsif user.anonymized_at #TODO PR #197 %>
+    <%# elsif user.anonymized_at #TODO PR #197 %>
   <% else %>
     <div>
       <i class="fas fa-user-lock"></i>
+      <strong> Informations personnelles </strong>
       <p>
-        Réservé pour <strong><%= user %></strong><br>
-        Né le <strong><%= user.birthdate.strftime('%d/%m/%Y') %></strong><br>
-        Réservation strictement nominative. <br>
-        <strong>Date de naissance et nom seront vérifiés</strong> (pensez à vous munir d'une pièce d'identité)<br>
-        <em>N'oubliez pas votre carte Vitale (ou votre attestation de droits).</em>
+        Date de naissance : <strong><%= user.birthdate.strftime('%d/%m/%Y') %></strong><br>
+        <strong>Date de naissance et nom seront vérifiés.</strong> <br>
+        Munissez-vous d'une pièce d'identité et de votre
+        carte vitale.<br>
       </p>
     </div>
   <% end %>

--- a/app/views/matches/_pending.html.erb
+++ b/app/views/matches/_pending.html.erb
@@ -1,18 +1,23 @@
-<h2>Une dose de vaccin vous attend !</h2>
-<h2>Confirmez votre disponibilité. </h2>
+<h2>Une dose de vaccin est disponible ! Réservez-la dès maintenant. </h2>
 
 <p class="mt-4">
-  Bonne nouvelle ! Une dose est disponible près de chez vous.
-  <strong> Vous avez <%= time_ago_in_words(@match.expires_at, include_seconds: true) %> pour confirmer votre venue au centre de vaccination au créneau horaire proposé </strong>.
-  Passé ce délai, la dose sera attribuée à un autre de volontaire.
+  Bonne nouvelle ! Une dose est disponible près de chez vous. <br>
+  <strong>
+    Une confirmation de votre part dans un délai de <%= time_ago_in_words(@match.expires_at, include_seconds: true) %>
+    est indispensable pour réserver votre dose. <br>
+  </strong>
+  Passé ce délai, la dose sera attribuée à un autre volontaire.
 </p>
 
 <%= render 'match_details', match: @match %>
 <% user = match.user %>
 
-<div class="alert alert-primary" role="alert">
-  Merci de confirmer votre présence <strong>uniquement</strong> si vous pouvez vous rendre au centre de vaccination à
-  l'horaire communiqué.
+<div class="alert alert-danger" role="alert">
+  Ne réservez votre dose que si vous pouvez vous rendre au centre de vaccination
+  entre <%= l(match.campaign.starts_at, format: '%Hh%M') %>
+  et <%= l(match.campaign.ends_at, format: '%Hh%M') %> aujourd'hui. <br>
+  <strong>Si vous ne réservez pas votre dose, elle sera attribuée à un autre volontaire et vous ne pourrez vous faire
+    vacciner.</strong>
 </div>
 
 <form action="<%= match_path(match_confirmation_token: @match.match_confirmation_token) %>" method="POST" class="needs-validation row" novalidate>
@@ -55,7 +60,8 @@
     <div class="form-check flex-wrap">
       <input class="form-check-input" type="checkbox" value="" id="confirm_age" required>
       <label class="form-check-label w-75" for="confirm_age">
-        Je confirme avoir une pièce d'identité portant la date de naissance <strong><%= user.birthdate.strftime("%d/%m/%Y") %></strong>
+        Je confirme avoir une pièce d'identité portant la date de naissance
+        <strong><%= user.birthdate.strftime("%d/%m/%Y") %></strong>
       </label>
       <div class="invalid-feedback w-100">
         Vous devez confirmer votre date de naissance. <br>
@@ -70,39 +76,36 @@
       </small>
     </p>
   </div>
-  <div class="col-12 mb-2">
-    <div class="row">
-      <div class="col">
-        <button class="btn btn-primary mr-5" type="submit">Je suis disponible</button>
-        <%= link_to 'Refuser le RDV', match_path(match_confirmation_token: @match.match_confirmation_token), method: :delete, class: 'btn btn-danger ml-5', "data-confirm": "Souhaitez-vous vraiment refuser ce RDV ?" %>
-      </div>
-    </div>
+  <div class="col-12 d-flex flex-wrap">
+    <button class="btn btn-primary mr-2 btn-lg mb-3" type="submit">Je réserve la dose</button>
+    <%= link_to 'Refuser le RDV', match_path(match_confirmation_token: @match.match_confirmation_token), method: :delete, class: 'btn btn-danger btn-lg mb-3', "data-confirm": "Souhaitez-vous vraiment refuser ce RDV ?" %>
   </div>
 </form>
 
 
 <p>
   <small>
-    Une fois votre présence confirmée, vos coordonnées sont transmises au centre de vaccination. Votre compte et vos informations seront alors définitivement supprimés de Covidliste sous 
+    Une fois votre présence confirmée, vos coordonnées sont transmises au centre de vaccination. Votre compte et vos
+    informations seront alors définitivement supprimés de Covidliste sous
     <%= AnonymizeConfirmedMatchedUsersJob::DELAY_AFTER_MATCH_CONFIRMATION.parts.map { |unit, n| I18n.t unit, count: n, scope: 'duration' }.to_sentence %>
     , et vous ne recevrez plus de notifications.
   </small>
 </p>
 
 <script>
-// Script from https://getbootstrap.com/docs/5.0/forms/validation/
-(function () {
-  var forms = document.querySelectorAll('.needs-validation')
-  Array.prototype.slice.call(forms)
-    .forEach(function (form) {
-      form.addEventListener('submit', function (event) {
-        if (!form.checkValidity()) {
-          event.preventDefault()
-          event.stopPropagation()
-        }
+    // Script from https://getbootstrap.com/docs/5.0/forms/validation/
+    (function () {
+        var forms = document.querySelectorAll('.needs-validation')
+        Array.prototype.slice.call(forms)
+            .forEach(function (form) {
+                form.addEventListener('submit', function (event) {
+                    if (!form.checkValidity()) {
+                        event.preventDefault()
+                        event.stopPropagation()
+                    }
 
-        form.classList.add('was-validated')
-      }, false)
-    })
-})()
+                    form.classList.add('was-validated')
+                }, false)
+            })
+    })()
 </script>

--- a/app/views/matches/_pending.html.erb
+++ b/app/views/matches/_pending.html.erb
@@ -16,7 +16,8 @@
   Ne réservez votre dose que si vous pouvez vous rendre au centre de vaccination
   entre <%= l(match.campaign.starts_at, format: '%Hh%M') %>
   et <%= l(match.campaign.ends_at, format: '%Hh%M') %> aujourd'hui. <br>
-  <strong>Si vous ne réservez pas votre dose, elle sera attribuée à un autre volontaire et vous ne pourrez vous faire
+  <strong>Si vous ne réservez pas votre dose, elle sera attribuée à un autre volontaire et vous ne pourrez pas vous
+    faire
     vacciner.</strong>
 </div>
 

--- a/spec/system/matches_controller_spec.rb
+++ b/spec/system/matches_controller_spec.rb
@@ -17,24 +17,24 @@ RSpec.describe MatchesController, type: :system do
       it "it says une dose dispo" do
         subject
         expect(page).to have_text("Une dose est disponible")
-        expect(page).to have_text("Je suis disponible")
+        expect(page).to have_text("Je réserve la dose")
         expect(page).to have_text(center.address)
         expect(page).to have_field("firstname", with: user.firstname)
         expect(page).to have_field("lastname", with: user.lastname)
 
         fill_in :firstname, with: user.firstname
         fill_in :lastname, with: ""
-        click_on("Je suis disponible")
+        click_on("Je réserve la dose")
         expect(page).to have_text("Vous devez renseigner votre identité")
 
         fill_in :firstname, with: ""
         fill_in :lastname, with: user.lastname
-        click_on("Je suis disponible")
+        click_on("Je réserve la dose")
         expect(page).to have_text("Vous devez renseigner votre identité")
 
         fill_in :firstname, with: user.firstname
         fill_in :lastname, with: user.lastname
-        click_on("Je suis disponible")
+        click_on("Je réserve la dose")
         expect(page).not_to have_text("Vous devez renseigner votre identité")
         expect(page).to have_text("Votre disponibilité est confirmée")
         expect(page).to have_text(center.address)
@@ -87,7 +87,7 @@ RSpec.describe MatchesController, type: :system do
         expect(page).to have_text("Pour qu'aucune dose ne soit perdue, nous contactons quand c'est possible plusieurs volontaires.")
         expect(page).to have_text("Dans de rares cas, il arrive que toutes les doses soient prises.")
         expect(page).not_to have_text("Une dose est disponible")
-        expect(page).not_to have_text("Je suis disponible")
+        expect(page).not_to have_text("Je réserve la dose")
       end
     end
 
@@ -108,7 +108,7 @@ RSpec.describe MatchesController, type: :system do
 
         fill_in :firstname, with: generate(:firstname)
         fill_in :lastname, with: generate(:lastname)
-        click_on("Je suis disponible")
+        click_on("Je réserve la dose")
         expect(page).to have_text("La dose n'est plus disponible 😢")
       end
     end


### PR DESCRIPTION
### Objectif : Dissuader les volontaires de venir sans avoir confirmé

Discuté sur slack [ici](https://covidliste.slack.com/archives/C01T5RYDRAS/p1619186813328700)

Changements :
* Rewording SMS
* Rewording email
* Moins d'informations sur la page de match, style plus direct
* Plus gros boutons

**Inclus : ⚠️ Fix de deux bugs dans les liens de confirmation des emails**
* L'id du match était append dans l'url, ce qui donnait `/m/TOKEN/SOURCE.ID` ou `/m/TOKEN/ID`
* Une des deux url ne trackait pas les clicks.
* L'url était néanmoins fonctionelle à priori

|Before|After|
|-|-|
|"Bonne nouvelle ! Un vaccin astrazeneca est disponible. Réservez-le avant 12h34 en cliquant ici : URL"|"Un vaccin est disponible près de chez vous. Pour le réserver, suivez les instructions avant 12h34 : URL"|
|![Screenshot 2021-04-24 at 00-39-15 Covidliste - Sauvons nos doses de vaccin 💉](https://user-images.githubusercontent.com/5511564/115936438-87c74d00-a495-11eb-841a-1a1e93e6be0d.png)|![image](https://user-images.githubusercontent.com/5511564/115936543-d379f680-a495-11eb-9d2c-a89382946313.png)|
|![image](https://user-images.githubusercontent.com/5511564/115937718-ca3e5900-a498-11eb-9d24-3b7cda588c12.png)|![image](https://user-images.githubusercontent.com/5511564/115937548-864b5400-a498-11eb-86ea-2073ea3e0337.png)|