### PR TITLE
remove reachable users and better querying

### DIFF
--- a/app/services/grid_coords_service.rb
+++ b/app/services/grid_coords_service.rb
@@ -27,18 +27,6 @@ class GridCoordsService
     n_cells = (distance_in_m / cell_size).ceil
     cell = get_cell
 
-    irange = [*(cell[:i] - n_cells)..(cell[:i] + n_cells)]
-    jrange = [*(cell[:j] - n_cells)..(cell[:j] + n_cells)]
-
-    a = []
-    irange.each do |i|
-      jrange.each do |j|
-        if Math.sqrt((cell[:i] - i)**2 + (cell[:j] - j)**2) <= n_cells
-          a.append([i, j])
-        end
-      end
-    end
-
-    {center_cell: cell, dist_cells: n_cells, cells: a, cell_size_meters: cell_size}
+    {center_cell: cell, dist_cells: n_cells, cell_size_meters: cell_size}
   end
 end

--- a/app/services/reachable_users_service.rb
+++ b/app/services/reachable_users_service.rb
@@ -11,27 +11,12 @@ class ReachableUsersService
     get_users_with_random(limit)
   end
 
-  def get_vaccination_center_grid_query
-    cells = @covering[:cells]
-    "(grid_i, grid_j) IN ((" + cells.map { |sub| sub.join(",") }.join("),(") + "))"
-  end
-
   def get_users_with_v2(limit = nil)
     sql = <<~SQL.tr("\n", " ").squish
