### PR TITLE
Small UI improvements of partners area + Link to documents folder

### DIFF
--- a/app/controllers/partners/vaccination_centers_controller.rb
+++ b/app/controllers/partners/vaccination_centers_controller.rb
@@ -7,7 +7,7 @@ module Partners
     helper_method :sort_column, :sort_direction
 
     def index
-      @vaccination_centers = current_partner.vaccination_centers
+      @vaccination_centers = current_partner.vaccination_centers.includes([:partner_vaccination_centers, :partners])
       @unconfirmed_vaccination_centers = current_partner.unconfirmed_vaccination_centers
     end
 

--- a/app/views/partners/campaigns/show.html.erb
+++ b/app/views/partners/campaigns/show.html.erb
@@ -76,14 +76,16 @@
     <p class="mb-5">
       <strong>Important :</strong> Si vous avez l’impression que la campagne ne se remplit pas, ne créez pas une
       nouvelle campagne pour les mêmes doses disponibles. <a href="/faq">Nous recontacterons par SMS tous les
-      volontaires proches de votre centre</a> s’il vous reste des doses au cours de la campagne.
+      volontaires proches de votre lieu de vaccination</a> s’il vous reste des doses au cours de la campagne.
     </p>
   <% end %>
 
   <% if @campaign.running? %>
     <div class="alert alert-primary" role="alert">
       <strong>Votre campagne est actuellement en cours.</strong><br/>
-      La liste des volontaires ne sera complète que lorsque votre campagne sera terminée ou interrompue.
+      La liste des volontaires ne sera complète que lorsque votre campagne sera terminée ou interrompue.<br />
+      Dernière mise à jour de la liste : <%= l Time.zone.now %>
+      <%= link_to "Mettre à jour la liste maintenant", partners_campaign_path(@campaign) %>
     </div>
   <% elsif @campaign.completed? || @campaign.canceled? %>
     <div class="alert alert-success" role="alert">
@@ -97,27 +99,14 @@
     </div>
   <% end %>
 
-  <h2 class="mt-5 mb-4">
-    Volontaires confirmés
-  </h2>
+  <h2 class="mt-5 mb-4">Volontaires confirmés</h2>
 
   <p>
-    Les volontaires devront se présenter le <%= @campaign.starts_at.strftime('%d/%m/%Y') %> entre
-    <%= @campaign.starts_at.strftime('%Hh%M') %> et <%= @campaign.ends_at.strftime('%Hh%M')%>
+    Les volontaires se présenteront le <%= l(@campaign.starts_at, format: '%e %B %Y') %> entre
+    <%= l(@campaign.starts_at, format: '%Hh%M') %> et <%= l(@campaign.ends_at, format: '%Hh%M') %>.
   </p>
 
-  <p>
-    Ces informations seront supprimées définitivement dans quelques jours.
-    <br>
-    Ces informations ne doivent être utilisées que pour la vaccination des volontaires par votre centre.
-  </p>
-
-  <% if @campaign.matches.confirmed.any? %>
-    <p class="float-right">
-      <%= link_to "Télécharger la liste (CSV)", partners_campaign_path(@campaign, format: :csv) %>
-    </p>
-
-    <div class="table-responsive">
+  <div class="table-responsive">
       <table class="table table-bordered table-sm">
         <thead class="thead-light">
         <tr>
@@ -129,35 +118,58 @@
         </thead>
 
         <tbody>
-          <% @campaign.matches.confirmed.order(:confirmed_at).each do |match| %>
-            <% user = match.user %>
+          <% if @campaign.matches.confirmed.any? %>
+            <% @campaign.matches.confirmed.order(:confirmed_at).each do |match| %>
+              <% user = match.user %>
 
-            <tr>
-              <% if user.nil? %>
-                <td colspan="3">
-                  <em class="text-muted">
-                    Ce volontaire a confirmé le RDV puis a supprimé son compte.
-                  </em>
-                </td>
-              <% else %>
-                <% if user.anonymized_at %>
+              <tr>
+                <% if user.nil? %>
                   <td colspan="3">
                     <em class="text-muted">
