### PR TITLE
Use grid query in ReachableUsersService

### DIFF
--- a/app/services/grid_coords_service.rb
+++ b/app/services/grid_coords_service.rb
@@ -1,5 +1,7 @@
 class GridCoordsService
   DEFAULT_ZOOM_LEVEL = 15
+  EARTH_RADIUS = 6378137.0
+  EARTH_CIRCUMFERENCE = 2 * Math::PI * EARTH_RADIUS
 
   def initialize(lat, lon)
     @lat = lat
@@ -13,5 +15,18 @@ class GridCoordsService
     j = ((1.0 - Math.log(Math.tan(lat_rad) + (1 / Math.cos(lat_rad))) / Math::PI) / 2.0 * n).to_i
 
     {i: i, j: j}
+  end
+
+  def get_cell_size
+    lat_rad = @lat / 180 * Math::PI
+    EARTH_CIRCUMFERENCE * Math.cos(lat_rad) / (2.0 ** DEFAULT_ZOOM_LEVEL)
+  end
+
+  def get_covering(distance_in_m)
+    cell_size = get_cell_size
+    n_cells = (distance_in_m / cell_size).ceil
+    cell = get_cell
+
+    {range_i: [*(cell[:i] - n_cells)..(cell[:i] + n_cells)], range_j: [*(cell[:j] - n_cells)..(cell[:j] + n_cells)]}
   end
 end

--- a/app/services/grid_coords_service.rb
+++ b/app/services/grid_coords_service.rb
@@ -27,6 +27,18 @@ class GridCoordsService
     n_cells = (distance_in_m / cell_size).ceil
     cell = get_cell
 
-    {range_i: [*(cell[:i] - n_cells)..(cell[:i] + n_cells)], range_j: [*(cell[:j] - n_cells)..(cell[:j] + n_cells)]}
+    irange = [*(cell[:i] - n_cells)..(cell[:i] + n_cells)]
+    jrange = [*(cell[:j] - n_cells)..(cell[:j] + n_cells)]
+
+    a = []
+    irange.each do |i|
+        jrange.each do |j|
+            if Math.sqrt((cell[:i] - i) ** 2 + (cell[:j] - j) ** 2) <= n_cells
+                a.append([i, j])
+            end
+        end
+    end
+
+    {center_cell: cell, dist_cells: n_cells, cells: a}
   end
 end

--- a/app/services/grid_coords_service.rb
+++ b/app/services/grid_coords_service.rb
@@ -4,12 +4,12 @@ class GridCoordsService
   EARTH_CIRCUMFERENCE = 2 * Math::PI * EARTH_RADIUS
 
   def initialize(lat, lon)
-    @lat = lat
-    @lon = lon
+    @lat = lat.to_f
+    @lon = lon.to_f
   end
 
   def get_cell
-    lat_rad = @lat / 180 * Math::PI
+    lat_rad = @lat / 180.0 * Math::PI
     n = 2.0**DEFAULT_ZOOM_LEVEL
     i = ((@lon + 180.0) / 360.0 * n).to_i
     j = ((1.0 - Math.log(Math.tan(lat_rad) + (1 / Math.cos(lat_rad))) / Math::PI) / 2.0 * n).to_i

--- a/app/services/grid_coords_service.rb
+++ b/app/services/grid_coords_service.rb
@@ -39,6 +39,6 @@ class GridCoordsService
       end
     end
 
-    {center_cell: cell, dist_cells: n_cells, cells: a}
+    {center_cell: cell, dist_cells: n_cells, cells: a, cell_size_meters: cell_size}
   end
 end

--- a/app/services/grid_coords_service.rb
+++ b/app/services/grid_coords_service.rb
@@ -19,7 +19,7 @@ class GridCoordsService
 
   def get_cell_size
     lat_rad = @lat / 180 * Math::PI
-    EARTH_CIRCUMFERENCE * Math.cos(lat_rad) / (2.0 ** DEFAULT_ZOOM_LEVEL)
+    EARTH_CIRCUMFERENCE * Math.cos(lat_rad) / (2.0**DEFAULT_ZOOM_LEVEL)
   end
 
   def get_covering(distance_in_m)
@@ -32,11 +32,11 @@ class GridCoordsService
 
     a = []
     irange.each do |i|
