### PR TITLE
NO_MORE_THAN_ONE_MATCH_PER_PERIOD to 3 hours

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -5,7 +5,7 @@ class Match < ApplicationRecord
 
   class MissingNamesError < StandardError; end
 
-  NO_MORE_THAN_ONE_MATCH_PER_PERIOD = 24.hours
+  NO_MORE_THAN_ONE_MATCH_PER_PERIOD = 3.hours
   MATCH_TTL = 45.minutes
 
   has_secure_token :match_confirmation_token


### PR DESCRIPTION
La v2 du ranking algo est en cours de déploiement et permet aux volontaires qui ont été contactés récemment d'être contactés seulement après ceux qui ne l'ont pas été, on a donc un brassage plus efficace. Ceci devrait nous permettre de contacter un même utilisateur à une fréquence plus élevée (toutes les 3h) sans prendre le risque de contacter toujours les mêmes: un volontaire est contacté plusieurs fois dans la même journée seulement si les autres volontaires éligibles ont aussi été contactés entre temps.
De plus, en fin de semaine dernière, certains centres ont fait face à un manque de volontaire à contacter important. Ceci devrait ouvrir plus d'opportunités de matchs pour la fin de la semaine.

@mathieuripert @mininao 