### PR TITLE
Fix browser form validation display on Chrome

### DIFF
--- a/app/javascript/components/confirmation.js
+++ b/app/javascript/components/confirmation.js
@@ -87,13 +87,15 @@ const createConfirmModal = (element) => {
         return true;
       };
 
+      // Close the modal first otherwise it conflicts with browser form
+      // validations in chrome
+      closeModal();
+
       // Click the link again
       element.click();
 
       // Restore the confirm behavior
       Rails.confirm = old_confirm;
-
-      closeModal();
     });
 
   modal.querySelector("[data-behavior='commit']").focus();


### PR DESCRIPTION
Fixes #733 

## Résumé

Les messages d'erreur pour les validations dans le navigateur sur les champs de formulaires ne s'affichent pas correctement dans Google Chrome lorsque le formulaire a une modale de confirmation.

## Détails

Il y a un conflit entre la fermeture de la modale et l'affichage des erreurs dans Google Chrome. J'ai simplement échangé l'ordre des deux lignes `closeModal();` qui ferme la modale et `element.click();` qui submit le formulaire.

<img width="418" alt="Sans les changements" src="https://user-images.githubusercontent.com/33979976/118358936-51a35780-b581-11eb-89e4-c7913d8d9620.png">
<img width="588" alt="Avec les changements" src="https://user-images.githubusercontent.com/33979976/118358938-536d1b00-b581-11eb-984f-036fe863ac5c.png">

A noter ce que changement résoud le problème également pour les champs de formulaire qui ne sont pas des checkboxes.

<img width="608" alt="Les changements affectent tous les champs" src="https://user-images.githubusercontent.com/33979976/118358990-8d3e2180-b581-11eb-8f88-4b7d3d2f550c.png">

Vous pouvez tester que ça fonctionne bien simplement en allant sur le formulaire pour un nouveau partenaire de santé et en soumettant le formulaire avec et sans erreur !
