### PR TITLE
Afficher Ville, Code postal et Région avant confirmation d'un match

### DIFF
--- a/app/models/vaccination_center.rb
+++ b/app/models/vaccination_center.rb
@@ -113,6 +113,13 @@ class VaccinationCenter < ApplicationRecord
     end
   end
 
+  def human_friendly_geo_area
+    if zipcode && city && geo_context
+      region = geo_context.split(",")[-1]
+      "#{city}, #{region} (#{zipcode})"
+    end
+  end
+
   private
 
   def approximated_lat_lon

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -12,8 +12,10 @@
     <% else %>
       <strong> Distance du centre de vaccination </strong>
       <p>
-        <% distance = distance_delta({ lat: user.lat, lon: user.lon}, { lat: vaccination_center.lat, lon: vaccination_center.lon }) %>
-        <%= distance[:delta_in_words] %>
+        À
+        <% distance = distance_delta({lat: user.lat, lon: user.lon}, {lat: vaccination_center.lat, lon: vaccination_center.lon}) %>
+        <%= distance[:delta_in_words] %> de
+        vous<%= ", à #{vaccination_center.human_friendly_geo_area}" if vaccination_center.human_friendly_geo_area %>
       </p>
     <% end %>
   </div>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1,17 +1,19 @@
-<div class="row">
-  <div class="col-sm-12 col-md-8 col-lg-8">
-    <div class="text-left mt-4">
-      <% if @match.confirmed? %>
-        <%= render 'confirmed', match: @match %>
-      <% elsif @match.refused? %>
-        <%= render 'refused', match: @match %>
-      <% elsif @match.expired? %>
-        <%= render 'expired', match: @match %>
-      <% elsif !@match.confirmable? %>
-        <%= render 'overbooked', match: @match %>
-      <% elsif !@match.expired? %>
-        <%= render 'pending', match: @match %>
-      <% end %>
+<div class="container">
+  <div class="row">
+    <div class="col-sm-12 col-md-8 col-lg-8">
+      <div class="text-left mt-4">
+        <% if @match.confirmed? %>
+          <%= render 'confirmed', match: @match %>
+        <% elsif @match.refused? %>
+          <%= render 'refused', match: @match %>
+        <% elsif @match.expired? %>
+          <%= render 'expired', match: @match %>
+        <% elsif !@match.confirmable? %>
+          <%= render 'overbooked', match: @match %>
+        <% elsif !@match.expired? %>
+          <%= render 'pending', match: @match %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/db/migrate/20210429122735_add_city_zipcode_to_vaccination_centers.rb
+++ b/db/migrate/20210429122735_add_city_zipcode_to_vaccination_centers.rb
@@ -1,0 +1,13 @@
+class AddCityZipcodeToVaccinationCenters < ActiveRecord::Migration[6.1]
+  def change
+    add_column :vaccination_centers, :zipcode, :string
+    add_column :vaccination_centers, :city, :string
+    add_column :vaccination_centers, :geo_citycode, :string
+    add_column :vaccination_centers, :geo_context, :string
+
+    add_index :vaccination_centers, :zipcode
+    add_index :vaccination_centers, :city
+    add_index :vaccination_centers, :geo_citycode
+    add_index :vaccination_centers, :geo_context
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_29_110625) do
+ActiveRecord::Schema.define(version: 2021_04_29_122735) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -276,7 +276,15 @@ ActiveRecord::Schema.define(version: 2021_04_29_110625) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "confirmer_id"
     t.datetime "disabled_at"
+    t.string "zipcode"
+    t.string "city"
+    t.string "geo_citycode"
+    t.string "geo_context"
+    t.index ["city"], name: "index_vaccination_centers_on_city"
     t.index ["confirmer_id"], name: "index_vaccination_centers_on_confirmer_id"
+    t.index ["geo_citycode"], name: "index_vaccination_centers_on_geo_citycode"
+    t.index ["geo_context"], name: "index_vaccination_centers_on_geo_context"
+    t.index ["zipcode"], name: "index_vaccination_centers_on_zipcode"
   end
 
   add_foreign_key "campaign_batches", "campaigns"


### PR DESCRIPTION
## Problème

De nombreux utilisateurs ont utilisé une addresse erronée et se retrouvent matchés à l'autre bout de la France.

## Solution

* Calculer CP, Région, Ville pour chaque centre de vaccination
* L'afficher avant un match
* Ajouter une explication en cas de soucis

## Egalement inclus 🎁

* Marge restaurée sur les pages de match
* Bouton "refuser" moins proéminent (feedback de Christelle)

## Screenshots

|Avant|Après|
|-|-|
|<img width="438" alt="image" src="https://user-images.githubusercontent.com/5511564/116556114-6a630a80-a8fd-11eb-818c-b37fe04a1220.png">|<img width="552" alt="image" src="https://user-images.githubusercontent.com/5511564/116556837-33412900-a8fe-11eb-83eb-c17769b1714b.png">|

|Avant|Après|
|-|-|
|<img width="547" alt="image" src="https://user-images.githubusercontent.com/5511564/116556515-cf1e6500-a8fd-11eb-80c3-38614d6a1ea4.png">|<img width="553" alt="image" src="https://user-images.githubusercontent.com/5511564/116556307-a4341100-a8fd-11eb-9071-888353e30595.png">|

## Déploiements

Lancer cette commande en console rails pour recoder tous les centres existants.
@mathieuripert Est-ce qu'on a un risque de se faire jeter par l'API de geocodage si c'est dans un job ?
Je monitorerais sur Blazer que ça a bien marché une fois déployé.
```ruby
VaccinationCenter.all.each do |vaccination_center|
	vaccination_center.geocode_address
end
```