### PR TITLE
[Match] Stocker la distance entre le volontaire et le centre de vaccination à la création

### DIFF
--- a/db/migrate/20210427112116_add_distance_to_matches.rb
+++ b/db/migrate/20210427112116_add_distance_to_matches.rb
@@ -1,0 +1,5 @@
+class AddDistanceToMatches < ActiveRecord::Migration[6.1]
+  def change
+    add_column :matches, :distance_in_meters, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_27_090628) do
+ActiveRecord::Schema.define(version: 2021_04_27_112116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -157,6 +157,7 @@ ActiveRecord::Schema.define(version: 2021_04_27_090628) do
     t.datetime "sms_first_clicked_at"
     t.datetime "confirmation_failed_at"
     t.string "confirmation_failed_reason", default: "", null: false
+    t.integer "distance_in_meters"
     t.index ["campaign_batch_id"], name: "index_matches_on_campaign_batch_id"
     t.index ["campaign_id"], name: "index_matches_on_campaign_id"
     t.index ["confirmation_failed_reason"], name: "index_matches_on_confirmation_failed_reason"

--- a/spec/factories/vaccination_center_factory.rb
+++ b/spec/factories/vaccination_center_factory.rb
@@ -5,14 +5,16 @@ FactoryBot.define do
     kind { VaccinationCenter::Kinds::ALL.sample }
     name { generate(:company_name) }
     phone_number { generate(:french_phone_number) }
+    lat { Faker::Address.latitude }
+    lon { Faker::Address.longitude }
 
-    trait :from_lyon do
+    trait :from_paris do
       address { "21 Rue Bergère 75009 Paris" }
       lat { "48.87242501471677" }
       lon { "2.344941896580627" }
     end
 
-    trait :from_paris do
+    trait :from_lyon do
       address { "7 Rue Auguste Comte 69002 Lyon" }
       lat { "45.75620064462772" }
       lon { "4.8319385046869945" }

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -3,8 +3,9 @@
 require "rails_helper"
 
 RSpec.describe Match, type: :model do
-  let(:campaign) { create(:campaign, ends_at: 2.hours.from_now) }
-  let(:match) { create(:match, campaign: campaign) }
+  let(:vaccination_center) { create(:vaccination_center, :from_paris) }
+  let(:campaign) { create(:campaign, vaccination_center: vaccination_center, ends_at: 2.hours.from_now) }
+  let(:match) { create(:match, campaign: campaign, vaccination_center: vaccination_center) }
   let(:confirmed_match) { create(:match, :confirmed) }
   let(:now_utc) { Time.now.utc }
   let(:now) { double }


### PR DESCRIPTION
Dans le contexte de l'optimisation de l'algo de matching, comme les users sont anonymisés après un match, on perd l'information qui nous permettrait de calculer un taux confirmation vs distance au centre. Cette PR rajoute une colonne dans la table match avec la distance en mètre séparant le user et le centre.
La colonne est à nil par défaut, mais se remplit via un before_save qui check si la distance_in_meters est à nil avant d'essayer de la calculer. Cela permettra de gérer les matchs en cours. Après les matchs en cours seront légèrement biaisé car on va se basé sur la lat/lon anonymisé (léger aléatoire) contre les nouveaux qui seront calculé à la création du match donc avant l'anonymisation.