### PR TITLE
Update email footer

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -5,14 +5,13 @@
 <p>
   Vous venez de vous enregistrer sur Covidliste.
   <br>
-  Pour finaliser votre inscription, merci de cliquer sur le lien ci-dessous (ce lien reste valide pendant 24 heures,
-  au-delà des 24 heures vous devrez refaire une demande de confirmation).
+  Pour finaliser votre inscription, merci de cliquer sur le lien suivant, il est valide uniquement pendant 24 heures :
+  <%= link_to "Valider mon inscription", confirmation_url(@resource, confirmation_token: @token) %>
 </p>
 
 <p>
-  <%= link_to "Validez votre inscription en cliquant ici", confirmation_url(@resource, confirmation_token: @token) %>
-  <br>
   Si le lien ne fonctionne pas, copiez et collez l’adresse suivante dans votre navigateur :
+  <br>
   <%= confirmation_url(@resource, confirmation_token: @token) %>
 </p>
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -17,3 +17,4 @@
 </p>
 
 <%= render "mailer/footer" %>
+<%= render "mailer/automatic_message" %>

--- a/app/views/devise/mailer/magic_link.html.erb
+++ b/app/views/devise/mailer/magic_link.html.erb
@@ -4,8 +4,7 @@
   Bonjour,
   <br>
   <br>
-  Vous pouvez vous connecter en utilisant le lien ci-dessous, il est valable uniquement <%= Devise.passwordless_login_within.inspect %> :
-  <br>
+  Vous pouvez vous connecter en cliquant sur le lien suivant, il est valable uniquement <%= Devise.passwordless_login_within.inspect %> :
   <%= link_to "Me connecter à mon compte", magic_link_url %>
   <br>
   <br>

--- a/app/views/devise/mailer/magic_link.html.erb
+++ b/app/views/devise/mailer/magic_link.html.erb
@@ -15,3 +15,4 @@
 </p>
 
 <%= render "mailer/footer" %>
+<%= render "mailer/automatic_message" %>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -18,3 +18,4 @@
 </p>
 
 <%= render "mailer/footer" %>
+<%= render "mailer/automatic_message" %>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Votre compte a été verrouillé en raison d'un nombre excessif de tentatives de connexion infructueuses.</p>
 
-<p>Cliquez sur le lien ci-dessous pour déverrouiller votre compte:</p>
+<p>Cliquez sur le lien ci-dessous pour déverrouiller votre compte :</p>
 
 <p><%= link_to 'Déverrouiller mon compte', unlock_url(@resource, unlock_token: @token) %></p>
 

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -7,3 +7,5 @@
 <p><%= link_to 'Déverrouiller mon compte', unlock_url(@resource, unlock_token: @token) %></p>
 
 <%= render "mailer/footer" %>
+<%= render "mailer/automatic_message" %>
+

--- a/app/views/mailer/_automatic_message.html.erb
+++ b/app/views/mailer/_automatic_message.html.erb
@@ -1,7 +1,7 @@
 <p>
   <small>
     <em>
-      Ceci est un email automatique, merci de ne pas y répondre.
+      Ce message est envoyé automatiquement, merci de ne pas y répondre.
     </em>
   </small>
 </p>

--- a/app/views/mailer/_automatic_message.html.erb
+++ b/app/views/mailer/_automatic_message.html.erb
@@ -1,0 +1,7 @@
+<p>
+  <small>
+    <em>
+      Ceci est un email automatique, merci de ne pas y répondre.
+    </em>
+  </small>
+</p>

--- a/app/views/mailer/_footer.html.erb
+++ b/app/views/mailer/_footer.html.erb
@@ -1,13 +1,9 @@
 <p>
-  Pour toutes vos questions, n’hésitez pas à consulter notre
-  <%= link_to "Foire aux questions,", "https://www.covidliste.com/faq" %>
-  où vous pourrez retrouver toutes nos réponses aux questions les plus fréquentes.
-</p>
-
-<p>
-  <%= link_to "https://www.covidliste.com", "https://www.covidliste.com", style: "color: #333"%>
-</p>
-
-<p>
-  Ceci est un email automatique, merci de ne pas y répondre.
+  <small>
+    Pour toutes vos questions, n’hésitez pas à consulter notre
+    <%= link_to "Foire aux questions,", "https://www.covidliste.com/faq" %>
+    où vous pourrez retrouver toutes nos réponses aux questions les plus fréquentes.
+    <br>
+    <%= link_to "https://www.covidliste.com", "https://www.covidliste.com", style: "color: #333"%>
+  </small>
 </p>

