### PR TITLE
[Algo] random sorting for reachable_users_query

### DIFF
--- a/app/controllers/partners/campaigns_controller.rb
+++ b/app/controllers/partners/campaigns_controller.rb
@@ -48,7 +48,7 @@ module Partners
       campaign = Campaign.new(simulate_params.merge({vaccination_center: @vaccination_center}))
       reach = campaign.reachable_users_query.count
       render json: {
-        reach: Rails.env.production? ? reach : 1
+        reach: Rails.env.production? ? reach : 1,
         enough: reach >= (Vaccine.minimum_reach_to_dose_ratio(vaccine_type) * available_doses)
       }
     end

--- a/app/controllers/partners/campaigns_controller.rb
+++ b/app/controllers/partners/campaigns_controller.rb
@@ -48,7 +48,7 @@ module Partners
       vaccine_type = payload.delete(:vaccine_type)
       available_doses = payload.delete(:available_doses)
 
-      reach = @vaccination_center.reachable_users_query(**payload).count
+      reach = @campaign.reachable_users_query(**payload).count
       render json: {
         reach: Rails.env.production? ? reach : 1,
         enough: reach >= (Vaccine.minimum_reach_to_dose_ratio(vaccine_type) * available_doses)

--- a/app/controllers/partners/campaigns_controller.rb
+++ b/app/controllers/partners/campaigns_controller.rb
@@ -43,14 +43,12 @@ module Partners
     end
 
     def simulate_reach
-      # TODO: we should validate params here before running simulation
-      payload = simulate_params.to_h.symbolize_keys
-      vaccine_type = payload.delete(:vaccine_type)
-      available_doses = payload.delete(:available_doses)
-
-      reach = @campaign.reachable_users_query.count
+      vaccine_type = simulate_params[:vaccine_type]
+      available_doses = simulate_params[:available_doses]
+      campaign = Campaign.new(simulate_params.merge({vaccination_center: @vaccination_center}))
+      reach = campaign.reachable_users_query.count
       render json: {
-        reach: Rails.env.production? ? reach : 1,
+        reach: Rails.env.production? ? reach : 1
         enough: reach >= (Vaccine.minimum_reach_to_dose_ratio(vaccine_type) * available_doses)
       }
     end

--- a/app/controllers/partners/campaigns_controller.rb
+++ b/app/controllers/partners/campaigns_controller.rb
@@ -48,7 +48,7 @@ module Partners
       vaccine_type = payload.delete(:vaccine_type)
       available_doses = payload.delete(:available_doses)
 
-      reach = @campaign.reachable_users_query(**payload).count
+      reach = @campaign.reachable_users_query.count
       render json: {
         reach: Rails.env.production? ? reach : 1,
         enough: reach >= (Vaccine.minimum_reach_to_dose_ratio(vaccine_type) * available_doses)

--- a/app/jobs/send_campaign_job.rb
+++ b/app/jobs/send_campaign_job.rb
@@ -11,7 +11,7 @@ class SendCampaignJob < ApplicationJob
 
     limit = (campaign.remaining_slots * Vaccine.overbooking_factor(campaign.vaccine_type)).floor
 
-    users = campaign.vaccination_center.reachable_users_query(
+    users = campaign.reachable_users_query(
       min_age: campaign.min_age,
       max_age: campaign.max_age,
       max_distance_in_meters: campaign.max_distance_in_meters,

--- a/app/jobs/send_campaign_job.rb
+++ b/app/jobs/send_campaign_job.rb
@@ -11,12 +11,7 @@ class SendCampaignJob < ApplicationJob
 
     limit = (campaign.remaining_slots * Vaccine.overbooking_factor(campaign.vaccine_type)).floor
 
-    users = campaign.reachable_users_query(
-      min_age: campaign.min_age,
-      max_age: campaign.max_age,
-      max_distance_in_meters: campaign.max_distance_in_meters,
-      limit: limit
-    )
+    users = campaign.reachable_users_query(limit: limit)
 
     return campaign.completed! if users.none?
 

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -27,7 +27,7 @@ class Campaign < ApplicationRecord
     available_doses - matches.confirmed.size
   end
 
-  def reachable_users_query(min_age:, max_age:, max_distance_in_meters:, limit: nil)
+  def reachable_users_query(limit: nil)
     User.confirmed.active.distinct
       .where("EXTRACT(YEAR FROM AGE(birthdate))::int BETWEEN ? AND ?", min_age, max_age)
       .where("SQRT(((? - lat)*110.574)^2 + ((? - lon)*111.320*COS(lat::float*3.14159/180))^2) < ?", lat, lon, max_distance_in_meters / 1000)
@@ -35,7 +35,7 @@ class Campaign < ApplicationRecord
       .where("matches.confirmed_at IS NULL")
       .where("(matches.id IS NULL) OR (matches.created_at = (SELECT MAX(matches.created_at) FROM matches WHERE users.id = matches.user_id))")
       .where("(matches.id IS NULL) OR (matches.created_at + interval '1' day < now())")
-      .order(Arel.sql('RANDOM()'))
+      .order(Arel.sql("RANDOM()"))
       .limit(limit)
   end
 

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -27,6 +27,18 @@ class Campaign < ApplicationRecord
     available_doses - matches.confirmed.size
   end
 
+  def reachable_users_query(min_age:, max_age:, max_distance_in_meters:, limit: nil)
+    User.confirmed.active.distinct
+      .where("EXTRACT(YEAR FROM AGE(birthdate))::int BETWEEN ? AND ?", min_age, max_age)
+      .where("SQRT(((? - lat)*110.574)^2 + ((? - lon)*111.320*COS(lat::float*3.14159/180))^2) < ?", lat, lon, max_distance_in_meters / 1000)
+      .joins("LEFT JOIN matches ON matches.user_id = users.id")
+      .where("matches.confirmed_at IS NULL")
+      .where("(matches.id IS NULL) OR (matches.created_at = (SELECT MAX(matches.created_at) FROM matches WHERE users.id = matches.user_id))")
+      .where("(matches.id IS NULL) OR (matches.created_at + interval '1' day < now())")
+      .order(Arel.sql('RANDOM()'))
+      .limit(limit)
+  end
+
   def to_csv
     CSV.generate(headers: true) do |csv|
       csv << %w[firstname lastname birthdate phone_number confirmed_at]

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -31,11 +31,11 @@ class Campaign < ApplicationRecord
     User.confirmed.active
       .where("EXTRACT(YEAR FROM AGE(birthdate))::int BETWEEN ? AND ?", min_age, max_age)
       .where("SQRT(((? - lat)*110.574)^2 + ((? - lon)*111.320*COS(lat::float*3.14159/180))^2) < ?", vaccination_center.lat, vaccination_center.lon, max_distance_in_meters / 1000)
-      .where("""id not in (
+      .where("id not in (
         select user_id from matches
         where user_id is not null
         and ((created_at >= now() - interval '24 hours') or (confirmed_at is not null))
-        )""") # exclude user_id that have been matched in the last 24 hours, or confirmed
+        )") # exclude user_id that have been matched in the last 24 hours, or confirmed
       .order("RANDOM()")
       .limit(limit)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,7 @@ class User < ApplicationRecord
   after_commit :reverse_geocode, if: -> { (saved_change_to_lat? || saved_change_to_lon?) && anonymized_at.nil? }
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }
+  scope :active, -> { where.not(anonymized_at: nil) }
   scope :between_age, ->(min, max) { where("birthdate between ? and ?", max.years.ago, min.years.ago) }
   scope :with_roles, -> { joins(:roles) }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ApplicationRecord
   after_commit :reverse_geocode, if: -> { (saved_change_to_lat? || saved_change_to_lon?) && anonymized_at.nil? }
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }
-  scope :active, -> { where.not(anonymized_at: nil) }
+  scope :active, -> { where(anonymized_at: nil) }
   scope :between_age, ->(min, max) { where("birthdate between ? and ?", max.years.ago, min.years.ago) }
   scope :with_roles, -> { joins(:roles) }
 

--- a/app/models/vaccination_center.rb
+++ b/app/models/vaccination_center.rb
@@ -95,20 +95,6 @@ class VaccinationCenter < ApplicationRecord
     end
   end
 
-  def reachable_users_query(min_age:, max_age:, max_distance_in_meters:, limit: nil)
-    User.distinct
-      .where.not(confirmed_at: nil)
-      .where(anonymized_at: nil)
-      .where("EXTRACT(YEAR FROM AGE(birthdate))::int BETWEEN ? AND ?", min_age, max_age)
-      .where("SQRT(((? - lat)*110.574)^2 + ((? - lon)*111.320*COS(lat::float*3.14159/180))^2) < ?", lat, lon, max_distance_in_meters / 1000)
-      .joins("LEFT JOIN matches ON matches.user_id = users.id")
-      .where("matches.confirmed_at IS NULL")
-      .where("(matches.id IS NULL) OR (matches.created_at = (SELECT MAX(matches.created_at) FROM matches WHERE users.id = matches.user_id))")
-      .where("(matches.id IS NULL) OR (matches.created_at + interval '1' day < now())")
-      .order(id: :asc)
-      .limit(limit)
-  end
-
   private
 
   def push_to_slack

--- a/lib/tasks/batches.rake
+++ b/lib/tasks/batches.rake
@@ -20,7 +20,7 @@ namespace :batches do
     puts "Batch #{batch.id} created"
 
     # Looking for users to match
-    users = batch.vaccination_center.reachable_users_query(
+    users = batch.campaign.reachable_users_query(
       min_age: campaign.min_age,
       max_age: campaign.max_age,
       max_distance_in_meters: campaign.max_distance_in_meters,

--- a/spec/jobs/send_campaign_job_spec.rb
+++ b/spec/jobs/send_campaign_job_spec.rb
@@ -22,7 +22,7 @@ describe SendCampaignJob do
   subject { SendCampaignJob.new.perform(campaign) }
 
   before do
-    allow_any_instance_of(VaccinationCenter).to receive(:reachable_users_query).and_return(reachable_users_query)
+    allow_any_instance_of(Campaign).to receive(:reachable_users_query).and_return(reachable_users_query)
   end
 
   context "with one reachable user" do

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -81,4 +81,39 @@ RSpec.describe Campaign, type: :model do
       expect(campaign.errors[:available_doses]).to include("doit être inférieur ou égal à #{Campaign::MAX_DOSES}")
     end
   end
+
+  describe "#reachable_users_query" do
+    it "should not re-match someone who was matched less than a day ago" do
+      campaign = create(:campaign, vaccination_center: vaccination_center, min_age: 50, max_age: 70)
+      user1 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
+      user2 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
+
+      users = campaign.reachable_users_query(
+        min_age: campaign.min_age, max_age: campaign.max_age, max_distance_in_meters: campaign.max_distance_in_meters, limit: 10
+      )
+      expect(users).to include(user1)
+
+      create(:match, user: user1, vaccination_center: vaccination_center, campaign: campaign, created_at: 23.hours.ago)
+
+      users = campaign.reachable_users_query(
+        min_age: campaign.min_age, max_age: campaign.max_age, max_distance_in_meters: campaign.max_distance_in_meters, limit: 10
+      )
+      expect(users).not_to include(user1)
+      expect(users).to include(user2)
+    end
+
+    it "should rematch someone who was matched more than a day ago" do
+      campaign = create(:campaign, vaccination_center: vaccination_center, min_age: 50, max_age: 70)
+      user1 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
+
+      create(:match, user: user1, vaccination_center: vaccination_center, campaign: campaign, created_at: 25.hours.ago)
+
+      users = campaign.reachable_users_query(
+        min_age: campaign.min_age, max_age: campaign.max_age, max_distance_in_meters: campaign.max_distance_in_meters, limit: 10
+      )
+      expect(users).to include(user1)
+    end
+  end
+
+
 end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -84,29 +84,25 @@ RSpec.describe Campaign, type: :model do
 
   describe "#reachable_users_query" do
     it "should not re-match someone who was matched less than a day ago" do
-      campaign = create(:campaign, vaccination_center: vaccination_center, min_age: 50, max_age: 70)
+      campaign = create(:campaign, min_age: 50, max_age: 70)
       user1 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
       user2 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
 
-      users = campaign.reachable_users_query(
-        min_age: campaign.min_age, max_age: campaign.max_age, max_distance_in_meters: campaign.max_distance_in_meters, limit: 10
-      )
+      users = campaign.reachable_users_query(limit: 10)
       expect(users).to include(user1)
 
-      create(:match, user: user1, vaccination_center: vaccination_center, campaign: campaign, created_at: 23.hours.ago)
+      create(:match, user: user1, campaign: campaign, created_at: 23.hours.ago)
 
-      users = campaign.reachable_users_query(
-        min_age: campaign.min_age, max_age: campaign.max_age, max_distance_in_meters: campaign.max_distance_in_meters, limit: 10
-      )
+      users = campaign.reachable_users_query(limit: 10)
       expect(users).not_to include(user1)
       expect(users).to include(user2)
     end
 
     it "should rematch someone who was matched more than a day ago" do
-      campaign = create(:campaign, vaccination_center: vaccination_center, min_age: 50, max_age: 70)
+      campaign = create(:campaign, min_age: 50, max_age: 70)
       user1 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
 
-      create(:match, user: user1, vaccination_center: vaccination_center, campaign: campaign, created_at: 25.hours.ago)
+      create(:match, user: user1, campaign: campaign, created_at: 25.hours.ago)
 
       users = campaign.reachable_users_query(
         min_age: campaign.min_age, max_age: campaign.max_age, max_distance_in_meters: campaign.max_distance_in_meters, limit: 10
@@ -114,6 +110,4 @@ RSpec.describe Campaign, type: :model do
       expect(users).to include(user1)
     end
   end
-
-
 end

--- a/spec/models/campaign_spec.rb
+++ b/spec/models/campaign_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe Campaign, type: :model do
   describe "#to_csv" do
-    let(:campaign) { build(:campaign) }
+    let!(:vaccination_center) { create(:vaccination_center, lat: 42, lon: 2) }
+    let(:campaign) { build(:campaign, vaccination_center: vaccination_center) }
     let!(:match) { create(:match, campaign: campaign, confirmed_at: Time.now) }
     let!(:unconfirmed_match) { create(:match, campaign: campaign, confirmed_at: nil) }
 
@@ -83,8 +84,9 @@ RSpec.describe Campaign, type: :model do
   end
 
   describe "#reachable_users_query" do
+    let!(:vaccination_center) { create(:vaccination_center, lat: 42, lon: 2) }
     it "should not re-match someone who was matched less than a day ago" do
-      campaign = create(:campaign, min_age: 50, max_age: 70)
+      campaign = create(:campaign, vaccination_center: vaccination_center, min_age: 50, max_age: 70)
       user1 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
       user2 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
 
@@ -99,14 +101,12 @@ RSpec.describe Campaign, type: :model do
     end
 
     it "should rematch someone who was matched more than a day ago" do
-      campaign = create(:campaign, min_age: 50, max_age: 70)
+      campaign = create(:campaign, vaccination_center: vaccination_center, min_age: 50, max_age: 70)
       user1 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
 
       create(:match, user: user1, campaign: campaign, created_at: 25.hours.ago)
 
-      users = campaign.reachable_users_query(
-        min_age: campaign.min_age, max_age: campaign.max_age, max_distance_in_meters: campaign.max_distance_in_meters, limit: 10
-      )
+      users = campaign.reachable_users_query(limit: 10)
       expect(users).to include(user1)
     end
   end

--- a/spec/models/vaccination_center_spec.rb
+++ b/spec/models/vaccination_center_spec.rb
@@ -18,37 +18,4 @@ RSpec.describe VaccinationCenter, type: :model do
       end
     end
   end
-
-  describe "#reachable_users_query" do
-    it "should not re-match someone who was matched less than a day ago" do
-      campaign = create(:campaign, vaccination_center: vaccination_center, min_age: 50, max_age: 70)
-      user1 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
-      user2 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
-
-      users = vaccination_center.reachable_users_query(
-        min_age: campaign.min_age, max_age: campaign.max_age, max_distance_in_meters: campaign.max_distance_in_meters, limit: 10
-      )
-      expect(users).to include(user1)
-
-      create(:match, user: user1, vaccination_center: vaccination_center, campaign: campaign, created_at: 23.hours.ago)
-
-      users = vaccination_center.reachable_users_query(
-        min_age: campaign.min_age, max_age: campaign.max_age, max_distance_in_meters: campaign.max_distance_in_meters, limit: 10
-      )
-      expect(users).not_to include(user1)
-      expect(users).to include(user2)
-    end
-
-    it "should rematch someone who was matched more than a day ago" do
-      campaign = create(:campaign, vaccination_center: vaccination_center, min_age: 50, max_age: 70)
-      user1 = create(:user, lat: 42, lon: 2, birthdate: (Time.now.utc - 60.years))
-
-      create(:match, user: user1, vaccination_center: vaccination_center, campaign: campaign, created_at: 25.hours.ago)
-
-      users = vaccination_center.reachable_users_query(
-        min_age: campaign.min_age, max_age: campaign.max_age, max_distance_in_meters: campaign.max_distance_in_meters, limit: 10
-      )
-      expect(users).to include(user1)
-    end
-  end
 end


### PR DESCRIPTION
Modification du "ranking" utilisé dans l'algorithme de matching. 
Au lieu de classer les volontaires éligibles par date d'inscription, le ranking se fait de façon aléatoire.

Par ailleurs, la méthode `reachable_users_query` a été déplacée de `VaccinationCenter` à `Campaign` car + logique que ce soit rattaché à une campagne, car les volontaires éligibles dépendent des critères de campagne.