### PR TITLE
Gestion d'une limite de SMS envoyé par campagne pour limiter les coûts

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -57,7 +57,7 @@ class Campaign < ApplicationRecord
 
   def min_age_lesser_than_max_age
     if (min_age || 0) >= (max_age || 0)
-      errors.add(:max_age, "doit être supérieur à l’âge minimum")
+      errors.add(:max_age, "doit être supérieur à lâge minimum")
     end
   end
 
@@ -69,7 +69,7 @@ class Campaign < ApplicationRecord
 
   def sms_sent_count_lesser_or_equal_than_sms_max_count
     if sms_sent_count > sms_max_count
-      errors.add(:base, "a atteint son doit être postérieur à la date de début")
+      errors.add(:base, "La limite maximale d’envoi de SMS a été atteinte")
     end
   end
 

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -12,7 +12,7 @@ class Campaign < ApplicationRecord
   enum status: {running: 0, completed: 1, canceled: 2}
 
   validates :available_doses, numericality: {greater_than: 0, less_than_or_equal_to: MAX_DOSES}
-  validates :sms_sent_count, :sms_max_count, numericality: {greater_than_or_equal_to: 0}
+  validates :sms_sent_count, :sms_max_count, numericality: {greater_than_or_equal_to: 0, only_integer: true}
   validates :vaccine_type, presence: true
   validates :min_age, numericality: {greater_than: 17}
   validates :max_age, numericality: {greater_than: 17}
@@ -69,7 +69,7 @@ class Campaign < ApplicationRecord
 
   def sms_sent_count_lesser_or_equal_than_sms_max_count
     if sms_sent_count > sms_max_count
-      errors.add(:base, "La limite maximale d’envoi de SMS a été atteinte")
+      errors.add(:base, "a atteint le nombre maximal de SMS autorisé")
     end
   end
 

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -1,6 +1,7 @@
 class Campaign < ApplicationRecord
   MAX_DOSES = 200
   MAX_DISTANCE_IN_KM = 50
+  AVG_SMS_COUNT_COST_PER_DOSE = 100
 
   belongs_to :vaccination_center
   belongs_to :partner
@@ -11,12 +12,16 @@ class Campaign < ApplicationRecord
   enum status: {running: 0, completed: 1, canceled: 2}
 
   validates :available_doses, numericality: {greater_than: 0, less_than_or_equal_to: MAX_DOSES}
+  validates :sms_sent_count, :sms_max_count, numericality: {greater_than_or_equal_to: 0}
   validates :vaccine_type, presence: true
   validates :min_age, numericality: {greater_than: 17}
   validates :max_age, numericality: {greater_than: 17}
   validates :max_distance_in_meters, numericality: {greater_than: 0, less_than_or_equal_to: MAX_DISTANCE_IN_KM * 1000}
   validate :min_age_lesser_than_max_age
   validate :starts_at_lesser_than_ends_at
+  validate :sms_sent_count_lesser_or_equal_than_sms_max_count
+
+  before_validation :compute_derived_calculations
 
   def canceled!
     update_attribute(:canceled_at, Time.now.utc)
@@ -25,6 +30,10 @@ class Campaign < ApplicationRecord
 
   def remaining_slots
     available_doses - matches.confirmed.size
+  end
+
+  def sms_exhausted?
+    sms_sent_count >= sms_max_count
   end
 
   def to_csv
@@ -56,5 +65,20 @@ class Campaign < ApplicationRecord
     if starts_at >= ends_at
       errors.add(:ends_at, "doit être postérieur à la date de début")
     end
+  end
+
+  def sms_sent_count_lesser_or_equal_than_sms_max_count
+    if sms_sent_count > sms_max_count
+      errors.add(:base, "a atteint son doit être postérieur à la date de début")
+    end
+  end
+
+  def compute_sms_max_count
+    return if sms_max_count.to_i > 0
+    self.sms_max_count = (available_doses * Vaccine.average_sms_count_cost_per_dose(vaccine_type)).floor if available_doses
+  end
+
+  def compute_derived_calculations
+    compute_sms_max_count
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -59,6 +59,10 @@ class Match < ApplicationRecord
     save!
   end
 
+  def sms_sent!
+    Campaign.increment_counter(:sms_sent_count, 1) if update(sms_sent_at: Time.now.utc)
+  end
+
   def confirmable?
     !confirmed? && campaign.remaining_slots > 0 && !refused?
   end

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -25,4 +25,13 @@ class Vaccine < ApplicationRecord
       2
     end
   end
+
+  def self.average_sms_count_cost_per_dose(vaccine)
+    case vaccine
+    when Brands::ASTRAZENECA
+      100
+    else
+      90
+    end
+  end
 end

--- a/app/models/vaccine.rb
+++ b/app/models/vaccine.rb
@@ -10,7 +10,7 @@ class Vaccine < ApplicationRecord
 
   def self.minimum_reach_to_dose_ratio(vaccine)
     case vaccine
-    when Brands::ASTRAZENECA
+    when Vaccine::Brands::ASTRAZENECA
       20
     else
       5