-                      Ce volontaire a été anonymisé quelques jours après le RDV.
+                      Ce volontaire a confirmé le RDV puis a supprimé son compte.
                     </em>
                   </td>
                 <% else %>
-                  <td> <%= user %> </td>
-                  <td> <%= user.human_friendly_phone_number %> </td>
-                  <td> <%= user.birthdate.strftime("%d/%m/%Y") %> </td>
+                  <% if user.anonymized_at %>
+                    <td colspan="3">
+                      <em class="text-muted">
+                        Ce volontaire a été anonymisé quelques jours après le RDV.
+                      </em>
+                    </td>
+                  <% else %>
+                    <td> <%= user %> </td>
+                    <td> <%= user.human_friendly_phone_number %> </td>
+                    <td> <%= user.birthdate.strftime("%d/%m/%Y") %> </td>
+                  <% end %>
                 <% end %>
-              <% end %>
 
-              <td> <%= l match.confirmed_at %> </td>
+                <td> <%= l match.confirmed_at %> </td>
+              </tr>
+            <% end %>
+          <% else %>
+            <tr class="text-center">
+              <td colspan="4">
+                <em class="text-muted">
+                  <% if @campaign.running? %>
+                    Aucun volontaire confirmé pour l'instant
+                  <% else %>
+                    Aucun volontaire confirmé
+                  <% end %>
+                </em>
+              </td>
             </tr>
           <% end %>
         </tbody>
       </table>
+
+      <p class="text-right mt-0">
+        <%= link_to "Télécharger la liste (format CSV)", partners_campaign_path(@campaign, format: :csv) %>
+      </p>
+
+      <p class="small text-muted">
+        Les informations des volontaires seront supprimées définitivement dans quelques jours.
+        <br>
+        Elles doivent être utilisées uniquement pour la vaccination des volontaires et pas à d'autres fins.
+      </p>
     </div>
-  <% end %>
 </div>

--- a/app/views/partners/vaccination_centers/index.html.erb
+++ b/app/views/partners/vaccination_centers/index.html.erb
@@ -9,7 +9,7 @@
 
   <p class="small">
     <%= icon("fas", "phone", current_partner.human_friendly_phone_number) %>
-    <br />
+    <br/>
     Informations incorrectes ?
     <%= link_to "Modifiez votre profil", partners_path %>
   </p>
@@ -18,7 +18,7 @@
     Bienvenue dans l’espace <strong>réservé aux professionnels de santé assurant la vaccination</strong>.
     <br>
     Merci de nous avoir rejoint et merci pour ce que vous faites pour aider à la vaccination du plus grand nombre !
-    <br />
+    <br/>
     Un problème, une question ? Contactez-nous sur
     <%= link_to "partenaires@covidliste.com", "mailto:partenaires@covidliste.com" %>
   </p>
@@ -31,61 +31,60 @@
     <div class="table-responsive">
       <table class="table table-bordered table-sm">
         <thead class="thead-light">
-          <tr>
-            <th scope="col"> Nom </th>
-            <th scope="col"> Coordonnées </th>
-            <th scope="col"> Vaccins </th>
-            <th scope="col"> Collaborateurs </th>
-            <th scope="col" class="text-center"> Actions </th>
-          </tr>
+        <tr>
+          <th scope="col"> Nom</th>
+          <th scope="col"> Coordonnées</th>
+          <th scope="col"><abbr data-toggle="tooltip" title="Collaborateurs">Collab.</abbr></th>
+          <th scope="col" class="text-center"> Actions</th>
+        </tr>
         </thead>
 
         <tbody>
-          <% @vaccination_centers.each do |vaccination_center| %>
-            <tr>
-              <td>
-                <strong>
-                  <%= link_to vaccination_center.name, partners_vaccination_center_path(vaccination_center.id) %>
-                </strong>
-                <br>
-                <i><%= vaccination_center.kind %></i>
-                <br>
-                <%= vaccination_center.description %>
-              </td>
+        <% @vaccination_centers.each do |vaccination_center| %>
+          <tr>
+            <td>
+              <strong>
+                <%= link_to vaccination_center.name, partners_vaccination_center_path(vaccination_center.id) %>
+              </strong>
+              <br>
+              <i><%= vaccination_center.kind %></i>
+              <br>
+              <%= vaccination_center.description %>
+            </td>
 
