### PR TITLE
Changement du nom du champ extra info "Infos supplémentaires" > "Détails d'accès"

### DIFF
--- a/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
+++ b/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
@@ -50,7 +50,14 @@ const _CampaignCreator = ({
               </h2>
               <CampaignCreatorAgeRange />
               <CampaignCreatorMaxDistance />
+
+              <h2>
+                <i className="fas fa-info-circle"></i> Informations pour les volontaires
+              </h2>
+              <p>
+                Les volontaires verront les informations suivantes uniquement <strong>après avoir confirmé leur rendez-vous.</strong> Il leur est déjà demandé déjà d’apporter leur carte vitale et une pièce d’identité.</p>
               <CampaignCreatorExtraInfo />
+            {/*ajouter la possibilité de faire apparaître son téléphone*/}
 
               <h2>
                 <i className="fas fa-bullhorn"></i> Lancer la campagne

--- a/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
+++ b/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
@@ -58,7 +58,7 @@ const _CampaignCreator = ({
               <p>
                 Les volontaires verront les informations suivantes uniquement
                 <strong> après avoir confirmé leur rendez-vous.</strong> Il leur
-                est déjà demandé déjà d’apporter leur carte vitale et une pièce
+                est déjà demandé d’apporter leur carte vitale et une pièce
                 d’identité.
               </p>
               <CampaignCreatorExtraInfo />

--- a/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
+++ b/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
@@ -56,8 +56,8 @@ const _CampaignCreator = ({
                 volontaires
               </h2>
               <p>
-                Les volontaires verront les informations suivantes uniquement{" "}
-                <strong>après avoir confirmé leur rendez-vous.</strong> Il leur
+                Les volontaires verront les informations suivantes uniquement
+                <strong> après avoir confirmé leur rendez-vous.</strong> Il leur
                 est déjà demandé déjà d’apporter leur carte vitale et une pièce
                 d’identité.
               </p>

--- a/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
+++ b/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
@@ -52,12 +52,17 @@ const _CampaignCreator = ({
               <CampaignCreatorMaxDistance />
 
               <h2>
-                <i className="fas fa-info-circle"></i> Informations pour les volontaires
+                <i className="fas fa-info-circle"></i> Informations pour les
+                volontaires
               </h2>
               <p>
-                Les volontaires verront les informations suivantes uniquement <strong>après avoir confirmé leur rendez-vous.</strong> Il leur est déjà demandé déjà d’apporter leur carte vitale et une pièce d’identité.</p>
+                Les volontaires verront les informations suivantes uniquement{" "}
+                <strong>après avoir confirmé leur rendez-vous.</strong> Il leur
+                est déjà demandé déjà d’apporter leur carte vitale et une pièce
+                d’identité.
+              </p>
               <CampaignCreatorExtraInfo />
-            {/*ajouter la possibilité de faire apparaître son téléphone*/}
+              {/*ajouter la possibilité de faire apparaître son téléphone*/}
 
               <h2>
                 <i className="fas fa-bullhorn"></i> Lancer la campagne

--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorExtraInfo.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorExtraInfo.jsx
@@ -5,8 +5,7 @@ import { CampaignCreatorField } from "components/partners/campaign_creator/field
 export const CampaignCreatorExtraInfo = () => {
   return (
     <CampaignCreatorField
-      label="Informations supplémentaires"
-      sublabel="Accès, modalités... Les volontaires ne verront ces informations qu’après avoir confirmé leur rendez-vous."
+      label="Détails d’accès"
       name="extraInfo"
     >
       <Field
@@ -15,6 +14,8 @@ export const CampaignCreatorExtraInfo = () => {
         id="extraInfo"
         className="form-control form-control-full-width"
         rows="2"
+        cols="100"
+        placeholder="Vous pouvez préciser les modalités d’accès au lieu de vaccination"
       />
     </CampaignCreatorField>
   );

--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorExtraInfo.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorExtraInfo.jsx
@@ -4,7 +4,10 @@ import { CampaignCreatorField } from "components/partners/campaign_creator/field
 
 export const CampaignCreatorExtraInfo = () => {
   return (
-    <CampaignCreatorField label="Détails d’accès" name="extraInfo">
+    <CampaignCreatorField
+      label="Détails d’accès"
+      name="extraInfo"
+    >
       <Field
         as="textarea"
         name="extraInfo"

--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorExtraInfo.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorExtraInfo.jsx
@@ -15,7 +15,7 @@ export const CampaignCreatorExtraInfo = () => {
         className="form-control form-control-full-width"
         rows="2"
         cols="100"
-        placeholder="Vous pouvez préciser les modalités d’accès au lieu de vaccination"
+        placeholder="Vous pouvez préciser les modalités d’accès au lieu de vaccination."
       />
     </CampaignCreatorField>
   );

--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorExtraInfo.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorExtraInfo.jsx
@@ -4,10 +4,7 @@ import { CampaignCreatorField } from "components/partners/campaign_creator/field
 
 export const CampaignCreatorExtraInfo = () => {
   return (
-    <CampaignCreatorField
-      label="Détails d’accès"
-      name="extraInfo"
-    >
+    <CampaignCreatorField label="Détails d’accès" name="extraInfo">
       <Field
         as="textarea"
         name="extraInfo"

--- a/app/views/partners/new.html.erb
+++ b/app/views/partners/new.html.erb
@@ -31,7 +31,7 @@
 
         <p class="mb-4">
           Vous êtes un professionnel de santé déjà inscrit ? Connectez-vous sur
-          <%= link_to "l'espace professionnels de santé", new_partner_session_path %>
+          <%= link_to "l’espace professionnels de santé", new_partner_session_path %>
         </p>
 
         <% if @partner.errors.any? %>
@@ -48,14 +48,14 @@
             <div class="alert alert-success" role="alert">
               Merci ! Vous êtes bien enregistré en tant que professionnel de santé assurant la vaccination sur Covidliste.
               Vous allez recevoir dans quelques instants un email de confirmation qui vous permettra de valider votre
-              inscription et d'accéder à votre espace sécurisé.
+              inscription et d’accéder à votre espace sécurisé.
             </div>
           </div>
 
         <% else %>
 
           <button class="btn btn-primary" type="button" id="health-professionnal" data-toggle="collapse" data-target="#collapseForm" aria-expanded="false" aria-controls="collapseForm">
-            S'inscrire en tant que professionnel de santé assurant la vaccination
+            S’inscrire en tant que professionnel de santé assurant la vaccination
           </button>
 
           <div class="collapse <%= @partner.errors.any? ? 'show' : '' %>" id="collapseForm">


### PR DESCRIPTION
## Résumé

Précision du champ `extra_info` lors de la création de campagne pour éviter tous les messages de filtre des pro ou de prise de rdv

## Détails

- Ajout d'une nouvelle catégorie "Informations pour les volontaires" au sein de laquelle on pourra ajouter la checkbox pour afficher ou non le numéro de téléphone aux matchés.
- Ajout d'un placeholder
- Affichage de la textarea sur toute la largeur

![image](https://user-images.githubusercontent.com/68182973/118379551-83e1a300-b5db-11eb-9358-6732923c517c.png)

(et des petites apostrophes par-ci par-là pour faire plaisir à @GuillaumeWrobel )
