### PR TITLE
Zoomable map

### DIFF
--- a/app/javascript/controllers/maps/map_controller.js
+++ b/app/javascript/controllers/maps/map_controller.js
@@ -139,7 +139,7 @@ export default class extends Controller {
       mapStyle: null,
       canvas: "deck-canvas",
       initialViewState: INITIAL_VIEW_STATE,
-      controller: false,
+      controller: true,
       onViewStateChange: ({ viewState }) => {
         map.jumpTo({
           center: [viewState.longitude, viewState.latitude],


### PR DESCRIPTION
This PR enables the user to pan and zoom using touch / mouse.
I wasn't able to add controls as the mapbox map and deckgl needs to synchronise their states, and I didn't find a solid way to do it in VanillaJS.
In react it would be quite simple:
https://stackoverflow.com/questions/53008068/basic-deckgl-map-with-controller-buttons-in-react