### PR TITLE
[Match] Afficher l'adresse du centre uniquement quand confirmé ou lat/lon manquant

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,17 +43,17 @@ module ApplicationHelper
   end
 
   def distance_delta(p1, p2)
-    distance = Geocoder::Calculations.distance_between([p1[:lat], p1[:lon]], [p2[:lat], p2[:lon]], { unit: :km })
+    distance = Geocoder::Calculations.distance_between([p1[:lat], p1[:lon]], [p2[:lat], p2[:lon]], {unit: :km})
     if distance < 1
-      distance = (distance.round(3) * 1000).round(-1)
+      distance = (distance.round(2) * 1000).round(-1)
       distance_in_words = "#{distance} m"
     else
-      distance = distance.round(-1) if distance > 10
+      distance = distance.round(1)
       distance_in_words = "#{distance.round(1)} km"
     end
     {
       delta: distance,
-      delta_in_words: distance_in_words,
+      delta_in_words: distance_in_words
     }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -41,4 +41,19 @@ module ApplicationHelper
     return "" if number.blank?
     ActionController::Base.helpers.number_with_delimiter(number, locale: :fr).gsub(" ", "&nbsp;").html_safe
   end
+
+  def distance_delta(p1, p2)
+    distance = Geocoder::Calculations.distance_between([p1[:lat], p1[:lon]], [p2[:lat], p2[:lon]], { unit: :km })
+    if distance < 1
+      distance = (distance.round(3) * 1000).round(-1)
+      distance_in_words = "#{distance} m"
+    else
+      distance = distance.round(-1) if distance > 10
+      distance_in_words = "#{distance.round(1)} km"
+    end
+    {
+      delta: distance,
+      delta_in_words: distance_in_words,
+    }
+  end
 end

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -4,7 +4,7 @@
 <div>
   <div>
     <i class="fas fa-map-pin"></i>
-    <% if match.confirmed? || (vaccination_center.lat.blank? && vaccination_center.lon.blank?) %>
+    <% if match.confirmed? || vaccination_center.lat.blank? || vaccination_center.lon.blank? %>
       <strong> Adresse du centre de vaccination </strong>
       <p>
         <%= vaccination_center.address %>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -1,8 +1,21 @@
+<% user = match.user %>
+<% vaccination_center = match.vaccination_center %>
+
 <div>
   <div>
     <i class="fas fa-map-pin"></i>
-    <strong> Adresse du centre de vaccination </strong>
-    <p><%= match.vaccination_center.address %></p>
+    <% if match.confirmed? || (vaccination_center.lat.blank? && vaccination_center.lon.blank?) %>
+      <strong> Adresse du centre de vaccination </strong>
+      <p>
+        <%= vaccination_center.address %>
+      </p>
+    <% else %>
+      <strong> Distance du centre de vaccination </strong>
+      <p>
+        <% distance = distance_delta({ lat: user.lat, lon: user.lon}, { lat: vaccination_center.lat, lon: vaccination_center.lon }) %>
+        <%= distance[:delta_in_words] %>
+      </p>
+    <% end %>
   </div>
 
   <div>
@@ -15,8 +28,6 @@
       et <%= l(ends_at, format: '%Hh%M') %>
     </p>
   </div>
-
-  <% user = match.user %>
 
   <% if user.blank? %>
     <div>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -21,8 +21,20 @@ RSpec.describe ApplicationHelper, type: :helper do
         p1 = { lat: 48.872624, lon: 2.336625 }
         p2 = { lat: 48.872824, lon: 2.321619 }
         expect(helper.distance_delta(p1, p2)).to eq({
-          delta: 1.0977142227228804,
+          delta: 1.1,
           delta_in_words: "1.1 km",
+        })
+      end
+    end
+    context "points more than one kilometer away" do
+      it "calculates the delta distance between two points" do
+        # p1 (18 Boulevard Haussmann 75009 Paris France)
+        # p2 (60 Avenue de la Grande Armée 75017 Paris France)
+        p1 = { lat: 48.872624, lon: 2.336625 }
+        p2 = { lat: 48.8768581, lon: 2.284386 }
+        expect(helper.distance_delta(p1, p2)).to eq({
+          delta: 3.8,
+          delta_in_words: "3.8 km",
         })
       end
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "distance_delta" do
+    context "points under one kilometer away" do
+      it "calculates the delta distance between two points" do
+        # p1 (18 Boulevard Haussmann 75009 Paris France)
+        # p2 (43 Boulevard Haussmann 75009 Paris France)
+        p1 = { lat: 48.872624, lon: 2.336625 }
+        p2 = { lat: 48.873342, lon: 2.329358 }
+        expect(helper.distance_delta(p1, p2)).to eq({
+          delta: 540,
+          delta_in_words: "540 m",
+        })
+      end
+    end
+    context "points more than one kilometer away" do
+      it "calculates the delta distance between two points" do
+        # p1 (18 Boulevard Haussmann 75009 Paris France)
+        # p2 (24 Boulevard Malesherbes 75009 Paris France)
+        p1 = { lat: 48.872624, lon: 2.336625 }
+        p2 = { lat: 48.872824, lon: 2.321619 }
+        expect(helper.distance_delta(p1, p2)).to eq({
+          delta: 1.0977142227228804,
+          delta_in_words: "1.1 km",
+        })
+      end
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
   describe "distance_delta" do
