### PR TITLE
Display warning when selecting AZ in campaign

### DIFF
--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorVaccineType.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorVaccineType.jsx
@@ -33,6 +33,14 @@ export const CampaignCreatorVaccineType = () => {
           </div>
         );
       })}
+      { values.vaccineType === "astrazeneca" && (
+        <p className="small">
+          Il est de plus en plus difficile de trouver des volontaires pour AstraZeneca.
+          Pour maximiser vos chances, regroupez vos campagnes : une seule grosse campagne est plus efficace que plusieurs petites.
+          Et surtout, n'interrompez pas vos campagnes pour les relancer si elles ne se remplissent pas bien, cela empire le problème.
+          Chaque dose sauvée est une victoire !
+        </p>
+      ) }
     </CampaignCreatorField>
   );
 };

--- a/app/javascript/components/partners/campaign_creator/initialFormState.jsx
+++ b/app/javascript/components/partners/campaign_creator/initialFormState.jsx
@@ -1,4 +1,5 @@
 import dayjs from "dayjs";
+import { vaccineTypes } from "./vaccineTypes";
 
 export function initialFormState(initialCampaign) {
   const ceilToFiveMinutes = (date) =>
@@ -18,7 +19,7 @@ export function initialFormState(initialCampaign) {
 
   return {
     availableDoses: initialCampaign.availableDoses || 16,
-    vaccineType: initialCampaign.vaccineType || "astrazeneca",
+    vaccineType: initialCampaign.vaccineType || vaccineTypes[0].value,
     minAge: initialCampaign.minAge || 55,
     maxAge: initialCampaign.maxAge || 130,
     maxDistanceInMeters: initialCampaign.maxDistanceInMeters || 5000,

--- a/app/javascript/components/partners/campaign_creator/vaccineTypes.js
+++ b/app/javascript/components/partners/campaign_creator/vaccineTypes.js
@@ -1,10 +1,5 @@
 export const vaccineTypes = [
   {
-    value: "astrazeneca",
-    label: "AstraZeneca",
-    minimumMinAge: 55,
-  },
-  {
     value: "pfizer",
     label: "Pfizer",
   },
@@ -15,6 +10,11 @@ export const vaccineTypes = [
   {
     value: "janssen",
     label: "Janssen / Johnson & Johnson",
+    minimumMinAge: 55,
+  },
+  {
+    value: "astrazeneca",
+    label: "AstraZeneca",
     minimumMinAge: 55,
   },
 ];


### PR DESCRIPTION
Fixes #771 

## Résumé

Ajout d'un texte d'avertissement lorsqu'on sélectionne le vaccin AstraZeneca.

## Détails

![image](https://user-images.githubusercontent.com/3766352/118397422-20478c00-b654-11eb-820f-28cdb8659a4a.png)

![image](https://user-images.githubusercontent.com/3766352/118397437-35bcb600-b654-11eb-8143-1e2532ec4f11.png)
