### PR TITLE
Corrige un bug à la création d'un compte si mauvaise géolocalisation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,8 +54,11 @@ class User < ApplicationRecord
     return unless lat.nil? || lon.nil?
     return if address.blank?
     results = GeocodingService.new(address).call
-    self.lat = results[:lat]
-    self.lon = results[:lon]
+
+    if results.present?
+      self.lat = results[:lat]
+      self.lon = results[:lon]
+    end
   end
 
   def reverse_geocode


### PR DESCRIPTION
Fixes #672 

## Avant

Erreur 500 (exemple [Appsignal](https://appsignal.com/hostolab/sites/606a007b3b6e073e78117293/exceptions/incidents/239))

## Après

Erreur de validation affichée sans casser : 

![image](https://user-images.githubusercontent.com/20317297/116611243-6d2e2180-a936-11eb-93c4-308fa98c9188.png)
