### PR TITLE
Fix open graph url

### DIFF
--- a/app/helpers/meta_tags_helper.rb
+++ b/app/helpers/meta_tags_helper.rb
@@ -10,4 +10,8 @@ module MetaTagsHelper
   def meta_image(meta)
     meta.presence || image_url("meta/main.png")
   end
+
+  def meta_url(meta)
+    meta.presence || request.original_url.force_encoding("utf-8")
+  end
 end

--- a/app/views/layouts/_head_seo_social.html.erb
+++ b/app/views/layouts/_head_seo_social.html.erb
@@ -1,12 +1,12 @@
 <title><%= meta_title(yield(:meta_title)) %></title>
 <meta name="description" content="<%= meta_description(yield(:meta_description)) %>"/>
 <meta property="og:type" content="website"/>
-<meta property="og:url" content="https://www.covidliste.com"/>
+<meta property="og:url" content="<%= meta_url(yield(:meta_url)) %>"/>
 <meta property="og:title" content="<%= meta_title(yield(:meta_title)) %>"/>
 <meta property="og:description" content="<%= meta_description(yield(:meta_description)) %>"/>
 <meta property="og:image" content="<%= meta_image(yield(:meta_image)) %>"/>
 <meta property="twitter:card" content="summary_large_image"/>
-<meta property="twitter:url" content="https://www.covidliste.com"/>
+<meta property="twitter:url" content="<%= meta_url(yield(:meta_url)) %>"/>
 <meta property="twitter:title" content="<%= meta_title(yield(:meta_title)) %>"/>
 <meta property="twitter:description" content="<%= meta_description(yield(:meta_description)) %>"/>
 <meta property="twitter:image" content="<%= meta_image(yield(:meta_image)) %>"/>


### PR DESCRIPTION
Cette PR corrige le problème du mauvais extrait de prévisualisation (snippet preview) pour les réseaux sociaux.

### Avant

**https://www.covidliste.com/partners/login**
```ruby
<meta property="og:url" content="https://www.covidliste.com"/>
...
<meta property="twitter:url" content="https://www.covidliste.com"/>
...
```

### Après

**https://www.covidliste.com/partners/login**
```ruby
<meta property="og:url" content="https://www.covidliste.com/partners/login"/>
...
<meta property="twitter:url" content="https://www.covidliste.com/partners/login"/>
...
```