-              <td>
-                <%= icon("fas", "phone", vaccination_center.human_friendly_phone_number) %>
-                <br>
-                <%= vaccination_center.address %>
-              </td>
+            <td class="small">
+              <%= icon("fas", "phone", vaccination_center.human_friendly_phone_number) %>
+              <br>
+              <%= vaccination_center.address %>
+              <br>
+              <% if vaccination_center.pfizer %>
+                <span class="mr-1"> <%= Vaccine::Brands::PFIZER.capitalize %> </span>
+              <% end %>
+              <% if vaccination_center.moderna %>
+                <span class="mr-1"> <%= Vaccine::Brands::MODERNA.capitalize %> </span>
+              <% end %>
+              <% if vaccination_center.astrazeneca %>
+                <span class="mr-1"> <%= Vaccine::Brands::ASTRAZENECA.capitalize %> </span>
+              <% end %>
+              <% if vaccination_center.janssen %>
+                <span class="mr-1"> <%= Vaccine::Brands::JANSSEN.capitalize %> </span>
+              <% end %>
+            </td>
 
-              <td>
-                <% if vaccination_center.pfizer %>
-                  <span class="mr-1"> <%= Vaccine::Brands::PFIZER.capitalize %> </span><br />
-                <% end %>
-                <% if vaccination_center.moderna %>
-                  <span class="mr-1"> <%= Vaccine::Brands::MODERNA.capitalize %> </span><br />
-                <% end %>
-                <% if vaccination_center.astrazeneca %>
-                  <span class="mr-1"> <%= Vaccine::Brands::ASTRAZENECA.capitalize %> </span><br />
-                <% end %>
-                <% if vaccination_center.janssen %>
-                  <span class="mr-1"> <%= Vaccine::Brands::JANSSEN.capitalize %> </span><br />
-                <% end %>
-              </td>
-
-              <td>
+            <td class="small text-center" data-toggle="tooltip" data-html="true" title="
+                Collaborateurs : <br>
                 <% vaccination_center.partners.each do |partner| %>
-                  <%= partner.name %>
+                  - <%= partner.name %>
                   <br>
-                <% end %>
-              </td>
+                <% end %>">
+              <%= icon("fas", "user", vaccination_center.partners.count) %>
+            </td>
 
-              <td class="text-center">
-                <%= link_to "Voir / Gérer les campagnes", partners_vaccination_center_path(vaccination_center.id) %>
-              </td>
-            </tr>
-          <% end %>
+            <td class="text-center">
+              <%= link_to "Voir / Gérer les campagnes", partners_vaccination_center_path(vaccination_center.id), class: "btn btn-primary btn-sm" %>
+            </td>
+          </tr>
+        <% end %>
         </tbody>
       </table>
     </div>
@@ -101,11 +100,12 @@
     </p>
 
     <div class="alert alert-primary" role="alert" style="position: inherit">
-      Nous allons vous contacter dans les prochaines heures ou les prochains jours pour valider vos lieux de vaccination en attente.
-      <br />
+      Nous allons vous contacter dans les prochaines heures ou les prochains jours pour valider vos lieux de vaccination
+      en attente.
+      <br/>
       Vérifiez vos informations, et particulièrement votre numéro de téléphone portable :
       <strong><%= current_partner.human_friendly_phone_number %></strong>
-      <br />
+      <br/>
       Numéro incorrect ?
       <%= link_to "Modifiez-le sur votre page profil", partners_path %>
     </div>
@@ -114,10 +114,10 @@
       <table class="table table-bordered table-sm">
         <thead class="thead-light">
         <tr>
-          <th> Nom </th>
-          <th> Coordonnées </th>
-          <th> Vaccins </th>
-          <th> État </th>
+          <th scope="col"> Nom</th>
+          <th scope="col"> Coordonnées</th>
+          <th scope="col"><abbr data-toggle="tooltip" title="Collaborateurs">Collab.</abbr></th>
+          <th scope="col"> État</th>
         </tr>
         </thead>
 
@@ -134,25 +134,32 @@
               <%= vaccination_center.description %>
             </td>
 
