### PR TITLE
Make migration container aware of installed gems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - db
     volumes:
       - .:/usr/src/app
+      - gems:/usr/local/bundle
     env_file:
       - docker/environments/db.env
       - docker/environments/web.env


### PR DESCRIPTION
When trying to set up my local environment I realised the migration container crashes because it doesn't know about gems

This fixes it, but I'm not sure why I would be the only one having this issue ? Maybe this container is not used and people just exec a rails db:migrate into the web one ? 