### PR TITLE
Envoi d'un email à l'utilisateur suite à la confirmation du match

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -30,6 +30,7 @@ class MatchesController < ApplicationController
     if user.valid_attributes?(:statement, :toc)
       user.save(validate: false)
       @match.confirm!
+      SendConfirmedMatchEmailJob.perform_later(@match.id)
     else
       raise ActiveRecord::RecordInvalid.new(user)
     end

--- a/app/jobs/send_confirmed_match_email_job.rb
+++ b/app/jobs/send_confirmed_match_email_job.rb
@@ -1,0 +1,11 @@
+class SendConfirmedMatchEmailJob < ApplicationJob
+  queue_as :mailer
+
+  def perform(match_id)
+    match = Match.find(match_id)
+
+    return if match.confirmed_mail_sent_at.present?
+    MatchMailer.with(match: match).send_confirmed_match_details.deliver_now
+    match.update(confirmed_mail_sent_at: Time.now.utc)
+  end
+end

--- a/app/mailers/match_mailer.rb
+++ b/app/mailers/match_mailer.rb
@@ -14,7 +14,6 @@ class MatchMailer < ApplicationMailer
 
   def send_confirmed_match_details
     @match = params[:match]
-    @vaccination_center = @match.vaccination_center
     return if @match.user.blank?
 
     mail(

--- a/app/mailers/match_mailer.rb
+++ b/app/mailers/match_mailer.rb
@@ -12,6 +12,17 @@ class MatchMailer < ApplicationMailer
     )
   end
 
+  def send_confirmed_match_details
+    @match = params[:match]
+    @vaccination_center = @match.vaccination_center
+    return if @match.user.blank?
+
+    mail(
+      to: @match.user.email,
+      subject: "Covidliste - Votre rendez-vous de vaccination est confirmé"
+    )
+  end
+
   def send_anonymisation_notice
     @match = params[:match]
     user_email = params[:user_email] || @match&.user&.email

--- a/app/views/match_mailer/send_confirmed_match_details.html.erb
+++ b/app/views/match_mailer/send_confirmed_match_details.html.erb
@@ -1,0 +1,49 @@
+<div>
+  <p>
+    Bonjour,
+  </p>
+
+  <h3>
+    Votre dose de vaccin <%= @match.campaign.vaccine_type.capitalize %> est bien réservée !
+  </h3>
+
+  <p>
+    <strong>Informations et accès</strong>
+    <ul>
+      <li>Adresse : <%= @vaccination_center.address %></li>
+      <li>Créneau horaire : <%= l(@match.campaign.starts_at, format: '%A %e %B %Y').capitalize %> entre <%= l(@match.campaign.starts_at, format: '%Hh%M') %>
+      et <%= l(@match.campaign.ends_at, format: '%Hh%M') %> </li>
+      <% if @match.campaign.extra_info.present? %>
+        <li>Détails d’accès : <%= @match.campaign.extra_info %></li>
+      <% end %>
+    </ul>
+  </p>
+
+  <p>
+    <strong>Rappel de vos informations</strong>
+    <ul>
+      <li>Identité : <%= @match.user.full_name %></li>
+      <li>Date de naissance : <%= @match.user.birthdate.strftime('%d/%m/%Y') %></li>
+    </ul>
+  </p>
+
+  <p>
+    <strong>N’oubliez-pas d’apporter :</strong>
+    <ul>
+      <li>votre <strong>carte Vitale</strong> (ou attestation de droit)</li>
+      <li>votre <strong>pièce d’identité</strong> (aux nom et date de naissance renseignés ci-dessus)</li>
+    </ul>
+  </p>
+
+  <p>
+    Si vous n’êtes plus disponible, prévenez le centre et réinscrivez-vous sur Covidliste après 72h. En cas de problème, contactez <%= mail_to "hello@covidliste.com", "hello@covidliste.com" %>.
+  </p>
+
+  <p>
+    Nous sommes heureux de vous permettre d’accéder à la vaccination.
+  </p>
+
+
+  <%= render "mailer/footer" %>
+  <%= render "mailer/automatic_message" %>
+</div>

--- a/app/views/match_mailer/send_confirmed_match_details.html.erb
+++ b/app/views/match_mailer/send_confirmed_match_details.html.erb
@@ -10,12 +10,13 @@
   <p>
     <strong>Informations et accès</strong>
     <ul>
-      <li>Adresse : <%= @vaccination_center.address %></li>
+      <li>Adresse : <%= @match.vaccination_center.address %></li>
       <li>Créneau horaire : <%= l(@match.campaign.starts_at, format: '%A %e %B %Y').capitalize %> entre <%= l(@match.campaign.starts_at, format: '%Hh%M') %>
       et <%= l(@match.campaign.ends_at, format: '%Hh%M') %> </li>
       <% if @match.campaign.extra_info.present? %>
         <li>Détails d’accès : <%= @match.campaign.extra_info %></li>
       <% end %>
+      <!-- numéro de téléphone facultatif -->
     </ul>
   </p>
 

--- a/app/views/matches/_confirmed.html.erb
+++ b/app/views/matches/_confirmed.html.erb
@@ -1,7 +1,7 @@
 <h2>Votre disponibilité est confirmée !</h2>
 
 <p class="mt-4">
