### PR TITLE
anonymize users when destroy

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -22,7 +22,7 @@ module Admin
     end
 
     def destroy
-      @user.destroy
+      @user.anonymize!
 
       respond_to do |format|
         format.html { redirect_to admin_users_url, notice: "l'utilisateur a été supprimé." }

--- a/app/controllers/matches/users_controller.rb
+++ b/app/controllers/matches/users_controller.rb
@@ -6,7 +6,7 @@ module Matches
     end
 
     def destroy
-      @match.user.destroy
+      @match.user.anonymize!
       redirect_to root_path, notice: "🎉 🎉 🎉 Votre compte a été supprimé de nos serveurs. Portez-vous bien."
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -58,7 +58,8 @@ class UsersController < ApplicationController
   def delete
     @user = current_user
     authorize @user
-    @user.destroy
+    sign_out @user
+    @user.anonymize!
     flash[:success] = "Votre compte a bien été supprimé."
     redirect_to root_path
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -151,6 +151,8 @@ class User < ApplicationRecord
     self.geo_context = nil
     self.phone_number = nil
     self.birthdate = nil
+    self.grid_i = nil
+    self.grid_j = nil
     self.anonymized_at = Time.now.utc
     save(validate: false)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,6 +138,7 @@ class User < ApplicationRecord
 
   def anonymize!
     return unless anonymized_at.nil?
+    refuse_pending_matching
 
     self.email = "anonymous#{id}+#{rand(100_000_000)}@null"
     self.firstname = nil

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -87,15 +87,16 @@ RSpec.describe Admin::UsersController, type: :controller do
       subject { delete :destroy, params: {id: user_1.id} }
 
       it "deletes the user" do
-        expect { subject }.to change { User.count }.by(-1)
-        expect { user_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+        subject
+        expect(user_1.reload.anonymized_at?).to eq(true)
       end
 
       it "refuses the user pending matches" do
         expect { subject }.to change { Match.pending.count }.by(-1)
 
         expect(match.reload.refused_at).to_not be_nil
-        expect(match.user_id).to be_nil
+        expect(match.user_id).to_not be_nil
+        expect(match.user.anonymized_at?).to eq(true)
       end
     end
   end

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Admin Users", type: :system do
             find_by_id(dom_id(user, :delete)).click
           end
           expect(page).to have_text "l'utilisateur a été supprimé."
-          expect { user.reload.anonymized_at? }.to eq(true)
+          expect(user.reload.anonymized_at?).to eq(true)
         end
       end
     end

--- a/spec/system/admin/users_spec.rb
+++ b/spec/system/admin/users_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Admin Users", type: :system do
             find_by_id(dom_id(user, :delete)).click
           end
           expect(page).to have_text "l'utilisateur a été supprimé."
-          expect { user.reload }.to raise_error(ActiveRecord::RecordNotFound)
+          expect { user.reload.anonymized_at? }.to eq(true)
         end
       end
     end

--- a/spec/system/matches/destroy_user_account_spec.rb
+++ b/spec/system/matches/destroy_user_account_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "Destroy user account from match email", type: :system do
         accept_confirm_modal do
           click_on dom_id(user, :delete)
         end
-      end.to change { User.count }.by(-1)
+      end.to change { User.active.count }.by(-1)
         .and change { Match.pending.count }.by(-1)
     end
 

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -144,7 +144,7 @@ RSpec.describe "Users", type: :system do
         accept_confirm_modal do
           click_on "Supprimer mon compte"
         end
-      end.to change { User.count }.by(-1)
+      end.to change { User.active.count }.by(-1)
 
       expect(page).to have_text("Votre compte a bien été supprimé.")
     end
@@ -154,7 +154,7 @@ RSpec.describe "Users", type: :system do
         decline_confirm_modal do
           click_on "Supprimer mon compte"
         end
-      end.to change { User.count }.by(0)
+      end.to change { User.active.count }.by(0)
     end
 
     context "with a confirmed match" do
@@ -172,7 +172,7 @@ RSpec.describe "Users", type: :system do
           accept_confirm_modal do
             click_on "Supprimer mon compte"
           end
-        end.to change { User.count }.by(0)
+        end.to change { User.active.count }.by(0)
 
         expect(page).to_not have_text("Votre compte a bien été supprimé.")
         expect(page).to have_text("Vous ne pouvez pas supprimer votre compte actuellement car vous avez confirmé un rendez-vous de vaccination.")
@@ -194,7 +194,7 @@ RSpec.describe "Users", type: :system do
           accept_confirm_modal do
             click_on "Supprimer mon compte"
           end
-        end.to change { User.count }.by(-1)
+        end.to change { User.active.count }.by(-1)
 
         expect(page).to have_text("Votre compte a bien été supprimé.")
       end


### PR DESCRIPTION
In order to keep our statistics correct, we need to keep user_ids in our matches. So that we can correctly count the total number of people contacted. 
Anonymising users data is providing the same level of data protection than deleting records. By the way, this is the thing we do for people who confirmed a match.