### PR TITLE
Kill CampaignBatch

### DIFF
--- a/app/controllers/partners/campaigns_controller.rb
+++ b/app/controllers/partners/campaigns_controller.rb
@@ -37,7 +37,7 @@ module Partners
     def update
       if params[:cancel] == "true" && @campaign.running?
         @campaign.canceled!
-        flash[:notice] = "La campagne est en cours d'interruption. Attention, des volontaires ont reçu des SMS et peuvent encore confirmer dans les #{SendCampaignJob::BATCH_EXPIRE_IN_MINUTES + 1} prochaines minutes"
+        flash[:notice] = "La campagne est en cours d'interruption. Attention, des volontaires ont reçu des SMS et peuvent encore confirmer dans les #{Match::EXPIRE_IN_MINUTES + 1} prochaines minutes"
         redirect_to partners_campaign_path(@campaign)
       end
     end

--- a/app/jobs/send_campaign_job.rb
+++ b/app/jobs/send_campaign_job.rb
@@ -6,7 +6,7 @@ class SendCampaignJob < ApplicationJob
   def perform(campaign, partner = nil)
     return unless campaign.running?
     return campaign.completed! if campaign.remaining_slots <= 0 || (campaign.ends_at - STOP_SENDING_BEFORE_CAMPAIGN_ENDS_AT) < Time.now.utc
-    
+
     limit = (campaign.remaining_slots * Vaccine.overbooking_factor(campaign.vaccine_type)).floor
     users = campaign.reachable_users_query(limit: limit)
 

--- a/app/jobs/send_campaign_job.rb
+++ b/app/jobs/send_campaign_job.rb
@@ -1,32 +1,21 @@
 class SendCampaignJob < ApplicationJob
   queue_as :critical
 
-  BATCH_EXPIRE_IN_MINUTES = 30
   STOP_SENDING_BEFORE_CAMPAIGN_ENDS_AT = 10.minutes
 
   def perform(campaign, partner = nil)
     return unless campaign.running?
     return campaign.completed! if campaign.remaining_slots <= 0 || (campaign.ends_at - STOP_SENDING_BEFORE_CAMPAIGN_ENDS_AT) < Time.now.utc
-
+    
     limit = (campaign.remaining_slots * Vaccine.overbooking_factor(campaign.vaccine_type)).floor
-
     users = campaign.reachable_users_query(limit: limit)
 
     return campaign.completed! if users.none?
-
-    batch = CampaignBatch.create!(
-      campaign: campaign,
-      vaccination_center: campaign.vaccination_center,
-      size: [limit, users.size].min,
-      partner: partner,
-      duration_in_minutes: BATCH_EXPIRE_IN_MINUTES
-    )
 
     users.each do |user|
       REDIS_LOCK.lock!("create_match_for_user_id_#{user.id}", 2000) do
         Match.create(
           campaign: campaign,
-          campaign_batch: batch,
           vaccination_center: campaign.vaccination_center,
           user: user
         )
@@ -36,6 +25,6 @@ class SendCampaignJob < ApplicationJob
     end
 
     # Prepare for next campaign batch
-    SendCampaignJob.set(wait: BATCH_EXPIRE_IN_MINUTES.minutes + 1.minute).perform_later(campaign, partner)
+    SendCampaignJob.set(wait: Match::EXPIRE_IN_MINUTES.minutes + 1.minute).perform_later(campaign, partner)
   end
 end

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -5,7 +5,6 @@ class Campaign < ApplicationRecord
   belongs_to :vaccination_center
   belongs_to :partner
 
-  has_many :campaign_batches
   has_many :matches
 
   enum status: {running: 0, completed: 1, canceled: 2}

--- a/app/models/campaign_batch.rb
+++ b/app/models/campaign_batch.rb
@@ -1,6 +1,0 @@
-class CampaignBatch < ApplicationRecord
-  belongs_to :vaccination_center
-  belongs_to :partner, optional: true
-  belongs_to :campaign
-  has_many :matches
-end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -6,12 +6,12 @@ class Match < ApplicationRecord
   class MissingNamesError < StandardError; end
 
   NO_MORE_THAN_ONE_MATCH_PER_PERIOD = 24.hours
+  EXPIRE_IN_MINUTES = 30
 
   has_secure_token :match_confirmation_token
 
   belongs_to :vaccination_center
   belongs_to :campaign
-  belongs_to :campaign_batch
   belongs_to :user
 
   accepts_nested_attributes_for :user
@@ -77,7 +77,7 @@ class Match < ApplicationRecord
 
   def set_expiration!
     return unless expires_at.nil?
-    self.expires_at = [Time.now.utc + campaign_batch.duration_in_minutes.minutes, campaign.ends_at].min
+    self.expires_at = [Time.now.utc + Match::EXPIRE_IN_MINUTES.minutes, campaign.ends_at].min
     save
   end
 

--- a/app/views/partners/campaigns/show.html.erb
+++ b/app/views/partners/campaigns/show.html.erb
@@ -19,7 +19,7 @@
         <%= link_to "Interrompre",
                     partners_campaign_path(@campaign, cancel: true),
                     method: :patch,
