### PR TITLE
Rediriger les volontaires vers leur profil après connexion

### DIFF
--- a/app/controllers/devise/passwordless/magic_links_controller.rb
+++ b/app/controllers/devise/passwordless/magic_links_controller.rb
@@ -26,6 +26,16 @@ class Devise::Passwordless::MagicLinksController < DeviseController
 
   private
 
+  def after_sign_in_path_for(resource)
+    if resource.is_a?(Partner)
+      partners_vaccination_centers_path
+    elsif resource.is_a?(User)
+      profile_path
+    else
+      new_user_session_path
+    end
+  end
+
   def create_params
     resource_params.permit(:email, :remember_me)
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,13 +94,12 @@ ActiveRecord::Schema.define(version: 2021_05_04_200923) do
   create_table "campaign_batches", force: :cascade do |t|
     t.bigint "campaign_id"
     t.bigint "vaccination_center_id"
-    t.bigint "partner_id"
     t.integer "size", null: false
     t.integer "duration_in_minutes", default: 10, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "partner_id"
     t.index ["campaign_id"], name: "index_campaign_batches_on_campaign_id"
-    t.index ["partner_id"], name: "index_campaign_batches_on_partner_id"
     t.index ["vaccination_center_id"], name: "index_campaign_batches_on_vaccination_center_id"
     t.check_constraint "duration_in_minutes > 0", name: "duration_in_minutes_gt_zero"
     t.check_constraint "size > 0", name: "size_gt_zero"
@@ -123,6 +122,7 @@ ActiveRecord::Schema.define(version: 2021_05_04_200923) do
     t.integer "status", default: 0
     t.datetime "canceled_at"
     t.string "algo_version"
+    t.jsonb "parameters"
     t.index ["partner_id"], name: "index_campaigns_on_partner_id"
     t.index ["status"], name: "index_campaigns_on_status"
     t.index ["vaccination_center_id"], name: "index_campaigns_on_vaccination_center_id"
@@ -255,11 +255,13 @@ ActiveRecord::Schema.define(version: 2021_05_04_200923) do
     t.string "city"
     t.string "geo_citycode"
     t.string "geo_context"
-    t.datetime "anonymized_at"
     t.boolean "statement", default: false
+    t.datetime "anonymized_at"
     t.datetime "statement_accepted_at"
     t.datetime "toc_accepted_at"
     t.string "email_domain"
+    t.integer "grid_i"
+    t.integer "grid_j"
     t.index ["anonymized_at"], name: "index_users_on_anonymized_at"
     t.index ["birthdate"], name: "index_users_on_birthdate"
     t.index ["city"], name: "index_users_on_city"
@@ -268,6 +270,8 @@ ActiveRecord::Schema.define(version: 2021_05_04_200923) do
     t.index ["email_bidx"], name: "index_users_on_email_bidx", unique: true
     t.index ["geo_citycode"], name: "index_users_on_geo_citycode"
     t.index ["geo_context"], name: "index_users_on_geo_context"
+    t.index ["grid_i"], name: "index_users_on_grid_i"
+    t.index ["grid_j"], name: "index_users_on_grid_j"
     t.index ["zipcode"], name: "index_users_on_zipcode"
   end
 
@@ -309,7 +313,7 @@ ActiveRecord::Schema.define(version: 2021_05_04_200923) do
   end
 
   add_foreign_key "campaign_batches", "campaigns"
-  add_foreign_key "campaign_batches", "partners"
+  add_foreign_key "campaign_batches", "partners", name: "campaign_batches_partner_id_fkey"
   add_foreign_key "campaign_batches", "vaccination_centers"
   add_foreign_key "campaigns", "partners"
   add_foreign_key "campaigns", "vaccination_centers"

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -113,9 +113,7 @@ RSpec.describe "Users", type: :system do
       visit users_magic_link_url({user: {email: user.email, token: token}})
 
       expect(page).to have_text("Connecté(e).")
-      expect(page).to have_text("Accélérons la campagne de vaccination.")
-
-      visit profile_url
+      expect(page).to have_text("Vous êtes inscrit sur Covidliste depuis")
     end
 
     it "it allows me to edit personal information " do


### PR DESCRIPTION
## Résumé

Les volontaires sont actuellement renvoyés vers la page d'acceuil après connexion, ils sont parfois perdus. En les amenant directement à leur profil, il peuvent facilement se désinscrire ou changer leurs informations.