### PR TITLE
Add no_url and no_phone_number validations on Campaign#extra_info

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -18,6 +18,7 @@ class Campaign < ApplicationRecord
   validates :min_age, numericality: {greater_than: 17}
   validates :max_age, numericality: {greater_than: 17}
   validates :max_distance_in_meters, numericality: {greater_than: 0, less_than_or_equal_to: MAX_DISTANCE_IN_KM * 1000}
+  validates :extra_info, no_url: true, no_phone_number: true
   validate :min_age_lesser_than_max_age
   validate :starts_at_lesser_than_ends_at
 

--- a/app/validators/no_phone_number_validator.rb
+++ b/app/validators/no_phone_number_validator.rb
@@ -1,0 +1,7 @@
+class NoPhoneNumberValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if Phonelib.parse(value).valid?
+      record.errors.add(attribute, "ne doit pas contenir de numéro de téléphone")
+    end
+  end
+end

--- a/app/validators/no_url_validator.rb
+++ b/app/validators/no_url_validator.rb
@@ -1,0 +1,9 @@
+require "uri"
+
+class NoUrlValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.to_s.match?(URI::DEFAULT_PARSER.make_regexp)
+      record.errors.add(attribute, "ne doit pas contenir d'URL")
+    end
+  end
+end

--- a/spec/validators/no_phone_number_validator_spec.rb
+++ b/spec/validators/no_phone_number_validator_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe NoPhoneNumberValidator do
+  subject do
+    Class.new do
+      include ActiveModel::Validations
+
+      attr_accessor :content
+
+      validates :content, no_phone_number: true
+    end.new
+  end
+
+  context "when content contains an phone number" do
+    it "is invalid" do
+      contents = [
+        "This contains a mobile phone number 06 06 06 06 06",
+        "This contains a fixed line phone number 0478787878",
+        "This contains a mobile phone with country code +33606060606",
+        "This contains a fixed line phone number with country code +334 78 78 78 78"
+      ]
+
+      contents.each do |content|
+        subject.content = content
+
+        expect(subject).to be_invalid
+      end
+    end
+  end
+
+  context "when content does not contain a phone number" do
+    it "is valid" do
+      subject.content = "This does not contain a phone number"
+
+      expect(subject).to be_valid
+    end
+  end
+end

--- a/spec/validators/no_url_validator_spec.rb
+++ b/spec/validators/no_url_validator_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe NoUrlValidator do
+  subject do
+    Class.new do
+      include ActiveModel::Validations
+
+      attr_accessor :content
+
+      validates :content, no_url: true
+    end.new
+  end
+
+  context "when content contains an URL" do
+    it "is invalid" do
+      subject.content = "This contains a URL https://www.covidliste.com/"
+
+      expect(subject).to be_invalid
+    end
+  end
+
+  context "when content does not contain an URL" do
+    it "is valid" do
+      subject.content = "This does not contain a URL"
+
+      expect(subject).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
Fixes #773

## Résumé

On ajoute deux validations au champ informations supplémentaires des campagnes (extra_info) pour éviter qu'il contienne une URL ou un numéro de téléphone pour prendre rdv.

## Détails

⚠️  Warning : ne mettre en prod que lorsque le numéro de téléphone des lieux de vaccination seront - s'ils le souhaitent - disponible dans la page de confirmation d'un match, afin que des volontaires puissent tout de même les contacter et que nous ne bloquions pas tous les centres qui souhaiteraient laisser leur coordonnées de contact.

J'ai ajouté les validations demandées, mais par contre le message d'erreur n'est pas clair du tout pour le moment.

![Screenshot 2021-05-16 at 22 54 15](https://user-images.githubusercontent.com/33979976/118412397-f618bd00-b699-11eb-9354-2735278e47fc.png)