-            <td>
+            <td class="small">
               <%= icon("fas", "phone", vaccination_center.human_friendly_phone_number) %>
               <br>
               <%= vaccination_center.address %>
-            </td>
-
-            <td>
+              <br>
               <% if vaccination_center.pfizer %>
-                <span class="mr-1"> <%= Vaccine::Brands::PFIZER.capitalize %> </span><br />
+                <span class="mr-1"> <%= Vaccine::Brands::PFIZER.capitalize %> </span>
               <% end %>
               <% if vaccination_center.moderna %>
-                <span class="mr-1"> <%= Vaccine::Brands::MODERNA.capitalize %> </span><br />
+                <span class="mr-1"> <%= Vaccine::Brands::MODERNA.capitalize %> </span>
               <% end %>
               <% if vaccination_center.astrazeneca %>
-                <span class="mr-1"> <%= Vaccine::Brands::ASTRAZENECA.capitalize %> </span><br />
+                <span class="mr-1"> <%= Vaccine::Brands::ASTRAZENECA.capitalize %> </span>
               <% end %>
               <% if vaccination_center.janssen %>
-                <span class="mr-1"> <%= Vaccine::Brands::JANSSEN.capitalize %> </span><br />
+                <span class="mr-1"> <%= Vaccine::Brands::JANSSEN.capitalize %> </span>
               <% end %>
+            </td>
+
+            <td class="small text-center" data-toggle="tooltip" data-html="true" title="
+                Collaborateurs : <br>
+                <% vaccination_center.partners.each do |partner| %>
+                  - <%= partner.name %>
+                  <br>
+                <% end %>">
+              <%= icon("fas", "user", vaccination_center.partners.count) %>
             </td>
 
             <td>
@@ -165,73 +172,87 @@
     </div>
   <% end %>
 
-  <p>
-    <%= link_to "Demander la création d’un nouveau lieu de vaccination", new_partners_vaccination_center_path, class: "btn btn-primary btn-sm" %>
-  </p>
+  <% if @vaccination_centers.any? || @unconfirmed_vaccination_centers.any? %>
+    <p class="small">
+      Vous gèrez une autre lieu de vaccination ?
+      <%= link_to "Demandez la création d’un autre lieu de vaccination", new_partners_vaccination_center_path %>
+    </p>
+  <% else %>
+    <p class="small">
+      <%= link_to "Demander la création d’un nouveau lieu de vaccination", new_partners_vaccination_center_path, class: "btn btn-primary" %>
+    </p>
+  <% end %>
 
-  <p class="mt-4 small">
-    Si vous souhaitez rejoindre un centre déjà existant sur Covidliste, contactez-nous sur
-    <%= link_to "partenaires@covidliste.com", "mailto:partenaires@covidliste.com" %>.
-  </p>
+    <p class="mt-4 small">
+      Si vous souhaitez rejoindre un lieu de vaccination déjà existant sur Covidliste, contactez-nous sur
+      <%= link_to "partenaires@covidliste.com", "mailto:partenaires@covidliste.com" %>.
+    </p>
 