-      with reachable_users as (
-        SELECT
-        u.id as user_id,
-        (SQRT((((:lat) - u.lat)*110.574)^2 + (((:lon) - u.lon)*111.320*COS(u.lat::float*3.14159/180))^2)) as distance
-        FROM users u
-        WHERE u.confirmed_at IS NOT NULL
-        AND u.anonymized_at is NULL
-        AND u.birthdate between (:min_date) and (:max_date)
-        AND (SQRT((((:lat) - u.lat)*110.574)^2 + (((:lon) - u.lon)*111.320*COS(u.lat::float*3.14159/180))^2)) < (:rayon_km)
-      )
-      ,users_stats as (
+      with users_stats as (
         select
         u.id as user_id,
-        (distance / 5.0)::int * 5 as distance_bucket,
+        ((SQRT((((:lat) - u.lat)*110.574)^2 + (((:lon) - u.lon)*111.320*COS(u.lat::float*3.14159/180))^2)) / 5.0)::int * 5 as distance_bucket,
         u.created_at::date as created_at,
         COUNT(m.id) filter (where vaccine_type = (:vaccine_type)) as vaccine_matches_count,
         COUNT(m.id) as total_matches_count,
@@ -39,10 +24,15 @@ class ReachableUsersService
         MAX(m.created_at)::date as last_match,
         SUM(case when m.refused_at is not null and vaccine_type = (:vaccine_type) then 1 else 0 end) as vaccine_refusals_count,
         SUM(case when m.refused_at is not null then 1 else 0 end) as total_refusals_count
-        from reachable_users r
-        inner join users u on (r.user_id = u.id)
-        left outer join matches m on (m.user_id = r.user_id)
+        from users u
+        left outer join matches m on (m.user_id = u.id)
         left outer join campaigns c on (c.id = m.campaign_id and c.status != 2)
+        WHERE
+          u.anonymized_at is NULL
+          AND u.birthdate between (:min_date) and (:max_date)
+          AND u.grid_i >= :min_i AND u.grid_i <= :max_i
+          AND u.grid_j >= :min_j AND u.grid_j <= :max_j
+          AND (SQRT((((:lat) - u.lat)*110.574)^2 + (((:lon) - u.lon)*111.320*COS(u.lat::float*3.14159/180))^2)) < (:rayon_km)
         group by 1,2,3
         having
          (
@@ -75,6 +65,10 @@ class ReachableUsersService
       lat: @vaccination_center.lat,
       lon: @vaccination_center.lon,
       rayon_km: @campaign.max_distance_in_meters / 1000,
+      min_i: @covering[:center_cell][:i] - @covering[:dist_cells],
+      max_i: @covering[:center_cell][:i] + @covering[:dist_cells],
+      min_j: @covering[:center_cell][:j] - @covering[:dist_cells],
+      max_j: @covering[:center_cell][:j] + @covering[:dist_cells],
       vaccine_type: @campaign.vaccine_type,
       limit: limit,
       last_match_allowed_at: Match::NO_MORE_THAN_ONE_MATCH_PER_PERIOD.ago
@@ -107,6 +101,8 @@ class ReachableUsersService
         WHERE u.confirmed_at IS NOT NULL
         AND u.anonymized_at is NULL
         AND u.birthdate between (:min_date) and (:max_date)
+        AND u.grid_i >= :min_i AND u.grid_i <= :max_i
+        AND u.grid_j >= :min_j AND u.grid_j <= :max_j
         AND (SQRT((((:lat) - u.lat)*110.574)^2 + (((:lon) - u.lon)*111.320*COS(u.lat::float*3.14159/180))^2)) < (:rayon_km)
         AND m.id IS NULL
     SQL
@@ -116,6 +112,10 @@ class ReachableUsersService
       lat: @vaccination_center.lat,
       lon: @vaccination_center.lon,
       rayon_km: @campaign.max_distance_in_meters / 1000,
+      min_i: @covering[:center_cell][:i] - @covering[:dist_cells],
+      max_i: @covering[:center_cell][:i] + @covering[:dist_cells],
+      min_j: @covering[:center_cell][:j] - @covering[:dist_cells],
+      max_j: @covering[:center_cell][:j] + @covering[:dist_cells],
       vaccine_type: @campaign.vaccine_type
     }
     query = ActiveRecord::Base.send(:sanitize_sql_array, [sql, params])

--- a/app/services/reachable_users_service.rb
+++ b/app/services/reachable_users_service.rb
@@ -28,7 +28,8 @@ class ReachableUsersService
         left outer join matches m on (m.user_id = u.id)
         left outer join campaigns c on (c.id = m.campaign_id and c.status != 2)
         WHERE
-          u.anonymized_at is NULL
+          u.confirmed_at IS NOT NULL
+          AND u.anonymized_at is NULL
           AND u.birthdate between (:min_date) and (:max_date)
           AND u.grid_i >= :min_i AND u.grid_i <= :max_i
           AND u.grid_j >= :min_j AND u.grid_j <= :max_j

--- a/spec/services/reachable_users_service.rb
+++ b/spec/services/reachable_users_service.rb
@@ -8,13 +8,16 @@ def get_lat_lng_for_number(xtile, ytile, zoom)
   {lat: lat_deg, lon: lon_deg}
 end
 
+def get_rand_email
+  (0...8).map { rand(65..90).chr }.join + "@covidliste.com"
+end
+
 DEFAULT_ZOOM_LEVEL = 15
 
 RSpec.describe ReachableUsersService, type: :service do
   let!(:vaccination_center) { create(:vaccination_center, lat: 42, lon: 2) }
   let!(:campaign) { build(:campaign, vaccination_center: vaccination_center, max_distance_in_meters: 5000, min_age: 18, max_age: 130, available_doses: 10) }
   let!(:reachable_users_service) { ReachableUsersService.new(campaign) }
-  email_domain = "covidliste.com"
 
   describe "get_vaccination_center_grid_cells" do
     it "covering is valid" do
@@ -22,7 +25,9 @@ RSpec.describe ReachableUsersService, type: :service do
       expect(range[:center_cell][:i]).to eq(16566)
       expect(range[:center_cell][:j]).to eq(12164)
       expect(range[:dist_cells]).to eq(6)
-      expect(range[:cells].length).to eq(113)
+
+      expect(range[:cells_i]).to eq([16560, 16561, 16562, 16563, 16564, 16565, 16566, 16567, 16568, 16569, 16570, 16571, 16572])
+      expect(range[:cells_j]).to eq([12158, 12159, 12160, 12161, 12162, 12163, 12164, 12165, 12166, 12167, 12168, 12169, 12170])
 
       lat_lon_center = get_lat_lng_for_number(range[:center_cell][:i], range[:center_cell][:j], DEFAULT_ZOOM_LEVEL)
       expect(lat_lon_center[:lat]).to be_within(0.01).of(42)
@@ -35,7 +40,7 @@ RSpec.describe ReachableUsersService, type: :service do
       User.create(
         firstname: Faker::Name.first_name,
         lastname: Faker::Name.last_name,
-        email: Faker::Internet.unique.email(domain: email_domain),
+        email: get_rand_email,
         birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
         address: Faker::Address.full_address,
         phone_number: Faker::PhoneNumber.cell_phone_in_e164,
@@ -62,7 +67,7 @@ RSpec.describe ReachableUsersService, type: :service do
       User.create(
         firstname: Faker::Name.first_name,
         lastname: Faker::Name.last_name,
-        email: Faker::Internet.unique.email(domain: email_domain),
+        email: get_rand_email,
         birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
         address: Faker::Address.full_address,
         phone_number: Faker::PhoneNumber.cell_phone_in_e164,
@@ -81,25 +86,23 @@ RSpec.describe ReachableUsersService, type: :service do
 
   describe "get_users_with_v2 should find users" do
     before do
-      (1..5).each do |i|
-        User.create(
-          firstname: Faker::Name.first_name,
-          lastname: Faker::Name.last_name,
-          email: Faker::Internet.unique.email(domain: email_domain),
-          birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
-          address: Faker::Address.full_address,
-          phone_number: Faker::PhoneNumber.cell_phone_in_e164,
-          toc: true,
-          statement: true,
-          confirmed_at: Time.now.utc,
-          lat: 42,
-          lon: 2
-        )
-      end
       User.create(
         firstname: Faker::Name.first_name,
         lastname: Faker::Name.last_name,
-        email: Faker::Internet.unique.email(domain: email_domain),
+        email: get_rand_email,
+        birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
+        address: Faker::Address.full_address,
+        phone_number: Faker::PhoneNumber.cell_phone_in_e164,
+        toc: true,
+        statement: true,
+        confirmed_at: Time.now.utc,
+        lat: 48.8534,
+        lon: 2.3488
+      )
+      User.create(
+        firstname: Faker::Name.first_name,
+        lastname: Faker::Name.last_name,
+        email: get_rand_email,
         birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
         address: Faker::Address.full_address,
         phone_number: Faker::PhoneNumber.cell_phone_in_e164,
@@ -110,15 +113,50 @@ RSpec.describe ReachableUsersService, type: :service do
         lon: 1.93359375
       )
     end
-    it "get 5 users" do
+    it "get 1 user" do
       resp = reachable_users_service.get_users_with_v2(10)
 
-      expect(resp.length).to eq(5)
+      expect(resp.length).to eq(1)
 
       user = resp[0]
       # lat/lon randomisation can move cell around a bit
       expect(user.grid_i).to be_within(2).of(16565)
       expect(user.grid_j).to be_within(2).of(12163)
+    end
+  end
+
+  describe "get_users_count should find users" do
+    before do
+      User.create(
+        firstname: Faker::Name.first_name,
+        lastname: Faker::Name.last_name,
+        email: get_rand_email,
+        birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
+        address: Faker::Address.full_address,
+        phone_number: Faker::PhoneNumber.cell_phone_in_e164,
+        toc: true,
+        statement: true,
+        confirmed_at: Time.now.utc,
+        lat: 42,
+        lon: 2
+      )
+      User.create(
+        firstname: Faker::Name.first_name,
+        lastname: Faker::Name.last_name,
+        email: get_rand_email,
+        birthdate: Faker::Date.between(from: 100.years.ago, to: 55.years.ago),
+        address: Faker::Address.full_address,
+        phone_number: Faker::PhoneNumber.cell_phone_in_e164,
+        toc: true,
+        statement: true,
+        confirmed_at: Time.now.utc,
+        lat: 42.01665183556824,
+        lon: 1.93359375
+      )
+    end
+    it "count 1 user" do
+      resp = reachable_users_service.get_users_count
+      expect(resp).to eq(1)
     end
   end
 end


### PR DESCRIPTION
## Résumé

We encountered more issues with grid querying in production.
After running quite a few experiments it seems the overall query could use some work.

## Détails

Changes:
- Remove `reachable_users` view and integrate query directly into `user_stats`. This shaves off a few tens of milliseconds when run via `explain analyze`
- Reintroduce grid querying, but with `grid_* >= min AND grid_* <= max` syntax since we are working on a continuous range (much easier to read, my bad for not thinking about it earlier 🤦). This time we only add to the `WHERE` clause and leave other distance query untouched. Result is net speedup in unpopulated areas (424.452 ms to 1.577 ms) with no discernible loss of performance (even maybe a slight speedup) in populated areas.  