--- a/app/views/mailer/_footer.html.erb
+++ b/app/views/mailer/_footer.html.erb
@@ -1,9 +1,13 @@
 <p>
-  <small>
-    Pour toutes vos questions, n’hésitez pas à consulter notre
-    <%= link_to "Foire aux questions,", "https://www.covidliste.com/faq" %>
-    où vous pourrez retrouver toutes nos réponses aux questions les plus fréquentes.
-    <br>
-    <%= link_to "https://www.covidliste.com", "https://www.covidliste.com", style: "color: #333"%>
-  </small>
+  Pour toutes vos questions, n’hésitez pas à consulter notre
+  <%= link_to "Foire aux questions,", "https://www.covidliste.com/faq" %>
+  où vous pourrez retrouver toutes nos réponses aux questions les plus fréquentes.
+</p>
+<p>
+  L'équipe Covidliste
+  <br>
+  <%= link_to "https://www.covidliste.com", "https://www.covidliste.com", style: "color: #333"%>
+   - <%= link_to "Twitter", "https://twitter.com/covidliste" %>
+   - <%= link_to "Facebook", "https://www.facebook.com/covidliste" %>
+   - <%= link_to "Instagram", "https://www.instagram.com/covidliste/" %>
 </p>

--- a/app/views/match_mailer/match_confirmation_instructions.html.erb
+++ b/app/views/match_mailer/match_confirmation_instructions.html.erb
@@ -11,10 +11,8 @@
     <%= match_url(match_confirmation_token: @match_confirmation_token, source: 'email') %>
   </p>
 
-  <%= render "mailer/footer" %>
-
   <p>
-Vous ne souhaitez plus recevoir ces emails et souhaitez vous désinscrire de Covidliste ? 
+    Vous ne souhaitez plus recevoir ces emails et souhaitez vous désinscrire de Covidliste ?
     <%= link_to "Supprimer mon compte", edit_matches_users_url(match_confirmation_token: @match_confirmation_token) %>
   </p>
 
@@ -22,4 +20,8 @@ Vous ne souhaitez plus recevoir ces emails et souhaitez vous désinscrire de Cov
     Si le lien de suppression de compte ne fonctionne pas, copiez et collez l’adresse suivante dans votre navigateur : <br>
     <%= edit_matches_users_url(match_confirmation_token: @match_confirmation_token) %>
   </p>
+
+  <%= render "mailer/footer" %>
+  <%= render "mailer/automatic_message" %>
 </div>
+

--- a/app/views/match_mailer/send_anonymisation_notice.html.erb
+++ b/app/views/match_mailer/send_anonymisation_notice.html.erb
@@ -1,7 +1,7 @@
 <div>
-  <h2>
+  <p>
     Bonjour,
-  </h2>
+  </p>>
 
   <p>
     Cette semaine, vous avez été mis en contact avec un centre de vaccination grâce à Covidliste. Nous en sommes très heureux et espérons que vous avez pu vous rendre au rendez-vous.
@@ -18,5 +18,4 @@
   </p>
 
   <%= render 'mailer/footer' %>
-
 </div>

--- a/app/views/match_mailer/send_anonymisation_notice.html.erb
+++ b/app/views/match_mailer/send_anonymisation_notice.html.erb
@@ -14,7 +14,6 @@
   </p>
   <p>
     Merci de nous avoir fait confiance,<br>
-    Covidliste
   </p>
 
   <%= render 'mailer/footer' %>

--- a/config/locales/devise.fr.yml
+++ b/config/locales/devise.fr.yml
@@ -77,7 +77,7 @@ fr:
         action: Confirmer mon email
         greeting: Bienvenue %{recipient} !
         instruction: "Vous pouvez confirmer votre email grâce au lien ci-dessous :"
-        subject: Instructions de confirmation
+        subject: Validez votre inscription sur Covidliste
       email_changed:
         greeting: Bonjour %{recipient} !
         message: Nous vous contactons pour vous notifier que votre adresse email a été changée en %{email}.


### PR DESCRIPTION
- Update du footer des emails avec signature "L'équipe Covidliste" + lien vers les réseaux sociaux 
- Séparation de la mention "mail automatique, merci de ne pas y répondre" pour ne l'indiquer que lorsque nécessaire

![image](https://user-images.githubusercontent.com/68182973/116857329-e3fc4080-abfc-11eb-9555-c1124997d09c.png)
