### PR TITLE
Résout problème de centrage horizontal

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -51,7 +51,7 @@
           <% end %>
         <% end %>
       </div>
-      <div class="col-12 col-lg-3 offset-lg-1 d-flex align-items-center border rounded">
+      <div class="col-12 col-lg-3 offset-lg-1 d-flex align-items-center justify-content-center border rounded">
         <div class="text-center px-2">
           <div class="mt-4">
             <%= icon("fas", "hospital-user", class: "rounded p-3 bg-light text-primary h2") %>

--- a/app/views/partners/new.html.erb
+++ b/app/views/partners/new.html.erb
@@ -107,7 +107,7 @@
         <% end %>
 
       </div>
-      <div class="col-12 col-lg-3 offset-lg-1 d-flex align-items-center border rounded">
+      <div class="col-12 col-lg-3 offset-lg-1 d-flex align-items-center justify-content-center border rounded">
         <div class="text-center px-2">
           <div class="mt-4">
             <%= icon("fas", "user-plus", class: "rounded p-3 bg-light text-primary h2") %>

--- a/app/views/partners/sessions/new.html.erb
+++ b/app/views/partners/sessions/new.html.erb
@@ -61,7 +61,7 @@
           <% end %>
         <% end %>
       </div>
-      <div class="col-12 col-lg-3 offset-lg-1 d-flex align-items-center border rounded">
+      <div class="col-12 col-lg-3 offset-lg-1 d-flex align-items-center justify-content-center border rounded">
         <div class="text-center px-2">
           <div class="mt-4">
             <%= icon("fas", "user-plus", class: "rounded p-3 bg-light text-primary h2") %>


### PR DESCRIPTION
## Résumé

Un simple problème de centrage horizontal sur une bannière (le problème ne se présente que sur une taille d'écran intermédiaire).

## Détails

J'ai repéré le problème à trois endroits, je ne mets qu'une seule capture mais c'est pareil partout.
J'ai simplement ajouté une classe `justify-content-center`.

### Avant

![image](https://user-images.githubusercontent.com/3766352/118396278-1d966800-b64f-11eb-8c63-cbed0d6c135e.png)

### Après

![image](https://user-images.githubusercontent.com/3766352/118396282-22f3b280-b64f-11eb-914f-174f26d64497.png)
