### PR TITLE
Améliorations d'accessibilité sur le formulaire d'inscription

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,16 +1,16 @@
-<div class="bg-white p-3 py-4 p-lg-4 rounded">
+<%= simple_form_for @user do |f| %>
+  <div class="bg-white p-3 py-4 p-lg-4 rounded">
 
-  <% if @user.present? && @user.errors.any? %>
-    <div class="alert alert-danger" role="alert" style="position: inherit">
-      <% @user.errors.full_messages.each do |msg| %>
-        <%= msg %><br/>
-      <% end %>
-    </div>
-  <% end %>
+    <% if @user.present? && @user.errors.any? %>
+      <div class="alert alert-danger" role="alert" style="position: inherit">
+        <% @user.errors.full_messages.each do |msg| %>
+          <%= msg %><br/>
+        <% end %>
+      </div>
+    <% end %>
 
-  <%= simple_form_for @user do |f| %>
     <%= f.input :email,
-      label: false,
+      label: "Adresse email",
       error: f.error(:email),
       placeholder: "jean@dupont.com",
       hint: "Une adresse email ne peut être utilisée que par une seule personne.",
@@ -20,9 +20,9 @@
     <hr>
 
     <%= f.input :address,
-      label: false,
+      label: "Adresse",
       error: f.error(:address),
-      placeholder: "Adresse",
+      placeholder: "5 avenue de Paris",
       required: true,
       input_html: {class: "pr-5"} %>
 
@@ -30,15 +30,15 @@
     <%= f.input_field :lon, as: :hidden %>
 
     <%= f.input :phone_number,
-      label: false,
+      label: "Numéro de téléphone portable",
       error: "Numéro de téléphone invalide",
-      placeholder: "Numéro de téléphone portable",
+      placeholder: "06 00 00 00 00",
       required: true,
       input_html: {autocomplete: "tel"} %>
 
     <%= f.input :birthdate,
       as: :date,
-      label: false,
+      label: "Date de naissance",
       order: [:day, :month, :year],
       start_year: Date.today.year - 120,
       end_year: Date.today.year - 18,
@@ -54,9 +54,9 @@
 
     <%= f.invisible_captcha :subtitle %>
     <%= f.button :submit, "S’inscrire", class: "btn btn-secondary btn-lg btn-block font-weight-bold", data: {disable_with: "Inscription en cours..."} %>
-  <% end %>
 
-</div>
-<div class="py-1 px-2">
-  <%= render partial: "users/mentions" %>
-</div>
+  </div>
+  <div class="py-1 px-2">
+    <%= render partial: "users/mentions" %>
+  </div>
+<% end %>


### PR DESCRIPTION
Résout une partie de #755 

## Résumé

- Ajout de labels aux champs du formulaire
- Le texte sur la politique de données est intégré dans la balise form

## Détails

Labels ajoutés et placeholders modifiés. Cela rend le formulaire légèrement plus long verticalement mais plus accessible.

L'intégration du texte en bas du formulaire dans la balise form est sans impact visuel.

### Avant

![image](https://user-images.githubusercontent.com/3766352/118351479-95379a80-b55c-11eb-97ed-876dd8a8d4c4.png)

### Après

![image](https://user-images.githubusercontent.com/3766352/118351485-9d8fd580-b55c-11eb-90e7-f59c4c363fae.png)

## Question

On peut éventuellement raccourcir un peu en enlevant la phrase "Votre date de naissance sera vérifiée lors du rendez-vous." et modifier le label pour mettre "Date de naissance (sera vérifiée lors du rendez-vous)"