@@ -19,7 +19,7 @@ class Vaccine < ApplicationRecord
 
   def self.overbooking_factor(vaccine)
     case vaccine
-    when Brands::ASTRAZENECA
+    when Vaccine::Brands::ASTRAZENECA
       3
     else
       2
@@ -28,7 +28,7 @@ class Vaccine < ApplicationRecord
 
   def self.average_sms_count_cost_per_dose(vaccine)
     case vaccine
-    when Brands::ASTRAZENECA
+    when Vaccine::Brands::ASTRAZENECA
       100
     else
       90

--- a/config/initializers/redlock.rb
+++ b/config/initializers/redlock.rb
@@ -2,5 +2,5 @@ redis_url = (ENV["REDIS_URL"] || "redis://localhost:6379")
 REDIS_LOCK = Redlock::Client.new([redis_url])
 if Rails.env.test?
   require "redlock/testing"
-  REDIS_LOCK.testing_mode = :bypass
+  Redlock::Client.testing_mode = :bypass
 end

--- a/db/migrate/20210424110052_add_budget_sms_to_campaigns.rb
+++ b/db/migrate/20210424110052_add_budget_sms_to_campaigns.rb
@@ -1,0 +1,13 @@
+class AddBudgetSmsToCampaigns < ActiveRecord::Migration[6.1]
+  def up
+    add_column :campaigns, :sms_max_count, :integer, null: false, default: 0
+    add_column :campaigns, :sms_sent_count, :integer, null: false, default: 0
+    add_check_constraint :campaigns, "sms_sent_count <= sms_max_count", name: "sms_sent_count_lt_eq_sms_max_count"
+  end
+
+  def down
+    remove_check_constraint :campaigns, name: "sms_sent_count_lt_eq_sms_max_count"
+    remove_column :campaigns, :sms_sent_count, :integer, null: false, default: 0
+    remove_column :campaigns, :sms_max_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_23_073642) do
+ActiveRecord::Schema.define(version: 2021_04_24_110052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -122,6 +122,8 @@ ActiveRecord::Schema.define(version: 2021_04_23_073642) do
     t.integer "max_age"
     t.integer "status", default: 0
     t.datetime "canceled_at"
+    t.integer "sms_max_count", default: 0, null: false
+    t.integer "sms_sent_count", default: 0, null: false
     t.index ["partner_id"], name: "index_campaigns_on_partner_id"
     t.index ["status"], name: "index_campaigns_on_status"
     t.index ["vaccination_center_id"], name: "index_campaigns_on_vaccination_center_id"
@@ -130,6 +132,7 @@ ActiveRecord::Schema.define(version: 2021_04_23_073642) do
     t.check_constraint "(vaccine_type)::text = ANY ((ARRAY['pfizer'::character varying, 'moderna'::character varying, 'astrazeneca'::character varying, 'janssen'::character varying])::text[])", name: "vaccine_type_is_a_known_brand"
     t.check_constraint "max_distance_in_meters > 0", name: "max_distance_in_meters_gt_zero"
     t.check_constraint "min_age > 0", name: "min_age_gt_zero"
+    t.check_constraint "sms_sent_count <= sms_max_count", name: "sms_sent_count_lt_eq_sms_max_count"
     t.check_constraint "starts_at < ends_at", name: "starts_at_lt_ends_at"
   end
 

--- a/lib/tasks/batches.rake
+++ b/lib/tasks/batches.rake
@@ -74,7 +74,7 @@ namespace :batches do
             body: "Bonne nouvelle ! Un vaccin #{batch.campaign.vaccine_type} est disponible. Réservez-le avant #{match.expires_at.strftime("%Hh%M")} en cliquant ici : https://www.covidliste.com/m/#{match.match_confirmation_token}"
           )
           puts response.body
-          match.update(sms_sent_at: Time.now.utc)
+          match.sms_sent!
         rescue => e
           puts e.class
           puts e.message


### PR DESCRIPTION
**### MERGER UNIQUEMENT APRÈS UNE BONNE REVIEW !**

Je propose une gestion de SMS par campagne en fonction du coût moyen de SMS par doses de vaccin et par type de vaccin pour réguler les envois des sms et éviter d'envoyer une tonne SMS qui ne sont jamais confirmé.

On ne cap pas le nombre de sms / budget par campagne par centre actuellement.
Certains centres nous coûte des centaines d’euros pour quelques doses d'astrazeneca.

Je n'ai pas mis la partie où campagne doit s'arrêter, actuellement elle continue mais juste arrête d'envoyer des SMS et continue uniquement avec les emails.

**Je pense faudrait l'avis des data scientist pour voir en moyen combien de SMS on a besoin d'envoyer par campagne.**

Regarder aussi peut-être si le format email est plus efficace que le SMS en terme de ratio.
Voir si le type de vaccin influe sur le nombre de SMS (je sais que certain sont réticent avec l'astra par exemple)
Voir si la localisation influe aussi sur le nombre de SMS à envoyer nécessaire

N'hésitez pas à mettre vos retours.