-        jrange.each do |j|
-            if Math.sqrt((cell[:i] - i) ** 2 + (cell[:j] - j) ** 2) <= n_cells
-                a.append([i, j])
-            end
+      jrange.each do |j|
+        if Math.sqrt((cell[:i] - i)**2 + (cell[:j] - j)**2) <= n_cells
+          a.append([i, j])
         end
+      end
     end
 
     {center_cell: cell, dist_cells: n_cells, cells: a}

--- a/app/services/reachable_users_service.rb
+++ b/app/services/reachable_users_service.rb
@@ -12,7 +12,7 @@ class ReachableUsersService
 
   def get_vaccination_center_grid_query
     cells = ::GridCoordsService.new(@vaccination_center.lat, @vaccination_center.lon).get_covering(@campaign.max_distance_in_meters)[:cells]
-    '(grid_i, grid_j) IN ((' + cells.map{ |sub| sub.join(",")}.join('),(') + '))'
+    "(grid_i, grid_j) IN ((" + cells.map { |sub| sub.join(",") }.join("),(") + "))"
   end
 
   def get_users_with_v2(limit = nil)
@@ -77,7 +77,7 @@ class ReachableUsersService
       limit: limit,
       last_match_allowed_at: Match::NO_MORE_THAN_ONE_MATCH_PER_PERIOD.ago
     }
-    sql = sql.sub! '__GRID_QUERY__', get_vaccination_center_grid_query
+    sql = sql.sub! "__GRID_QUERY__", get_vaccination_center_grid_query
     query = ActiveRecord::Base.send(:sanitize_sql_array, [sql, params])
     User.where(id: ActiveRecord::Base.connection.execute(query).to_a.pluck("user_id"))
   end

--- a/app/services/reachable_users_service.rb
+++ b/app/services/reachable_users_service.rb
@@ -21,7 +21,7 @@ class ReachableUsersService
       with reachable_users as (
         SELECT
         u.id as user_id,
-        (SQRT( (:vc_grid_i - u.grid_i)^2 + (:vc_grid_j - u.grid_j)^2 ) * :grid_cell_size) as distance
+        (SQRT( ((:vc_grid_i - u.grid_i) * :grid_cell_size)^2 + ((:vc_grid_j - u.grid_j) * :grid_cell_size)^2 )) as distance
         FROM users u
         WHERE u.confirmed_at IS NOT NULL
         AND u.anonymized_at is NULL

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -10,7 +10,7 @@ namespace :populate do
         email: Faker::Internet.unique.email(domain: "covidliste.com"),
         birthdate: Faker::Date.between(from: 100.years.ago, to: 18.years.ago),
         address: Faker::Address.full_address,
-        phone_number: "06 01 02 03 04",
+        phone_number: "+33601020304",
         toc: true,
         statement: true,
         lat: Faker::Address.latitude,

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -13,8 +13,8 @@ namespace :populate do
         phone_number: "+33601020304",
         toc: true,
         statement: true,
-        lat: Faker::Address.latitude,
-        lon: Faker::Address.longitude,
+        lat: rand(41.5..42.5),
+        lon: rand(1.5..2.5),
       )
       user.skip_confirmation!
       user.save!

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -14,7 +14,7 @@ namespace :populate do
         toc: true,
         statement: true,
         lat: rand(41.5..42.5),
-        lon: rand(1.5..2.5),
+        lon: rand(1.5..2.5)
       )
       user.skip_confirmation!
       user.save!

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -10,11 +10,11 @@ namespace :populate do
         email: Faker::Internet.unique.email(domain: "covidliste.com"),
         birthdate: Faker::Date.between(from: 100.years.ago, to: 18.years.ago),
         address: Faker::Address.full_address,
-        lat: Faker::Address.latitude,
-        lon: Faker::Address.longitude,
         phone_number: "06 01 02 03 04",
         toc: true,
-        statement: true
+        statement: true,
+        lat: rand(42.261..51.2757),
+        lon: rand(-4.943848..8.679199),
       )
       user.skip_confirmation!
       user.save!

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -13,8 +13,8 @@ namespace :populate do
         phone_number: "06 01 02 03 04",
         toc: true,
         statement: true,
-        lat: rand(42.261..51.2757),
-        lon: rand(-4.943848..8.679199),
+        lat: Faker::Address.latitude,
+        lon: Faker::Address.longitude,
       )
       user.skip_confirmation!
       user.save!

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -98,6 +98,14 @@ RSpec.describe User, type: :model do
       expect(user.grid_i).to eq(16577)
       expect(user.grid_j).to eq(11343)
     end
