### PR TITLE
Optimisations around SQL + tracking SQL caller + activation bullet gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,8 @@ gem "ahoy_email"
 gem "redlock"
 gem "react_on_rails", "12.2.0"
 gem "mini_racer", platforms: :ruby
+gem "marginalia"
+gem "memoist"
 
 group :development, :test do
   gem "dotenv-rails", "2.7.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,10 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.0)
+    marginalia (1.10.1)
+      actionpack (>= 2.3)
+      activerecord (>= 2.3)
+    memoist (0.16.2)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
@@ -530,6 +534,8 @@ DEPENDENCIES
   lockbox
   lograge
   logstash-event
+  marginalia
+  memoist
   mini_racer
   pagy
   pg (~> 1.1)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  extend Memoist
   include HasPhoneNumberConcern
   has_phone_number_types %i[mobile]
   rolify
@@ -108,6 +109,7 @@ class User < ApplicationRecord
       end
     end
   end
+  memoize :has_role?
 
   def anonymize!
     return unless anonymized_at.nil?

--- a/config/initializers/active_record_logger.rb
+++ b/config/initializers/active_record_logger.rb
@@ -25,5 +25,5 @@ if Rails.env.development?
     end
   end
   # ActiveRecord::Base.logger = nil # Hide completely all logs SQL
-  ActiveRecord::Base.logger = ActiveSupport::TaggedLogging.new(CacheFreeLogger.new(STDOUT))
+  ActiveRecord::Base.logger = ActiveSupport::TaggedLogging.new(CacheFreeLogger.new($stdout))
 end

--- a/config/initializers/active_record_logger.rb
+++ b/config/initializers/active_record_logger.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# This event happens quite a lot and fans out to ExplainSubscriber
+# and Logger, this cuts out 2 method calls that every time we run SQL
+#
+# In production we do not care about Explain or Logging SQL statements
+# at this level
+#
+# Micro bench shows for `User.first` this takes us from 3.3k/s to 3.5k/s
+if Rails.env.production?
+  ActiveSupport::Notifications.notifier.unsubscribe("sql.active_record")
+end
+
+# ActiveRecord logging is great because it shows every SQL query that hits your database.
+# You can easily pinpoint slow, useless, or duplicate queries and optimize your code accordingly.
+# Thanks to SQL caching, ActiveRecord will hit the database only once per needed query.
+# But it will still log them twice, prefixed with CACHE on the second time.
+# These last two lines aren’t actual queries. They don’t hit the database, always take 0.0ms, and pollute your logs.
+# To fix this, we create a logger that ignores messages containing "CACHE"
+# There you go, no more CACHE logs. Happy SQL optimizing!
+if Rails.env.development?
+  class CacheFreeLogger < ::Logger
+    def debug(message, *args, &block)
+      super unless message.include? "CACHE "
+    end
+  end
+  # ActiveRecord::Base.logger = nil # Hide completely all logs SQL
+  ActiveRecord::Base.logger = ActiveSupport::TaggedLogging.new(CacheFreeLogger.new(STDOUT))
+end

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,0 +1,9 @@
+if defined? Bullet
+  if ENV.fetch("DISABLE_BULLET", false) == false
+    Bullet.enable = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+    Bullet.bullet_logger = true
+    Bullet.add_footer = true
+  end
+end

--- a/config/initializers/marginalia.rb
+++ b/config/initializers/marginalia.rb
@@ -1,0 +1,17 @@
+module Marginalia
+  module Comment
+    def self.controller
+      if marginalia_controller.respond_to?(:controller_path)
+        marginalia_controller.controller_path
+      end
+    end
+  end
+end
+
+Marginalia::Comment.components = %i[
+  controller_with_namespace
+  action
+  line
+  job
+  sidekiq_job
+]

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -12,6 +12,8 @@ Sidekiq.configure_server do |config|
   config.redis = {url: (ENV["REDIS_URL"] || "redis://localhost:6379")}
 end
 
+Marginalia::SidekiqInstrumentation.enable!
+
 schedule_file = "config/schedule.yml"
 
 if File.exist?(schedule_file) && Sidekiq.server?


### PR DESCRIPTION
Optimisation des logs SQL en :
- masquant en environnement de développement les requêtes qui commencent par "CACHE"
- masquer les explain des ExplainSubscriber en production qu'on se soucie pas

Rajout de deux gems:

- gem "marginalia"

Rajoute un commentaire après les requêtes SQL dans les logs pour savoir son origine.
Pour ceux qui annotent des requêtes, vous vous êtes probablement rendu compte que le commentaire dans PgHero ne vous indique que l'un des endroits d'où provient une requête, car des requêtes similaires sont regroupées.
Désormais, vous pouvez avoir une meilleure idée de tous les lieux auxquels il s’appelle.

- gem "memoist"
Pour faire de la mémorisation de méthode plus facilement
J'ai memoize le has_role?(params...) de sorte que si on fait appel deux fois à has_role?(:volunteer) dans une même page, la requete ne sera pas réexecuté

Activation de la gem bullet pour tracker les N+1 queries