### PR TITLE
Téléphone partenaire dans match confirmé #529

### DIFF
--- a/app/views/matches/_confirmed.html.erb
+++ b/app/views/matches/_confirmed.html.erb
@@ -18,5 +18,5 @@
 <% end %>
 
 <p class="mt-4">
-  En cas d'empêchement, vous pouvez joindre le centre de vaccination au numéro suivant : <%= link_to @match.vaccination_center.phone_number, "tel:#{@match.vaccination_center.phone_number}" %>
+  En cas d'empêchement, vous pouvez joindre le centre de vaccination au numéro suivant : <%= link_to @match.vaccination_center.phone_number, "tel:#{@match.vaccination_center.human_friendly_phone_number}" %>
 </p>

--- a/app/views/matches/_confirmed.html.erb
+++ b/app/views/matches/_confirmed.html.erb
@@ -18,5 +18,5 @@
 <% end %>
 
 <p class="mt-4">
-  En cas d'empêchement, vous pouvez joindre le centre de vaccination au numéro suivant : <%= @match.vaccination_center.phone_number %>
+  En cas d'empêchement, vous pouvez joindre le centre de vaccination au numéro suivant : <a href="tel:<%= @match.vaccination_center.phone_number %>"><%= @match.vaccination_center.phone_number %></a>
 </p>

--- a/app/views/matches/_confirmed.html.erb
+++ b/app/views/matches/_confirmed.html.erb
@@ -18,5 +18,5 @@
 <% end %>
 
 <p class="mt-4">
-  En cas d'empêchement, vous pouvez joindre le centre de vaccination au numéro suivant : <a href="tel:<%= @match.vaccination_center.phone_number %>"><%= @match.vaccination_center.phone_number %></a>
+  En cas d'empêchement, vous pouvez joindre le centre de vaccination au numéro suivant : <%= link_to @match.vaccination_center.phone_number, "tel:#{@match.vaccination_center.phone_number}" %>
 </p>

--- a/app/views/matches/_confirmed.html.erb
+++ b/app/views/matches/_confirmed.html.erb
@@ -16,3 +16,7 @@
     </p>
   </div>
 <% end %>
+
+<p class="mt-4">
+  En cas d'empêchement, vous pouvez joindre le centre de vaccination au numéro suivant : <%= @match.vaccination_center.phone_number %>
+</p>

--- a/app/views/matches/_confirmed.html.erb
+++ b/app/views/matches/_confirmed.html.erb
@@ -18,5 +18,5 @@
 <% end %>
 
 <p class="mt-4">
-  En cas d'empêchement, vous pouvez joindre le centre de vaccination au numéro suivant : <%= link_to @match.vaccination_center.phone_number, "tel:#{@match.vaccination_center.human_friendly_phone_number}" %>
+  Vous pouvez joindre le centre de vaccination au numéro suivant : <%= link_to @match.vaccination_center.human_friendly_phone_number, "tel:#{@match.vaccination_center.human_friendly_phone_number}" %>
 </p>


### PR DESCRIPTION
Issue  #529 
J'ai ajouté le numéro de téléphone du centre de vaccination sur la page de confirmation d'un match. J'ai improvisé sur le wording, n'hésitez pas à me faire des retours.
Voilà visuellement le résultat. Peut être que l'on peut plutôt ajouter une section en dessous de "adresse du centre de vaccination" ?
<img width="913" alt="Capture d’écran 2021-04-25 à 23 51 09" src="https://user-images.githubusercontent.com/51384884/116010745-4663a880-a621-11eb-9ced-137c01f0fb1d.png">