+
+
+    it "test range" do
+      lat = 48.345
+      lon = 2.123
+      range = ::GridCoordsService.new(lat, lon).get_covering(50000)
+      print range
+    end
   end
 
   describe "Email format" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -98,14 +98,6 @@ RSpec.describe User, type: :model do
       expect(user.grid_i).to eq(16577)
       expect(user.grid_j).to eq(11343)
     end
-
-
-    it "test range" do
-      lat = 48.345
-      lon = 2.123
-      range = ::GridCoordsService.new(lat, lon).get_covering(50000)
-      print range
-    end
   end
 
   describe "Email format" do

--- a/spec/services/reachable_users_service.rb
+++ b/spec/services/reachable_users_service.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+def get_lat_lng_for_number(xtile, ytile, zoom)
+  n = 2.0 ** zoom
+  lon_deg = xtile / n * 360.0 - 180.0
+  lat_rad = Math::atan(Math::sinh(Math::PI * (1 - 2 * ytile / n)))
+  lat_deg = 180.0 * (lat_rad / Math::PI)
+  {:lat => lat_deg, :lon => lon_deg}
+end
+
+DEFAULT_ZOOM_LEVEL = 15
+
+RSpec.describe ReachableUsersService, type: :service do
+  let!(:vaccination_center) { create(:vaccination_center, lat: 42, lon: 2) }
+  let!(:campaign) { build(:campaign, vaccination_center: vaccination_center, max_distance_in_meters: 5000, min_age: 18, max_age: 130, available_doses: 10) }
+  let!(:reachable_users_service) { ReachableUsersService.new(campaign) }
+
+  describe "get_vaccination_center_grid_cells" do
+    it "covering is valid" do
+      range = ::GridCoordsService.new(vaccination_center.lat, vaccination_center.lon).get_covering(campaign.max_distance_in_meters)
+      expect(range[:center_cell][:i]).to eq(16566)
+      expect(range[:center_cell][:j]).to eq(12164)
+      expect(range[:dist_cells]).to eq(6)
+      expect(range[:cells].length).to eq(113)
+
+      lat_lon_center = get_lat_lng_for_number(range[:center_cell][:i], range[:center_cell][:j], DEFAULT_ZOOM_LEVEL)
+      expect(lat_lon_center[:lat]).to be_within(0.01).of(42)
+      expect(lat_lon_center[:lon]).to be_within(0.01).of(2)
+    end
+  end
+
+  describe "get_users_with_random should find users" do
+    before do
+      User.create(
+        firstname: Faker::Name.first_name,
+        lastname: Faker::Name.last_name,
+        email: Faker::Internet.unique.email(domain: "covidliste.com"),
+        birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
+        address: Faker::Address.full_address,
+        phone_number: "+33601020304",
+        toc: true,
+        statement: true,
+        confirmed_at: Time.now.utc,
+        lat: 42,
+        lon: 2,
+      )
+    end
+    it "get user" do
+      resp = reachable_users_service.get_users_with_random(5)
+      user = resp[0]
+
+      expect(user.grid_i).to be_within(2).of(16565)
+      expect(user.grid_j).to be_within(2).of(12163)
+    end
+  end
+
+  describe "get_users_with_random should not find users" do
+    before do
+      User.create(
+        firstname: Faker::Name.first_name,
+        lastname: Faker::Name.last_name,
+        email: Faker::Internet.unique.email(domain: "covidliste.com"),
+        birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
+        address: Faker::Address.full_address,
+        phone_number: "+33601020304",
+        toc: true,
+        statement: true,
+        confirmed_at: Time.now.utc,
+        lat: 42.01665183556824,
+        lon: 1.93359375,
+      )
+    end
+    it "get user" do
+      resp = reachable_users_service.get_users_with_random(5)
+      expect(resp.length).to eq(0)
+    end
+  end
+end

--- a/spec/services/reachable_users_service.rb
+++ b/spec/services/reachable_users_service.rb
@@ -48,7 +48,7 @@ RSpec.describe ReachableUsersService, type: :service do
     it "get user" do
       resp = reachable_users_service.get_users_with_random(5)
       user = resp[0]