-  <% if @vaccination_centers.any? %>
-    <div class="mt-5 mb-5">
-      <p>
-        Êtes-vous satisfait de Covidliste ?
-        <button class="btn btn-sm btn-success mx-3" type="button"
-                data-toggle="collapse" data-target="#collapseRecommend"
-                aria-expanded="false" aria-controls="collapseRecommend">
-          Recommandez le service à un confrère
-        </button>
-      </p>
-      <div id="collapseRecommend" class="collapse mt-4">
-        <div class="row">
-          <div class="col-12 col-lg-6">
-            <p class="mt-4">
-              Si vous êtes satisfait de Covidliste, nous avons préparé pour vous un exemple de mail simple et
-              prêt à l'emploi pour recommander le service à un confrère en un clic :
-            </p>
-            <p>
-              <%= link_to icon("fas", "envelope") + " Recommander par mail", "mailto:?cc=partenaires@covidliste.com&subject=Je%20vous%20recommande%20Covidliste%20pour%20trouver%20des%20volontaires%20%C3%A0%20la%20vaccination&body=Cher%20confr%C3%A8re%2C%0D%0A%0D%0AJe%20souhaite%20vous%20faire%20part%20de%20l'existence%20de%20Covidliste%2C%20une%20plateforme%20sur%20laquelle%20je%20suis%20inscrit%2C%20qui%20permet%20aux%20professionnels%20de%20sant%C3%A9%20de%20trouver%20des%20volontaires%20%C3%A0%20la%20vaccination%20en%20cas%20de%20doses%20de%20vaccin%20surnum%C3%A9raires.%0D%0A%0D%0AVoici%20l'adresse%20pour%20s'inscrire%20en%20tant%20que%20professionnel%20%3A%20https%3A%2F%2Fwww.covidliste.com%2Fpartenaires%2F%0D%0A%0D%0AL'%C3%A9quipe%20de%20Covidliste%20est%20en%20copie%20de%20ce%20mail%20pour%20toute%20question%20ou%20besoin%20d'accompagnement.%0D%0A%0D%0ACordialement", class: "btn btn-sm btn-outline-primary", target: "_blank", rel: "noopener" %>
-            </p>
-            <p class="text-center text-muted font-italic my-4">
-              ou
-            </p>
-            <p>
-              Nous mettons à votre disposition ci-contre un exemple de contenu mail utilisable pour
-              recommander Covidliste à un confrère
-            </p>
-          </div>
-          <div class="col-12 col-lg-6">
-            <div class="card">
-              <div class="card-body small">
-                <p>
-                  Cc : <em><%=  link_to "partenaires@covidliste.com", "mailto:partenaires@covidliste.com" %></em><br />
-                  Sujet : <em>Je vous recommande Covidliste pour trouver des volontaires à la vaccination</em>
-                </p>
-                <p>
-                  Cher confrère,<br />
-                  <br />
-                  Je souhaite vous faire part de l'existence de Covidliste, une plateforme sur laquelle je suis
-                  inscrit, qui permet aux professionnels de santé de trouver des volontaires à la vaccination
-                  en cas de doses de vaccin surnuméraires.<br />
-                  <br />
-                  Voici l'adresse pour s'inscrire en tant que professionnel : https://www.covidliste.com/partenaires/<br />
-                  <br />
-                  L'équipe de Covidliste est en copie de ce mail pour toute question ou besoin d'accompagnement.<br />
-                  <br />
-                  Cordialement
-                </p>
+    <% if @vaccination_centers.any? %>
+      <div class="mt-5 mb-5">
+        <p>
+          Êtes-vous satisfait de Covidliste ?
+          <button class="btn btn-sm btn-success mx-3" type="button"
+                  data-toggle="collapse" data-target="#collapseRecommend"
+                  aria-expanded="false" aria-controls="collapseRecommend">
+            Recommandez le service à un confrère
+          </button>
+        </p>
+        <div id="collapseRecommend" class="collapse mt-4">
+          <div class="row">
+            <div class="col-12 col-lg-6">
+              <p class="mt-4">
+                Si vous êtes satisfait de Covidliste, nous avons préparé pour vous un exemple de mail simple et
+                prêt à l'emploi pour recommander le service à un confrère en un clic :
+              </p>
+              <p>
+                <%= link_to icon("fas", "envelope") + " Recommander par mail", "mailto:?cc=partenaires@covidliste.com&subject=Je%20vous%20recommande%20Covidliste%20pour%20trouver%20des%20volontaires%20%C3%A0%20la%20vaccination&body=Cher%20confr%C3%A8re%2C%0D%0A%0D%0AJe%20souhaite%20vous%20faire%20part%20de%20l'existence%20de%20Covidliste%2C%20une%20plateforme%20sur%20laquelle%20je%20suis%20inscrit%2C%20qui%20permet%20aux%20professionnels%20de%20sant%C3%A9%20de%20trouver%20des%20volontaires%20%C3%A0%20la%20vaccination%20en%20cas%20de%20doses%20de%20vaccin%20surnum%C3%A9raires.%0D%0A%0D%0AVoici%20l'adresse%20pour%20s'inscrire%20en%20tant%20que%20professionnel%20%3A%20https%3A%2F%2Fwww.covidliste.com%2Fpartenaires%2F%0D%0A%0D%0AL'%C3%A9quipe%20de%20Covidliste%20est%20en%20copie%20de%20ce%20mail%20pour%20toute%20question%20ou%20besoin%20d'accompagnement.%0D%0A%0D%0ACordialement", class: "btn btn-sm btn-outline-primary", target: "_blank", rel: "noopener" %>
+              </p>
+              <p class="text-center text-muted font-italic my-4">
+                ou
+              </p>
+              <p>
+                Nous mettons à votre disposition ci-contre un exemple de contenu mail utilisable pour
+                recommander Covidliste à un confrère
+              </p>
+            </div>
+            <div class="col-12 col-lg-6">
+              <div class="card">
+                <div class="card-body small">
+                  <p>
+                    Cc : <em><%= link_to "partenaires@covidliste.com", "mailto:partenaires@covidliste.com" %></em><br/>
+                    Sujet : <em>Je vous recommande Covidliste pour trouver des volontaires à la vaccination</em>
+                  </p>
+                  <p>
+                    Cher confrère,<br/>
+                    <br/>
+                    Je souhaite vous faire part de l'existence de Covidliste, une plateforme sur laquelle je suis
+                    inscrit, qui permet aux professionnels de santé de trouver des volontaires à la vaccination
+                    en cas de doses de vaccin surnuméraires.<br/>
+                    <br/>
+                    Voici l'adresse pour s'inscrire en tant que professionnel :
+                    https://www.covidliste.com/partenaires/<br/>
+                    <br/>
+                    L'équipe de Covidliste est en copie de ce mail pour toute question ou besoin d'accompagnement.<br/>
+                    <br/>
+                    Cordialement
+                  </p>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </div>
+    <% end %>
+
+    <p class="mb-5">
+      Besoin de documents pour communiquer à propos de Covidliste avec vos collègues, confrères, visiteurs ou patients ?<br/>
+      <small>Nous vous mettons à disposition un ensemble de documents imprimables adaptés à chaque public.</small>
+      <br />
+      <%= link_to "Documents pour les professionnels", "https://drive.google.com/drive/folders/1g79baMWlOFjZAcCrK7sa6uUNlyQBuzyC?usp=sharing", class: "btn btn-info btn-sm mt-2", target: "_blank", rel: "noopener" %>
+    </p>
+
+    <hr>
+
+    <%= link_to "Se déconnecter", destroy_partner_session_path, method: :delete, class: "btn btn-warning" %>
     </div>
