### PR TITLE
Fix access rights for support_member volunteers

### DIFF
--- a/app/policies/admin/campaign_policy.rb
+++ b/app/policies/admin/campaign_policy.rb
@@ -2,14 +2,14 @@ module Admin
   class CampaignPolicy < ApplicationPolicy
     class Scope < Scope
       def resolve
-        raise Pundit::NotAuthorizedError unless user&.has_role?(:supply_admin)
+        raise Pundit::NotAuthorizedError unless user&.has_role?(:supply_member)
 
         scope.all
       end
     end
 
     def index?
-      user.has_role?(:supply_admin)
+      user.has_role?(:supply_member)
     end
   end
 end

--- a/app/policies/admin/campaign_policy.rb
+++ b/app/policies/admin/campaign_policy.rb
@@ -2,14 +2,14 @@ module Admin
   class CampaignPolicy < ApplicationPolicy
     class Scope < Scope
       def resolve
-        raise Pundit::NotAuthorizedError unless user&.has_role?(:admin)
+        raise Pundit::NotAuthorizedError unless user&.has_role?(:supply_admin)
 
         scope.all
       end
     end
 
     def index?
-      user.has_role?(:admin)
+      user.has_role?(:supply_admin)
     end
   end
 end

--- a/app/policies/admin/home_policy.rb
+++ b/app/policies/admin/home_policy.rb
@@ -1,7 +1,7 @@
 module Admin
   class HomePolicy < ApplicationPolicy
     def index?
-      user&.has_role?(:admin)
+      user&.has_role?(:volunteer)
     end
   end
 end

--- a/app/policies/admin/stats_policy.rb
+++ b/app/policies/admin/stats_policy.rb
@@ -1,7 +1,7 @@
 module Admin
   class StatsPolicy < ApplicationPolicy
     def stats?
-      user.has_role?(:admin)
+      user.has_role?(:supply_admin)
     end
   end
 end

--- a/app/policies/admin/user_policy.rb
+++ b/app/policies/admin/user_policy.rb
@@ -2,14 +2,14 @@ module Admin
   class Admin::UserPolicy < ApplicationPolicy
     class Scope < Scope
       def resolve
-        raise Pundit::NotAuthorizedError unless user.has_role?(:admin)
+        raise Pundit::NotAuthorizedError unless user.has_role?(:support_member)
 
         scope.all
       end
     end
 
     def resend_confirmation?
-      user.has_role?(:admin)
+      user.has_role?(:support_member)
     end
 
     def destroy?

--- a/app/policies/admin/vaccination_center_policy.rb
+++ b/app/policies/admin/vaccination_center_policy.rb
@@ -21,8 +21,8 @@ module Admin
     def add_partner?
       user.has_role?(:supply_admin)
     end
-    alias_method :validate?, :index?
-    alias_method :enable?, :index?
-    alias_method :disable?, :index?
+    alias_method :validate?, :add_partner?
+    alias_method :enable?, :add_partner?
+    alias_method :disable?, :add_partner?
   end
 end

--- a/app/policies/admin/vaccination_center_policy.rb
+++ b/app/policies/admin/vaccination_center_policy.rb
@@ -2,25 +2,27 @@ module Admin
   class VaccinationCenterPolicy < ApplicationPolicy
     class Scope < Scope
       def resolve
-        raise Pundit::NotAuthorizedError unless user&.has_role?(:admin)
+        raise Pundit::NotAuthorizedError unless user&.has_role?(:supply_member)
 
         scope.all
       end
     end
 
     def index?
-      user.has_role?(:admin)
+      user.has_role?(:supply_member)
     end
-
-    alias_method :new?, :index?
     alias_method :show?, :index?
+    alias_method :new?, :index?
     alias_method :create?, :index?
-    alias_method :validate?, :index?
-    alias_method :enable?, :index?
-    alias_method :disable?, :index?
     alias_method :edit?, :index?
     alias_method :update?, :index?
     alias_method :destroy?, :index?
-    alias_method :add_partner?, :index?
+
+    def add_partner?
+      user.has_role?(:supply_admin)
+    end
+    alias_method :validate?, :index?
+    alias_method :enable?, :index?
+    alias_method :disable?, :index?
   end
 end