-
+      # lat/lon randomisation can move cell around a bit
       expect(user.grid_i).to be_within(2).of(16565)
       expect(user.grid_j).to be_within(2).of(12163)
     end
@@ -73,6 +73,60 @@ RSpec.describe ReachableUsersService, type: :service do
     it "get user" do
       resp = reachable_users_service.get_users_with_random(5)
       expect(resp.length).to eq(0)
+    end
+  end
+
+  describe "get_users_with_v2 should find users" do
+    before do
+      User.create(
+        firstname: Faker::Name.first_name,
+        lastname: Faker::Name.last_name,
+        email: Faker::Internet.unique.email(domain: "covidliste.com"),
+        birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
+        address: Faker::Address.full_address,
+        phone_number: "+33601020304",
+        toc: true,
+        statement: true,
+        confirmed_at: Time.now.utc,
+        lat: 42,
+        lon: 2
+      )
+      User.create(
+        firstname: Faker::Name.first_name,
+        lastname: Faker::Name.last_name,
+        email: Faker::Internet.unique.email(domain: "covidliste.com"),
+        birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
+        address: Faker::Address.full_address,
+        phone_number: "+33601020304",
+        toc: true,
+        statement: true,
+        confirmed_at: Time.now.utc,
+        lat: 42,
+        lon: 2
+      )
+      User.create(
+        firstname: Faker::Name.first_name,
+        lastname: Faker::Name.last_name,
+        email: Faker::Internet.unique.email(domain: "covidliste.com"),
+        birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
+        address: Faker::Address.full_address,
+        phone_number: "+33601020304",
+        toc: true,
+        statement: true,
+        confirmed_at: Time.now.utc,
+        lat: 42.01665183556824,
+        lon: 1.93359375
+      )
+    end
+    it "get user" do
+      resp = reachable_users_service.get_users_with_v2(5)
+
+      expect(resp.length).to eq(2)
+
+      user = resp[0]
+      # lat/lon randomisation can move cell around a bit
+      expect(user.grid_i).to be_within(2).of(16565)
+      expect(user.grid_j).to be_within(2).of(12163)
     end
   end
 end

--- a/spec/services/reachable_users_service.rb
+++ b/spec/services/reachable_users_service.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 def get_lat_lng_for_number(xtile, ytile, zoom)
-  n = 2.0 ** zoom
+  n = 2.0**zoom
   lon_deg = xtile / n * 360.0 - 180.0
-  lat_rad = Math::atan(Math::sinh(Math::PI * (1 - 2 * ytile / n)))
+  lat_rad = Math.atan(Math.sinh(Math::PI * (1 - 2 * ytile / n)))
   lat_deg = 180.0 * (lat_rad / Math::PI)
-  {:lat => lat_deg, :lon => lon_deg}
+  {lat: lat_deg, lon: lon_deg}
 end
 
 DEFAULT_ZOOM_LEVEL = 15
@@ -42,7 +42,7 @@ RSpec.describe ReachableUsersService, type: :service do
         statement: true,
         confirmed_at: Time.now.utc,
         lat: 42,
-        lon: 2,
+        lon: 2
       )
     end
     it "get user" do
@@ -67,7 +67,7 @@ RSpec.describe ReachableUsersService, type: :service do
         statement: true,
         confirmed_at: Time.now.utc,
         lat: 42.01665183556824,
-        lon: 1.93359375,
+        lon: 1.93359375
       )
     end
     it "get user" do

--- a/spec/services/reachable_users_service.rb
+++ b/spec/services/reachable_users_service.rb
@@ -14,6 +14,7 @@ RSpec.describe ReachableUsersService, type: :service do
   let!(:vaccination_center) { create(:vaccination_center, lat: 42, lon: 2) }
   let!(:campaign) { build(:campaign, vaccination_center: vaccination_center, max_distance_in_meters: 5000, min_age: 18, max_age: 130, available_doses: 10) }
   let!(:reachable_users_service) { ReachableUsersService.new(campaign) }
+  email_domain = "covidliste.com"
 
   describe "get_vaccination_center_grid_cells" do
     it "covering is valid" do