-                    data: { confirm: "Êtes-vous sûr de vouloir interrompre la recherche de volontaires pour cette campagne ? Attention l'interruption n'est pas immédiate et prendra environ #{SendCampaignJob::BATCH_EXPIRE_IN_MINUTES+1} minutes." },
+                    data: { confirm: "Êtes-vous sûr de vouloir interrompre la recherche de volontaires pour cette campagne ? Attention l'interruption n'est pas immédiate et prendra environ #{Match::EXPIRE_IN_MINUTES + 1} minutes." },
                     class: "btn btn-sm btn-danger" %>
       </span>
     <% end %>

--- a/lib/tasks/batches.rake
+++ b/lib/tasks/batches.rake
@@ -1,30 +1,15 @@
 namespace :batches do
   desc "Creates a batch, matches, and sends them an text"
-  task :create, [:campaign_id, :batch_duration_minutes, :batch_size] => [:environment] do |t, args|
-    # Finding campaign
-    puts "Campaign ##{args[:campaign_id]}"
-    puts "Batch duration: #{args[:batch_duration_minutes]} min"
-    puts "Batch size: #{args[:batch_size]}"
+  task :create, [:campaign_id, :batch_size] => [:environment] do |t, args|
     campaign = Campaign.find_by(id: args[:campaign_id])
-
     puts "Campaign : #{campaign.name}"
 
-    # Creating a new batch
-    puts "Let's create a batch"
-    batch = CampaignBatch.create!(
-      campaign: campaign,
-      vaccination_center: campaign.vaccination_center,
-      size: args[:batch_size],
-      duration_in_minutes: args[:batch_duration_minutes]
-    )
-    puts "Batch #{batch.id} created"
-
     # Looking for users to match