-  <% end %>
-
-
-  <hr>
-
-  <%= link_to "Se déconnecter", destroy_partner_session_path, method: :delete, class: "btn btn-warning" %>
-</div>

--- a/app/views/partners/vaccination_centers/show.html.erb
+++ b/app/views/partners/vaccination_centers/show.html.erb
@@ -33,7 +33,7 @@
         ></div>
       <% else %>
         <div class="alert alert-danger mb-4 small" role="alert" style="position: inherit">
-          Votre centre n'est pas correctement géocodé. Veuillez nous contacter. 
+          Votre lieu de vaccination n'est pas correctement localisé. Veuillez nous contacter.
         </div>
       <% end %>
     </div>
@@ -49,33 +49,54 @@
     </h5>
 
     <div class="table-responsive">
-      <table class="table table-bordered table-sm">
+      <table class="table table-bordered table-sm text-center">
         <thead class="thead-light">
           <tr>
-            <th> # </th>
-            <th> Statut </th>
-            <th> Volontaires confirmés </th>
-            <th> Doses disponibles </th>
-            <th> Vaccin </th>
-            <th> Date et heure </th>
-            <th> Âge </th>
-            <th> Distance </th>
+            <th scope="col"> # </th>
+            <th scope="col"> Statut </th>
+            <th scope="col"> Lancée le </th>
+            <th scope="col"> Volontaires confirmés </th>
+            <th scope="col"> Doses </th>
+            <th scope="col"> Rendez-vous </th>
+            <th scope="col"> Critères </th>
+            <th scope="col"> Actions </th>
           </tr>
         </thead>
 
         <tbody>
