### PR TITLE
[Devise] Autolog confirmation link + fix redirect already confirmed partner

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -4,22 +4,24 @@ class ConfirmationsController < ::Devise::ConfirmationsController
     yield resource if block_given?
     if resource.errors.empty?
       set_flash_message!(:notice, :confirmed)
-
-      # PasswordLess specific behaviour after confirmation there is a direct sign in
-      sign_in(resource) if resource.is_a?(User)
-
-      respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }
+      sign_in(resource)
+      respond_with_navigational(resource) do
+        redirect_to after_confirmation_path_for(resource_name, resource)
+      end
     elsif resource.confirmed?
       set_flash_message!(:notice, :already_confirmed)
-      respond_with_navigational(resource.errors, status: :unprocessable_entity) { redirect_to resource.is_a?(Partner) ? :new_partner_session : :new_user_session }
+      respond_with_navigational(resource.errors, status: :unprocessable_entity) do
+        redirect_to resource.is_a?(Partner) ? :new_partner_session : :new_user_session, status: :unprocessable_entity
+      end
     else
-      respond_with_navigational(resource.errors, status: :unprocessable_entity) { render :new }
+      respond_with_navigational(resource.errors, status: :unprocessable_entity) do
+        render :new, status: :unprocessable_entity
+      end
     end
   end
 
   def after_confirmation_path_for(_resource_name, resource)
     if resource.is_a?(Partner)
-      # NOTE(ssaunier): We already have a valid password at sign up
       partners_vaccination_centers_path
     elsif resource.is_a?(User)
       profile_path

--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -11,7 +11,7 @@ class ConfirmationsController < ::Devise::ConfirmationsController
       respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }
     elsif resource.confirmed?
       set_flash_message!(:notice, :already_confirmed)
-      respond_with_navigational(resource.errors, status: :unprocessable_entity) { redirect_to :new_user_session }
+      respond_with_navigational(resource.errors, status: :unprocessable_entity) { redirect_to resource.is_a?(Partner) ? :new_partner_session : :new_user_session }
     else
       respond_with_navigational(resource.errors, status: :unprocessable_entity) { render :new }
     end


### PR DESCRIPTION
Rajoute de l'appel à la méthode sign_in quand c'est un partenaire de santé également.
Sachant que ce lien de login n'est fonctionel et non crackable (il fait plus de 17 caractères caractères speciaux inclus) qu'une seule fois car après le compte est confirmé, et ne fais plus appel à ce block de fonction. De plus, lorsque le compte était déjà confirmé, et qu'on était partenaire de santé, on était redirigé vers la page de login des users et non des partners.