-    users = batch.campaign.reachable_users_query(
+    users = campaign.reachable_users_query(
       min_age: campaign.min_age,
       max_age: campaign.max_age,
       max_distance_in_meters: campaign.max_distance_in_meters,
-      limit: batch.size
+      limit: args[:batch_size]
     ).all
     puts "#{users.size} users found"
 
@@ -34,54 +19,10 @@ namespace :batches do
     users.each do |user|
       matches << Match.create(
         campaign: campaign,
-        campaign_batch: batch,
         vaccination_center: campaign.vaccination_center,
         user: user
       )
     end
     puts "#{matches.size} matches created"
-    puts "Batch #{batch.id} created"
-
-    # Sending email + sms
-  end
-
-  desc "Sends mails/sms to matches of a batch"
-  task :send, [:batch_id] => [:environment] do |t, args|
-    batch = CampaignBatch.find(args[:batch_id])
-
-    puts "Let's send them an email and an SMS"
-    client = Twilio::REST::Client.new
-    batch.matches.each do |match|
-      next if match.sms_sent_at.present? || match.mail_sent_at.present?
-
-      match.update(expires_at: Time.now.utc + match.campaign_batch.duration_in_minutes.minutes)
-
-      begin
-        MatchMailer.with(match: match, match_confirmation_token: match.match_confirmation_token).match_confirmation_instructions.deliver_now
-        match.update(mail_sent_at: Time.now.utc)
-      rescue => exception
-        puts exception.class
-        puts exception.message
-        puts "Error sending email to match #{match.id}"
-      end
-
-      # User can ban nil or anonymized, so we check if phone_number is present? before trying to send SMS
-      if match&.user&.phone_number.present?
-        begin
-          response = client.messages.create(
-            from: "COVIDLISTE",
-            to: match.user.phone_number,
-            body: "Bonne nouvelle ! Un vaccin #{batch.campaign.vaccine_type} est disponible. Réservez-le avant #{match.expires_at.strftime("%Hh%M")} en cliquant ici : https://www.covidliste.com/m/#{match.match_confirmation_token}"
-          )
-          puts response.body
-          match.update(sms_sent_at: Time.now.utc)
-        rescue => e
-          puts e.class
-          puts e.message
-          puts "Error sending sms to match #{match.id}"
-        end
-      end
-    end
-    puts "Done !"
   end
 end

--- a/spec/controllers/partners/campaigns_controller_spec.rb
+++ b/spec/controllers/partners/campaigns_controller_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Partners::CampaignsController, type: :controller do
+  render_views
+
+  let!(:partner) { create(:partner) }
+  let!(:center) { create(:vaccination_center, confirmed_at: 10.days.ago) }
+  let!(:campaign) { create(:campaign, vaccination_center: center) }
+
+  describe "#show" do
+    subject { get :show, params: {id: campaign.id} }
+
+    context "with partner logged in" do
+      before do
+        center.partners << partner
+        sign_in partner
+      end
+      it "loads properly" do
+        expect(subject).to have_http_status :ok
+      end
+    end
+  end
+end

--- a/spec/factories/campaign_batch_factory.rb
+++ b/spec/factories/campaign_batch_factory.rb
@@ -1,9 +1,0 @@
-FactoryBot.define do
-  factory :campaign_batch do
-    association :campaign
-    association :vaccination_center
-    association :partner
-
-    size { 60 }
-  end
-end

--- a/spec/factories/match_factory.rb
+++ b/spec/factories/match_factory.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :match do
     association :user
     association :campaign
-    association :campaign_batch
     association :vaccination_center
 
     trait :confirmed do

--- a/spec/jobs/send_campaign_job_spec.rb
+++ b/spec/jobs/send_campaign_job_spec.rb
@@ -28,7 +28,6 @@ describe SendCampaignJob do
   context "with one reachable user" do
     it "should create a batch and a match" do
       subject
-      expect(campaign.campaign_batches.count).to eq(1)
       expect(campaign.matches.count).to eq(1)
     end
 
@@ -46,15 +45,8 @@ describe SendCampaignJob do
 
     context "and with an already confirmed match" do
       before do
-        batch = campaign.campaign_batches.create!(
-          vaccination_center: center,
-          size: 1,
-          partner: partner,
-          duration_in_minutes: 6
-        )
         Match.create!(
           campaign: campaign,
-          campaign_batch: batch,
           vaccination_center: center,
           user: user,
           confirmed_at: Time.now.utc
@@ -84,7 +76,6 @@ describe SendCampaignJob do
     end
     it "should not create any batch or match" do
       subject
-      expect(campaign.campaign_batches.any?).to eq(false)
       expect(campaign.matches.any?).to eq(false)
     end
   end

--- a/spec/jobs/send_match_email_job_spec.rb
+++ b/spec/jobs/send_match_email_job_spec.rb
@@ -3,8 +3,7 @@ require "rails_helper"
 describe SendMatchEmailJob do
   let!(:user) { create(:user) }
   let!(:campaign) { create(:campaign) }
-  let!(:campaign_batch) { create(:campaign_batch) }
-  let!(:match) { create(:match, user: user, campaign_batch: campaign_batch, campaign: campaign) }
+  let!(:match) { create(:match, user: user, campaign: campaign) }
 
   subject { SendMatchEmailJob.new.perform(match) }
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -4,9 +4,8 @@ require "rails_helper"
 
 RSpec.describe Match, type: :model do
   let!(:campaign) { create(:campaign) }
-  let!(:campaign_batch) { create(:campaign_batch) }
-  let!(:match) { create(:match, campaign_batch: campaign_batch, campaign: campaign) }
-  let(:confirmed_match) { create(:match, :confirmed, campaign_batch: campaign_batch) }
+  let!(:match) { create(:match, campaign: campaign) }
+  let(:confirmed_match) { create(:match, :confirmed) }
   let(:now_utc) { Time.now.utc }
   let(:now) { double }
 
@@ -48,7 +47,7 @@ RSpec.describe Match, type: :model do
     it "should set correct expiration" do
       match.set_expiration!
       match.reload
-      expect(match.expires_at).to eq(Time.now.utc + campaign_batch.duration_in_minutes.minutes)
+      expect(match.expires_at).to eq(Time.now.utc + Match::EXPIRE_IN_MINUTES.minutes)
     end
 
     context "campaign ending now" do

--- a/spec/requests/matches_request_spec.rb
+++ b/spec/requests/matches_request_spec.rb
@@ -4,9 +4,8 @@ RSpec.describe "Matches", type: :request do
   let!(:user) { create(:user) }
   let!(:center) { create(:vaccination_center) }
   let!(:campaign) { create(:campaign, vaccination_center: center) }
-  let!(:batch) { create(:campaign_batch, campaign: campaign, vaccination_center: center) }
   let!(:match_confirmation_token) { "abcd" }
-  let!(:match) { create(:match, campaign_batch: batch, user: user, vaccination_center: center, match_confirmation_token: match_confirmation_token, expires_at: 1.hour.since, campaign: campaign) }
+  let!(:match) { create(:match, user: user, vaccination_center: center, match_confirmation_token: match_confirmation_token, expires_at: 1.hour.since, campaign: campaign) }
 
   describe "update" do
     it "will confirm a valid match with age and name confirmation" do

--- a/spec/system/matches_controller_spec.rb
+++ b/spec/system/matches_controller_spec.rb
@@ -6,9 +6,8 @@ RSpec.describe MatchesController, type: :system do
   let!(:partner) { create(:partner) }
   let!(:center) { create(:vaccination_center) }
   let!(:campaign) { create(:campaign, vaccination_center: center) }
-  let!(:batch) { create(:campaign_batch, campaign: campaign, vaccination_center: center) }
   let!(:match_confirmation_token) { "abcd" }
-  let!(:match) { create(:match, campaign_batch: batch, user: user, vaccination_center: center, match_confirmation_token: match_confirmation_token, expires_at: 1.hour.since, campaign: campaign) }
+  let!(:match) { create(:match, user: user, vaccination_center: center, match_confirmation_token: match_confirmation_token, expires_at: 1.hour.since, campaign: campaign) }
 
   subject { visit match_path(match_confirmation_token, source: "sms") }
 


### PR DESCRIPTION
Kill le modèle `CampaignBatch` qui ne sert finalement pas vraiment et rajoute une couche d'abstraction superflue