@@ -34,10 +35,10 @@ RSpec.describe ReachableUsersService, type: :service do
       User.create(
         firstname: Faker::Name.first_name,
         lastname: Faker::Name.last_name,
-        email: Faker::Internet.unique.email(domain: "covidliste.com"),
+        email: Faker::Internet.unique.email(domain: email_domain),
         birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
         address: Faker::Address.full_address,
-        phone_number: "+33601020304",
+        phone_number: Faker::PhoneNumber.cell_phone_in_e164,
         toc: true,
         statement: true,
         confirmed_at: Time.now.utc,
@@ -45,8 +46,10 @@ RSpec.describe ReachableUsersService, type: :service do
         lon: 2
       )
     end
-    it "get user" do
+    it "get user single" do
       resp = reachable_users_service.get_users_with_random(5)
+      expect(resp.length).to eq(1)
+
       user = resp[0]
       # lat/lon randomisation can move cell around a bit
       expect(user.grid_i).to be_within(2).of(16565)
@@ -59,10 +62,10 @@ RSpec.describe ReachableUsersService, type: :service do
       User.create(
         firstname: Faker::Name.first_name,
         lastname: Faker::Name.last_name,
-        email: Faker::Internet.unique.email(domain: "covidliste.com"),
+        email: Faker::Internet.unique.email(domain: email_domain),
         birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
         address: Faker::Address.full_address,
-        phone_number: "+33601020304",
+        phone_number: Faker::PhoneNumber.cell_phone_in_e164,
         toc: true,
         statement: true,
         confirmed_at: Time.now.utc,
@@ -70,7 +73,7 @@ RSpec.describe ReachableUsersService, type: :service do
         lon: 1.93359375
       )
     end
-    it "get user" do
+    it "get no users" do
       resp = reachable_users_service.get_users_with_random(5)
       expect(resp.length).to eq(0)
     end
@@ -78,39 +81,28 @@ RSpec.describe ReachableUsersService, type: :service do
 
   describe "get_users_with_v2 should find users" do
     before do
+      (1..5).each do |i|
+        User.create(
+          firstname: Faker::Name.first_name,
+          lastname: Faker::Name.last_name,
+          email: Faker::Internet.unique.email(domain: email_domain),
+          birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
+          address: Faker::Address.full_address,
+          phone_number: Faker::PhoneNumber.cell_phone_in_e164,
+          toc: true,
+          statement: true,
+          confirmed_at: Time.now.utc,
+          lat: 42,
+          lon: 2
+        )
+      end
       User.create(
         firstname: Faker::Name.first_name,
         lastname: Faker::Name.last_name,
-        email: Faker::Internet.unique.email(domain: "covidliste.com"),
+        email: Faker::Internet.unique.email(domain: email_domain),
         birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
         address: Faker::Address.full_address,
-        phone_number: "+33601020304",
-        toc: true,
-        statement: true,
-        confirmed_at: Time.now.utc,
-        lat: 42,
-        lon: 2
-      )
-      User.create(
-        firstname: Faker::Name.first_name,
-        lastname: Faker::Name.last_name,
-        email: Faker::Internet.unique.email(domain: "covidliste.com"),
-        birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
-        address: Faker::Address.full_address,
-        phone_number: "+33601020304",
-        toc: true,
-        statement: true,
-        confirmed_at: Time.now.utc,
-        lat: 42,
-        lon: 2
-      )
-      User.create(
-        firstname: Faker::Name.first_name,
-        lastname: Faker::Name.last_name,
-        email: Faker::Internet.unique.email(domain: "covidliste.com"),
-        birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
-        address: Faker::Address.full_address,
-        phone_number: "+33601020304",
+        phone_number: Faker::PhoneNumber.cell_phone_in_e164,
         toc: true,
         statement: true,
         confirmed_at: Time.now.utc,
@@ -118,10 +110,10 @@ RSpec.describe ReachableUsersService, type: :service do
         lon: 1.93359375
       )
     end
-    it "get user" do
-      resp = reachable_users_service.get_users_with_v2(5)
+    it "get 5 users" do
+      resp = reachable_users_service.get_users_with_v2(10)
 
-      expect(resp.length).to eq(2)
+      expect(resp.length).to eq(5)
 
       user = resp[0]
       # lat/lon randomisation can move cell around a bit


### PR DESCRIPTION
Closes #659 

This PR generates the list of grid cells to encompass desired area and applies to queries for `get_users_with_random` and `get_users_with_v2`.

BTW, I wanted to use `.where("(grid_i, grid_j) IN (?)", cells)` syntax, but rails doesn't handle `IN` statement when using pairs of arrays.