-        <% @vaccination_center.campaigns.order(id: :desc).each do |campaign| %>
-          <tr>
-            <th> <%= link_to campaign.id, partners_campaign_path(campaign) %> </th>
-            <td> <%= french_status(campaign) %> </td>
-            <td> <%= campaign.matches.confirmed.size %> </td>
-            <td> <%= campaign.available_doses %> </td>
-            <td> <%= campaign.vaccine_type.capitalize %> </td>
-            <td> <%= l campaign.starts_at %> </td>
-            <td> <%= campaign.min_age %>-<%= campaign.max_age %> ans</td>
-            <td> <%= campaign.max_distance_in_meters/1000 %> km</td>
-          </tr>
-        <% end %>
+          <% @vaccination_center.campaigns.order(id: :desc).each do |campaign| %>
+            <tr>
+              <td class="font-weight-bold"> <%= link_to campaign.id, partners_campaign_path(campaign) %> </td>
+              <td>
+                <%= link_to (content_tag :span, french_status(campaign), class: "badge badge-sm #{status_badge(campaign)}"), partners_campaign_path(campaign) %>
+              </td>
+              <td class=" small">
+                <%= l campaign.created_at %><br />
+                <span class="text-muted">par <%= campaign.partner.name %></span>
+              </td>
+              <td> <%= campaign.matches.confirmed.size %> </td>
+              <td>
+                <%= campaign.available_doses %>
+                <small class="text-muted"><%= campaign.available_doses > 1 ? "doses" : "dose" %></small><br />
+                <%= campaign.vaccine_type.capitalize %>
+              </td>
+              <td>
+                <%= l(campaign.starts_at, format: '%e %B %Y') %><br />
+                <small class="text-muted">entre</small>
+                <%= l(campaign.starts_at, format: '%Hh%M') %>
+                <small class="text-muted">et</small>
+                <%= l(campaign.ends_at, format: '%Hh%M') %>
+              </td>
+              <td>
+                <%= campaign.min_age %>-<%= campaign.max_age %> <small class="text-muted">ans</small><br />
+                <%= campaign.max_distance_in_meters/1000 %> <small class="text-muted">km</small>
+              </td>
+
+              <td>
+                <%= link_to "Voir la campagne", partners_campaign_path(campaign), class: "btn btn-primary btn-sm" %>
+              </td>
+            </tr>
+          <% end %>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## Résumé

Petites améliorations d'interface de l'espace partenaires (pour que ce soit plus clair) : interface centres, interface campagnes, interface campagne. En attendant une vraie grosse refonte.
Ajout d'un lien vers les documents pour les partenaires (google drive)

## Détails

### Accueil centre
#### Avant
![screencapture-covidliste-carsso-dev-partners-vaccination-centers-2021-05-06-04_36_49](https://user-images.githubusercontent.com/666182/117234361-230cda80-ae25-11eb-9930-0e9e2b54dcbf.png)
### Après
![screencapture-covidliste-carsso-dev-partners-vaccination-centers-2021-05-06-04_34_37](https://user-images.githubusercontent.com/666182/117234367-24d69e00-ae25-11eb-950d-dc958b8d23a4.png)

### Gestion des campagnes
#### Avant
![screencapture-covidliste-carsso-dev-partners-vaccination-centers-16-2021-05-06-04_36_59](https://user-images.githubusercontent.com/666182/117234358-21dbad80-ae25-11eb-8cb1-437b7d566781.png)
### Après
![screencapture-covidliste-carsso-dev-partners-vaccination-centers-16-2021-05-06-04_34_12](https://user-images.githubusercontent.com/666182/117234371-26a06180-ae25-11eb-9ac6-eec28e5ae885.png)

### Gestion d'une campagne
#### Avant
![screencapture-covidliste-carsso-dev-partners-campaigns-14-2021-05-06-04_37_07](https://user-images.githubusercontent.com/666182/117234357-20aa8080-ae25-11eb-9daa-b4b6e532a3e6.png)
### Après
![screencapture-covidliste-carsso-dev-partners-campaigns-14-2021-05-06-04_34_01](https://user-images.githubusercontent.com/666182/117234375-27d18e80-ae25-11eb-9c0a-6d295ce60e28.png)


A relire en "ignore whitespaces" pour que ce soit plus facile.