--- a/app/views/layouts/_admin_navbar.html.erb
+++ b/app/views/layouts/_admin_navbar.html.erb
@@ -28,9 +28,9 @@
 
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownSupply">
               <%= link_to "Lieux de vaccination", admin_vaccination_centers_path, class: "dropdown-item" %>
+              <%= link_to "Campagnes", admin_campaigns_path, class: "dropdown-item" %>
               <% if current_user.has_role?(:supply_admin) %>
                 <%= link_to "Statistiques volontaires", admin_stats_path, class: "dropdown-item" %>
-                <%= link_to "Campagnes", admin_campaigns_path, class: "dropdown-item" %>
               <% end %>
             </div>
           </li>

--- a/app/views/layouts/_admin_navbar.html.erb
+++ b/app/views/layouts/_admin_navbar.html.erb
@@ -28,8 +28,10 @@
 
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownSupply">
               <%= link_to "Lieux de vaccination", admin_vaccination_centers_path, class: "dropdown-item" %>
-              <%= link_to "Statistiques volontaires", admin_stats_path, class: "dropdown-item" %>
-              <%= link_to "Campagnes", admin_campaigns_path, class: "dropdown-item" %>
+              <% if current_user.has_role?(:supply_admin) %>
+                <%= link_to "Statistiques volontaires", admin_stats_path, class: "dropdown-item" %>
+                <%= link_to "Campagnes", admin_campaigns_path, class: "dropdown-item" %>
+              <% end %>
             </div>
           </li>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
       authenticate :user, lambda { |u| u.has_role?(:supply_member) } do
         # Supply
+        resources :campaigns, only: [:index]
         resources :vaccination_centers do
           authenticate :user, lambda { |u| u.has_role?(:supply_admin) } do
             # Supply Admin
@@ -21,8 +22,6 @@ Rails.application.routes.draw do
 
       authenticate :user, lambda { |u| u.has_role?(:supply_admin) } do
         # Supply admin
-        resources :campaigns, only: [:index]
-
         get "/stats" => "stats#stats"
         post "/stats" => "stats#stats"
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,13 +21,10 @@ Rails.application.routes.draw do
 
       authenticate :user, lambda { |u| u.has_role?(:supply_admin) } do
         # Supply admin
+        resources :campaigns, only: [:index]
+
         get "/stats" => "stats#stats"
         post "/stats" => "stats#stats"
-      end
-
-      authenticate :user, lambda { |u| u.has_role?(:supply_admin) } do
-        # Supply admin
-        resources :campaigns, only: [:index]
       end
 
       authenticate :user, lambda { |u| u.has_role?(:support_member) } do


### PR DESCRIPTION
Fixes #774

## Résumé

Résolution du bug des droits d'accès sur l'espace admin.

## Détails

Il y avait une incohérence dans l'espace admin entre l'autorisation des routes et celle des policies pundit. 

Par exemple pour le controlleur `Admin::UsersControlleur`, il suffisait d'avoir le rôle `support_member` pour passer l'autorisation au niveau de la route, mais dans les policies, il fallait nécéssairement avoir le rôle `admin` qui est un rôle plus puissant. C'est ce que je corrige dans cette PR.

@carsso si tu me confirmes que je suis parti sur la bonne voie, il y a deux choses que j'aimerais faire en plus ici :

- Rendre le path `/admin` accessible à tous les admins peu importe leur rôle. Pour l'instant il n'est accessible que aux personnes avec le rôle `admin`. Bien sûr il faut faire attention à ne leur montrer que les liens qui les concernent. Ca sera plus simple pour les admins de retenir seulement le path `/admin` puis de cliquer sur les liens auxquels ils ont accès selon leurs rôles dans la navbar plutôt de que retenir le path `/admin/users` par exemple, qu'est-ce que tu en penses ?
- Refaire un tour de tous les rôles, j'ai l'impression qu'on a le même bug par exemple pour `Admin::CampaignsController#index` qui nécessite le droit `supply_admin` au niveau de la route mais `admin` au niveau de la policy.