### PR TITLE
Fix more 08 phone numbers

### DIFF
--- a/app/models/vaccination_center.rb
+++ b/app/models/vaccination_center.rb
@@ -1,6 +1,6 @@
 class VaccinationCenter < ApplicationRecord
   include HasPhoneNumberConcern
-  has_phone_number_types %i[fixed_line mobile voip premium_rate]
+  has_phone_number_types %i[fixed_line mobile voip premium_rate toll_free uan]
   module Kinds
     CABINET_INFIRMIER = "Cabinet infirmier"
     CABINET_MEDICAL = "Cabinet médical"


### PR DESCRIPTION
## Résumé

Autorise les numéros en 08 0*9* pour les centres de vaccination (qui ne sont pas dans la même categorie 🤷)
