### PR TITLE
Rajouter le lien magique en plain text également en dessous du lien hypertexte

### DIFF
--- a/app/views/devise/mailer/magic_link.html.erb
+++ b/app/views/devise/mailer/magic_link.html.erb
@@ -1,11 +1,17 @@
+<%- magic_link_url = send("#{@scope_name.to_s.pluralize}_magic_link_url", Hash[@scope_name, {email: @resource.email, token: @token}]) %>
+
 <p>
   Bonjour,
+  <br>
+  <br>
+  Vous pouvez vous connecter en utilisant le lien ci-dessous, il est valable uniquement <%= Devise.passwordless_login_within.inspect %> :
+  <br>
+  <%= link_to "Me connecter à mon compte", magic_link_url %>
+  <br>
+  <br>
+  Si le lien ne fonctionne pas, copiez et collez l’adresse suivante dans votre navigateur :
+  <br>
+  <%= magic_link_url %>
 </p>
-
-<p>Vous pouvez vous connecter en utilisant le lien ci-dessous:</p>
-
-<p><%= link_to "Me connecter à mon compte", send("#{@scope_name.to_s.pluralize}_magic_link_url", Hash[@scope_name, {email: @resource.email, token: @token}]) %></p>
-
-<p>Ce lien est valable <%= Devise.passwordless_login_within.inspect %>.</p>
 
 <%= render "mailer/footer" %>


### PR DESCRIPTION
Certaines DSI d'entreprise retire ou filtre les liens qui sont en format hypertexte de leur email.
Cette PR vient rajouter le lien en plain text à la suite, au cas où.