-  Nous sommes heureux de vous permettre d'accéder à la vaccination plus rapidement. <br>
+  Nous sommes heureux de vous permettre d’accéder à la vaccination. <br>
   <br/>
   <strong><%= @match.vaccination_center.name %> (<%= @match.vaccination_center.kind %>) vous attend le <%= l(match.campaign.starts_at, format: '%A %e %B %Y')%>.</strong>
 </p>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -19,9 +19,9 @@
       </p>
       <p class="small">Trop loin de chez vous ?<br>
         <% if user.city && user.zipcode %>
-          D'après nos informations vous habitez à proximité de <%= user.city %> (<%= user.zipcode %>). <br>
+          D’après nos informations vous habitez à proximité de <%= user.city %> (<%= user.zipcode %>). <br>
         <% end %>
-        S'il y a une erreur dans votre adresse, refusez cette dose et modifiez votre adresse dans
+        S’il y a une erreur dans votre adresse, refusez cette dose et modifiez votre adresse dans
         votre <%= link_to "espace personnel", :new_user_session %> </p>
     <% end %>
   </div>
@@ -50,7 +50,7 @@
       <p>
         Date de naissance : <strong><%= user.birthdate.strftime('%d/%m/%Y') %></strong><br>
         <strong>Date de naissance et nom seront vérifiés.</strong> <br>
-        Munissez-vous d'une pièce d'identité et de votre
+        Munissez-vous d’une pièce d’identité et de votre
         carte vitale.<br>
       </p>
     </div>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -19,7 +19,7 @@
       </p>
       <p class="small">Trop loin de chez vous ?
         <% if user.city && user.zipcode %>
-          D’après nos informations vous habitez à proximité de <%= user.city %> (<%= user.zipcode %>). <br>
+          D’après nos informations vous habitez à proximité de <%= user.city %> (<%= user.zipcode %>).
         <% end %>
         S’il y a une erreur dans votre adresse, refusez cette dose et modifiez votre adresse dans
         votre <%= link_to "espace personnel", :new_user_session %> </p>

--- a/db/migrate/20210515232244_add_confirmed_mail_sent_at_to_matches.rb
+++ b/db/migrate/20210515232244_add_confirmed_mail_sent_at_to_matches.rb
@@ -1,0 +1,5 @@
+class AddConfirmedMailSentAtToMatches < ActiveRecord::Migration[6.1]
+  def change
+    add_column :matches, :confirmed_mail_sent_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_08_091206) do
+ActiveRecord::Schema.define(version: 2021_05_15_232244) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -168,6 +168,7 @@ ActiveRecord::Schema.define(version: 2021_05_08_091206) do
     t.integer "distance_in_meters"
     t.string "sms_provider"
     t.string "sms_provider_id"
+    t.datetime "confirmed_mail_sent_at"
     t.index ["campaign_batch_id"], name: "index_matches_on_campaign_batch_id"
     t.index ["campaign_id"], name: "index_matches_on_campaign_id"
     t.index ["confirmation_failed_reason"], name: "index_matches_on_confirmation_failed_reason"

--- a/spec/jobs/send_confirmed_match_mail_job.spec.rb
+++ b/spec/jobs/send_confirmed_match_mail_job.spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe SendConfirmedMatchEmailJob do
+  let!(:user) { create(:user) }
+  let!(:campaign) { create(:campaign) }
+  let!(:match) { create(:match, user: user, campaign: campaign) }
+  match.confirm!
+
+  subject { SendConfirmedMatchEmailJob.new.perform(match.id) }
+
+  context "match is confirmed by a user" do
+    it "sends the email" do
+      mail = double(:mail)
+      allow(MatchMailer).to receive_message_chain("with.send_confirmed_match_details").and_return(mail)
+      expect(mail).to receive(:deliver_now)
+      subject
+    end
+
+    it "set confirmed_mail_sent_at" do
+      subject
+      expect(match.reload.confirmed_mail_sent_at).to_not be(nil)
+    end
+  end
+end

--- a/test/mailers/previews/match_mailer_preview.rb
+++ b/test/mailers/previews/match_mailer_preview.rb
@@ -10,4 +10,9 @@ class MatchMailerPreview < ActionMailer::Preview
     match = FactoryBot.create(:match, :confirmed)
     MatchMailer.with(match: match).send_anonymisation_notice.deliver_now
   end
+
+  def send_confirmed_match_details
+    match = FactoryBot.create(:match, :confirmed)
+    MatchMailer.with(match: match).send_confirmed_match_details.deliver_now
+  end
 end


### PR DESCRIPTION
Fixes #779 

## Résumé

Simplifier la gestion des centres et rassurer les utilisateurs grâce à un mail récap suite à la confirmation d'un match.
<img width="792" alt="Capture d’écran 2021-05-16 à 11 27 10" src="https://user-images.githubusercontent.com/68182973/118392580-a6ef6f80-b63a-11eb-830f-5646885f67ca.png">


## Détails
- Ajout de `send_confirmed_match_details` dans le MatchMailer
- Création du Job `SendConfirmedMatchEmailJob`
- Ajout de la colonne `:confirmed_mail_sent_at` à Match
- Création du spec et mail preview


