### PR TITLE
Fix profile map tile size causing blur

### DIFF
--- a/app/javascript/plugins/user_map.js
+++ b/app/javascript/plugins/user_map.js
@@ -11,8 +11,6 @@ const userMap = () => {
       attribution:
         'Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',
       maxZoom: 14,
-      tileSize: 512,
-      zoomOffset: -1,
     }).addTo(lmap);
     lmap.panTo(new L.LatLng(lat, lon));
     L.circle([lat, lon], {


### PR DESCRIPTION
La config de la carte dans le profil fait que les tuiles sont rendues à la mauvaise taille et avec le mauvais niveau de zoom, donnant un effet "flou" aux images des tuiles
Avant : 
<img width="766" alt="Capture d’écran 2021-04-25 à 01 18 01" src="https://user-images.githubusercontent.com/666182/115975330-1efad600-a564-11eb-9d9a-63e1c75ae2e9.png">
Après : 
<img width="774" alt="Capture d’écran 2021-04-25 à 01 17 20" src="https://user-images.githubusercontent.com/666182/115975344-3e91fe80-a564-11eb-8662-1f0e85d099de.png">
