### PR TITLE
feat(ui): Redesign new partner page

### DIFF
--- a/app/views/partners/new.html.erb
+++ b/app/views/partners/new.html.erb
@@ -8,65 +8,41 @@
 
 <div class="container">
   <div class="row">
-    <div class="col-12 col-lg-8 offset-lg-2">
-      <% if @partner.errors.any? %>
-        <div class="alert alert-danger" role="alert">
-          <% @partner.errors.full_messages.each do |msg| %>
-            <%= msg %><br/>
-          <% end %>
+      <div class="col-12 d-flex flex-column text-center text-md-left flex-md-row align-items-center">
+        <div class="rounded p-3 bg-light text-primary mr-3 h2">
+          <%= icon("fas", "hospital-user") %>
         </div>
-      <% end %>
+        <h3>
+          Vous êtes membre d'un centre de vaccination ou professionnel de santé, devenez partenaire
+        </h3>
+      </div>
+  </div>
+  <div class="row mt-4">
 
-      <p><strong>Inscription en tant que professionnel de santé assurant la vaccination</strong></p>
+    <% if @partner.persisted? %>
 
-      <p class="text-justify mb-5">
-        Cette page d’inscription concerne uniquement l’inscription du
-        <strong>personnel médical assurant la vaccination :</strong>
-        membre d’un centre de vaccination, cabinet de médecine libérale, hôpital, pharmacie...
-      </p>
-
-      <h2>
-        <%= icon("far", "user") %>
-        <%= icon("fas", "syringe") %>
-      </h2>
-
-      <p>
-        Si vous êtes un particulier et souhaitez vous inscrire en tant volontaire à la vaccination, c’est par là !
-      </p>
-
-      <div class="btn btn-secondary">
-        <%= link_to "Je suis volontaire pour me faire vacciner", root_path, class: "text-white text-decoration-none" %>
+      <div class="col-12 col-lg-6 p-5-md p-4">
+        <div class="alert alert-success" role="alert">
+          Merci ! Vous êtes bien enregistré en tant que professionnel de santé assurant la vaccination sur Covidliste.
+          Vous allez recevoir dans quelques instants un email de confirmation qui vous permettra de valider votre
+          inscription et d'accéder à votre espace sécurisé.
+        </div>
       </div>
 
-      <h2 class="mt-5">
-        <%= icon("fas", "user-md") %>
-        <%= icon("fas", "clinic-medical") %>
-      </h2>
+    <% else %>
+      <div class="col-12 col-lg-6 mb-5 shadow-lg rounded p-5-md p-4">
+        <div>
+          <h4 class="text-primary font-weight-bold">Inscription en tant que centre de vaccination ou personnel médical</h4>
 
-      <p>
-        Si vous êtes un professionnel de santé assurant la vaccination et souhaitez inscrire votre lieu de vaccination
-        sur Covidliste, c’est bien ici !
-      </p>
+          <% if @partner.errors.any? %>
+            <div class="alert alert-danger mt-4" role="alert">
+              <% @partner.errors.full_messages.each do |msg| %>
+                <%= msg %><br/>
+              <% end %>
+            </div>
+          <% end %>
 
-      <% if @partner.persisted? %>
-
-        <div class="row mt-3">
-          <div class="alert alert-success" role="alert">
-            Merci ! Vous êtes bien enregistré en tant que professionnel de santé assurant la vaccination sur Covidliste.
-            Vous allez recevoir dans quelques instants un email de confirmation qui vous permettra de valider votre
-            inscription et d'accéder à votre espace sécurisé.
-          </div>
-        </div>
-
-      <% else %>
-
-        <button class="btn btn-primary" type="button" id="health-professionnal" data-toggle="collapse" data-target="#collapseForm" aria-expanded="false" aria-controls="collapseForm">
-          Je suis professionnel de santé assurant la vaccination
-        </button>
-
-        <div class="collapse <%= @partner.errors.any? ? 'show' : '' %>" id="collapseForm">
-          <div class="mt-4">
-            <p>Veuillez remplir le formulaire ci-dessous pour vous inscrire en tant que professionnel de santé.</p>
+          <div class="mt-3">
             <%= simple_form_for @partner do |f| %>
               <%= f.input :name, label: "Nom", error: "Nom requis", placeholder: "Prénom Nom" %>
               <%= f.input :phone_number, label: "Téléphone portable", placeholder: "06 .... (votre téléphone professionnel - pas de ligne fixe)", hint: "Ce numéro ne sera jamais communiqué aux volontaires. " %>
@@ -102,18 +78,32 @@
               <%= render partial: "users/input_statement", locals: {f: f, local_cgu_path: cgu_pro_path} %>
 
               <%= f.invisible_captcha :subtitle, honeypots: true %>
-              <%= f.button :submit, "S’inscrire", id: "create-new-partner", class: "btn btn-primary", data: {disable_with: "Validation...", confirm: "Vous êtes bien professionnel de santé ?"} %>
+              <%= f.button :submit, "Je m'inscris en tant que partenaire", id: "create-new-partner", class: "btn btn-primary font-weight-bold w-100 text-center", data: {disable_with: "Validation...", confirm: "Vous êtes bien professionnel de santé ?"} %>
+              
             <% end %>
-            <%= render partial: "mentions" %>
+
+            <p class="mt-3">
+              Déjà inscrit ? <%= link_to "Se connecter en tant que partenaire", new_partner_session_path %>
+            </p>
+
+            <small class="text-muted">
+              <%= render partial: "mentions" %>
+            </small>
           </div>
         </div>
 
-      <% end %>
+      </div>
 
-      <p class="mt-3">
-        <%= link_to "Se connecter en tant que professionnel de santé assurant la vaccination", new_partner_session_path %>
-      </p>
+    <% end %>
 
+    <div class="col-12 col-lg-6 d-flex flex-column align-items-center p-0 pl-lg-5">
+      <div class="border rounded p-5-md p-4">
+        <h4 class="font-weight-bold text-primary">Vous êtes un particulier ?</h4>
+        <p>Vous souhaitez vous inscrire en tant que volontaire pour recevoir une dose de vaccin ? C'est par ici :</p>
+        <div class="btn btn-secondary font-weight-bold">
+          <%= link_to "S'inscrire en tant que volontaire", root_path, class: "text-white text-decoration-none" %>
+        </div>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fix #207

Je n'ai pas suivi exactement la maquette, mais j'ai gardé l'esprit de la maquette en restant cohérent avec le thème des pages existantes. 

Notamment, je n'ai pas réutilisé le jaune pour la partie de droite, car aucune couleur existante proche n'existait, en dehors des "warning". Ici, ce n'est pas vraiment un "warning" mais plus une action de navigation alternative. Une couleur plus neutre me semble plus adaptée. 

J'ai conservé une partie du texte existant et non repris dans la maquette, ainsi que les couleurs différentes pour le bouton "primaire" de validation du formulaire, et le bouton "secondaire" pour la navigation vers l'autre page.

![Screenshot_2021-05-02 Devenez partenaires de Covidliste Desktop](https://user-images.githubusercontent.com/43094923/116821001-30ea0380-ab78-11eb-9734-cb7426795b37.png)
![Screenshot_2021-05-02 Devenez partenaires de Covidliste Mobile](https://user-images.githubusercontent.com/43094923/116821005-36474e00-ab78-11eb-8d3d-dc71ffb52c32.png)
![Screenshot_2021-05-02 Devenez partenaires de Covidliste - dektop confirm](https://user-images.githubusercontent.com/43094923/116821007-38111180-ab78-11eb-9513-f5964359f29e.png)