@@ -6,11 +6,11 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "calculates the delta distance between two points" do
         # p1 (18 Boulevard Haussmann 75009 Paris France)
         # p2 (43 Boulevard Haussmann 75009 Paris France)
-        p1 = { lat: 48.872624, lon: 2.336625 }
-        p2 = { lat: 48.873342, lon: 2.329358 }
+        p1 = {lat: 48.872624, lon: 2.336625}
+        p2 = {lat: 48.873342, lon: 2.329358}
         expect(helper.distance_delta(p1, p2)).to eq({
           delta: 540,
-          delta_in_words: "540 m",
+          delta_in_words: "540 m"
         })
       end
     end
@@ -18,11 +18,11 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "calculates the delta distance between two points" do
         # p1 (18 Boulevard Haussmann 75009 Paris France)
         # p2 (24 Boulevard Malesherbes 75009 Paris France)
-        p1 = { lat: 48.872624, lon: 2.336625 }
-        p2 = { lat: 48.872824, lon: 2.321619 }
+        p1 = {lat: 48.872624, lon: 2.336625}
+        p2 = {lat: 48.872824, lon: 2.321619}
         expect(helper.distance_delta(p1, p2)).to eq({
           delta: 1.1,
-          delta_in_words: "1.1 km",
+          delta_in_words: "1.1 km"
         })
       end
     end
@@ -30,11 +30,11 @@ RSpec.describe ApplicationHelper, type: :helper do
       it "calculates the delta distance between two points" do
         # p1 (18 Boulevard Haussmann 75009 Paris France)
         # p2 (60 Avenue de la Grande Armée 75017 Paris France)
-        p1 = { lat: 48.872624, lon: 2.336625 }
-        p2 = { lat: 48.8768581, lon: 2.284386 }
+        p1 = {lat: 48.872624, lon: 2.336625}
+        p2 = {lat: 48.8768581, lon: 2.284386}
         expect(helper.distance_delta(p1, p2)).to eq({
           delta: 3.8,
-          delta_in_words: "3.8 km",
+          delta_in_words: "3.8 km"
         })
       end
     end

--- a/spec/system/matches_controller_spec.rb
+++ b/spec/system/matches_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MatchesController, type: :system do
   let!(:user) { create(:user) }
   let!(:second_user) { create(:user) }
   let!(:partner) { create(:partner) }
-  let!(:center) { create(:vaccination_center) }
+  let!(:center) { create(:vaccination_center, :from_paris) }
   let!(:campaign) { create(:campaign, vaccination_center: center) }
   let!(:match_confirmation_token) { "abcd" }
   let!(:match) { create(:match, user: user, vaccination_center: center, match_confirmation_token: match_confirmation_token, expires_at: 1.hour.since, campaign: campaign) }
@@ -17,7 +17,7 @@ RSpec.describe MatchesController, type: :system do
         subject
         expect(page).to have_text("Une dose est disponible")
         expect(page).to have_text("Je réserve la dose")
-        expect(page).to have_text(center.address)
+        expect(page).to have_text("Distance du centre de vaccination")
         expect(page).to have_field("user_firstname", with: user.firstname)
         expect(page).to have_field("user_lastname", with: user.lastname)
 
@@ -42,6 +42,7 @@ RSpec.describe MatchesController, type: :system do
         click_on("Je réserve la dose")
         expect(page).not_to have_text("Vous devez renseigner votre identité")
         expect(page).to have_text("Votre disponibilité est confirmée")
+        expect(page).to have_text("Adresse du centre de vaccination")
         expect(page).to have_text(center.address)
         match.reload
         expect(match.sms_first_clicked_at).to_not eq(nil)
@@ -55,6 +56,7 @@ RSpec.describe MatchesController, type: :system do
       it "it says dispo confirmée" do
         subject
         expect(page).to have_text("Votre disponibilité est confirmée")
+        expect(page).to have_text("Adresse du centre de vaccination")
         expect(page).to have_text(center.address)
       end
     end


### PR DESCRIPTION
Afficher l'adresse du centre uniquement quand le match est confirme ou que la lat/lon est manquante, sinon on affiche la distance à vol d'oiseau entre le centre de vaccination, et la position lat/lon de l'utilisateur qui est je le rappelle randomisé dans un radius de 100m déja.

<img width="371" alt="Screenshot 2021-04-27 at 00 37 45" src="https://user-images.githubusercontent.com/6686865/116160799-fb19ca80-a6f2-11eb-9575-ef76b8069200.png">
<img width="312" alt="Screenshot 2021-04-27 at 00 37 24" src="https://user-images.githubusercontent.com/6686865/116160801-fc4af780-a6f2-11eb-971a-6c5e5a7f280d.png">
<img width="315" alt="Screenshot 2021-04-27 at 00 37 01" src="https://user-images.githubusercontent.com/6686865/116160804-fc4af780-a6f2-11eb-9267-a81fb7bc0160.png">
