### PR TITLE
Ajout d'un numéro de téléphone de contact dans les campagnes

### DIFF
--- a/app/controllers/partners/campaigns_controller.rb
+++ b/app/controllers/partners/campaigns_controller.rb
@@ -79,6 +79,7 @@ module Partners
       params.require(:campaign).permit(
         :available_doses,
         :extra_info,
+        :phone_number,
         :max_distance_in_meters,
         :min_age,
         :max_age,

--- a/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
+++ b/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
@@ -10,6 +10,7 @@ import { CampaignCreatorAgeRange } from "components/partners/campaign_creator/fi
 import { CampaignCreatorMaxDistance } from "components/partners/campaign_creator/fields/CampaignCreatorMaxDistance";
 import { CampaignCreatorExtraInfo } from "components/partners/campaign_creator/fields/CampaignCreatorExtraInfo";
 import { CampaignCreatorVaccineType } from "components/partners/campaign_creator/fields/CampaignCreatorVaccineType";
+import { CampaignCreatorPhoneNumber } from "components/partners/campaign_creator/fields/CampaignCreatorPhoneNumber";
 import { GenericError } from "components/partners/GenericError";
 import { CampaignCreatorAvailableDoses } from "components/partners/campaign_creator/fields/CampaignCreatorAvailableDoses";
 import { CampaignCreatorChecks } from "components/partners/campaign_creator/fields/CampaignCreatorChecks";
@@ -62,7 +63,9 @@ const _CampaignCreator = ({
                 d’identité.
               </p>
               <CampaignCreatorExtraInfo />
-              {/*ajouter la possibilité de faire apparaître son téléphone*/}
+              <CampaignCreatorPhoneNumber
+                vaccinationCenterPhoneNumber={vaccinationCenter.phoneNumber}
+              />
 
               <h2>
                 <i className="fas fa-bullhorn"></i> Lancer la campagne

--- a/app/javascript/components/partners/campaign_creator/CampaignCreatorReach.jsx
+++ b/app/javascript/components/partners/campaign_creator/CampaignCreatorReach.jsx
@@ -11,6 +11,7 @@ export const CampaignCreatorReach = ({ vaccinationCenter, className }) => {
     {
       campaign: omit(debouncedValues, [
         "extraInfo",
+        "phoneNumber",
         "checkDoses",
         "checkNotify",
       ]),

--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorChecks.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorChecks.jsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { Field, useFormikContext } from "formik";
-import { CampaignCreatorField } from "components/partners/campaign_creator/fields/CampaignCreatorField";
 
 export const CampaignCreatorChecks = () => {
-  const { values } = useFormikContext();
+  const { getFieldMeta, values } = useFormikContext();
   return (
     <div>
       <fieldset className="form-group boolean required">
@@ -25,6 +24,11 @@ export const CampaignCreatorChecks = () => {
             {values.endsAt?.format("HH:mm")}
           </label>
         </div>
+        { getFieldMeta("checkDoses").error && (
+          <div className="alert alert-danger" role="alert">
+            {getFieldMeta("checkDoses").error}
+          </div>
+        ) }
       </fieldset>
       <fieldset className="form-group boolean required">
         <div className="form-check">
@@ -45,6 +49,11 @@ export const CampaignCreatorChecks = () => {
           </label>
         </div>
       </fieldset>
+        { getFieldMeta("checkNotify").error && (
+          <div className="alert alert-danger" role="alert">
+            {getFieldMeta("checkNotify").error}
+          </div>
+        ) }
     </div>
   );
 };

--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorChecks.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorChecks.jsx
@@ -24,11 +24,11 @@ export const CampaignCreatorChecks = () => {
             {values.endsAt?.format("HH:mm")}
           </label>
         </div>
-        { getFieldMeta("checkDoses").error && (
+        {getFieldMeta("checkDoses").error && (
           <div className="alert alert-danger" role="alert">
             {getFieldMeta("checkDoses").error}
           </div>
-        ) }
+        )}
       </fieldset>
       <fieldset className="form-group boolean required">
         <div className="form-check">
@@ -49,11 +49,11 @@ export const CampaignCreatorChecks = () => {
           </label>
         </div>
       </fieldset>
-        { getFieldMeta("checkNotify").error && (
-          <div className="alert alert-danger" role="alert">
-            {getFieldMeta("checkNotify").error}
-          </div>
-        ) }
+      {getFieldMeta("checkNotify").error && (
+        <div className="alert alert-danger" role="alert">
+          {getFieldMeta("checkNotify").error}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorPhoneNumber.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorPhoneNumber.jsx
@@ -4,28 +4,31 @@ import { CampaignCreatorField } from "components/partners/campaign_creator/field
 import { CampaignCreatorInput } from "components/partners/campaign_creator/fields/CampaignCreatorInput";
 
 export const CampaignCreatorPhoneNumber = ({
-  vaccinationCenterPhoneNumber
+  vaccinationCenterPhoneNumber,
 }) => {
-  const fieldName = "phoneNumber"
+  const fieldName = "phoneNumber";
   const { setFieldValue, values } = useFormikContext();
   return (
     <>
-      <CampaignCreatorField label="Numéro de téléphone à communiquer aux volontaires (facultatif)" name={fieldName}>
-        <CampaignCreatorInput
-          type="tel"
-          name={fieldName}
-          id={fieldName}
-        />
+      <CampaignCreatorField
+        label="Numéro de téléphone à communiquer aux volontaires (facultatif)"
+        name={fieldName}
+      >
+        <CampaignCreatorInput type="tel" name={fieldName} id={fieldName} />
       </CampaignCreatorField>
-      { vaccinationCenterPhoneNumber && values[fieldName] !== vaccinationCenterPhoneNumber && (
-        <button
-          className="btn btn-outline-primary btn-sm"
-          type="button"
-          onClick={() => setFieldValue(fieldName, vaccinationCenterPhoneNumber)}
-        >
-          Utiliser le numéro du centre de vaccination ({vaccinationCenterPhoneNumber})
-        </button>
-      ) }
+      {vaccinationCenterPhoneNumber &&
+        values[fieldName] !== vaccinationCenterPhoneNumber && (
+          <button
+            className="btn btn-outline-primary btn-sm"
+            type="button"
+            onClick={() =>
+              setFieldValue(fieldName, vaccinationCenterPhoneNumber)
+            }
+          >
+            Utiliser le numéro du centre de vaccination (
+            {vaccinationCenterPhoneNumber})
+          </button>
+        )}
     </>
   );
 };

--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorPhoneNumber.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorPhoneNumber.jsx
@@ -11,7 +11,7 @@ export const CampaignCreatorPhoneNumber = ({
   return (
     <>
       <CampaignCreatorField
-        label="Numéro de téléphone à communiquer aux volontaires (facultatif)"
+        label="Numéro de téléphone (facultatif)"
         name={fieldName}
       >
         <CampaignCreatorInput type="tel" name={fieldName} id={fieldName} />

--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorPhoneNumber.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorPhoneNumber.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { useFormikContext } from "formik";
+import { CampaignCreatorField } from "components/partners/campaign_creator/fields/CampaignCreatorField";
+import { CampaignCreatorInput } from "components/partners/campaign_creator/fields/CampaignCreatorInput";
+
+export const CampaignCreatorPhoneNumber = ({
+  vaccinationCenterPhoneNumber
+}) => {
+  const fieldName = "phoneNumber"
+  const { setFieldValue, values } = useFormikContext();
+  return (
+    <>
+      <CampaignCreatorField label="Numéro de téléphone à communiquer aux volontaires (facultatif)" name={fieldName}>
+        <CampaignCreatorInput
+          type="tel"
+          name={fieldName}
+          id={fieldName}
+        />
+      </CampaignCreatorField>
+      { vaccinationCenterPhoneNumber && values[fieldName] !== vaccinationCenterPhoneNumber && (
+        <button
+          className="btn btn-outline-primary btn-sm"
+          type="button"
+          onClick={() => setFieldValue(fieldName, vaccinationCenterPhoneNumber)}
+        >
+          Utiliser le numéro du centre de vaccination ({vaccinationCenterPhoneNumber})
+        </button>
+      ) }
+    </>
+  );
+};

--- a/app/javascript/components/partners/campaign_creator/initialFormState.jsx
+++ b/app/javascript/components/partners/campaign_creator/initialFormState.jsx
@@ -26,5 +26,6 @@ export function initialFormState(initialCampaign) {
     startsAt,
     endsAt,
     extraInfo: "",
+    phoneNumber: initialCampaign.phoneNumber || "",
   };
 }

--- a/app/javascript/components/partners/campaign_creator/validateCampaignCreatorForm.js
+++ b/app/javascript/components/partners/campaign_creator/validateCampaignCreatorForm.js
@@ -77,7 +77,7 @@ export const validateCampaignCreatorForm = (values) => {
 
   // Campaign launch date validation
   if (now.isBefore(now.hour(7))) {
-    errors.extraInfo =
+    errors.checkNotify =
       "Les campagnes ne peuvent pas être lancées avant 7h du matin, pour ne pas prévenir de volontaires dans leur sommeil.";
   }
 

--- a/app/jobs/push_new_campaign_to_slack_job.rb
+++ b/app/jobs/push_new_campaign_to_slack_job.rb
@@ -39,6 +39,13 @@ class PushNewCampaignToSlackJob < ApplicationJob
       })
     end
 
+    if campaign.phone_number
+      context.append({
+        type: "mrkdwn",
+        text: "📞 #{campaign.phone_number}"
+      })
+    end
+
     blocks = [
       {
         type: "section",

--- a/app/models/vaccination_center.rb
+++ b/app/models/vaccination_center.rb
@@ -132,7 +132,7 @@ class VaccinationCenter < ApplicationRecord
   def build_campaign_smart_defaults
     last_campaign = campaigns.order(:created_at).last
     if last_campaign
-      last_campaign_slice = last_campaign.as_json.slice("extra_info", "vaccine_type", "min_age", "max_age", "max_distance_in_meters", "available_doses")
+      last_campaign_slice = last_campaign.as_json.slice("extra_info", "phone_number", "vaccine_type", "min_age", "max_age", "max_distance_in_meters", "available_doses")
       campaigns.build(last_campaign_slice)
     else
       campaigns.build

--- a/app/views/match_mailer/send_confirmed_match_details.html.erb
+++ b/app/views/match_mailer/send_confirmed_match_details.html.erb
@@ -16,7 +16,9 @@
       <% if @match.campaign.extra_info.present? %>
         <li>Détails d’accès : <%= @match.campaign.extra_info %></li>
       <% end %>
-      <!-- numéro de téléphone facultatif -->
+      <% if @match.campaign.phone_number.present? %>
+        <li>Numéro de téléphone : <%= @match.campaign.phone_number %></li>
+      <% end %>
     </ul>
   </p>
 

--- a/app/views/matches/_confirmed.html.erb
+++ b/app/views/matches/_confirmed.html.erb
@@ -22,3 +22,12 @@
     </p>
   </div>
 <% end %>
+
+<% if match.campaign.phone_number.present? %>
+  <div>
+    <p>
+      <i class="fas fa-phone"></i>
+      <%= match.campaign.phone_number %>
+    </p>
+  </div>
+<% end %>

--- a/db/migrate/20210516180557_add_phone_number_to_campaign.rb
+++ b/db/migrate/20210516180557_add_phone_number_to_campaign.rb
@@ -1,0 +1,5 @@
+class AddPhoneNumberToCampaign < ActiveRecord::Migration[6.1]
+  def change
+    add_column :campaigns, :phone_number, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_15_232244) do
+ActiveRecord::Schema.define(version: 2021_05_16_180557) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2021_05_15_232244) do
     t.datetime "canceled_at"
     t.string "algo_version"
     t.jsonb "parameters"
+    t.string "phone_number"
     t.index ["partner_id"], name: "index_campaigns_on_partner_id"
     t.index ["status"], name: "index_campaigns_on_status"
     t.index ["vaccination_center_id"], name: "index_campaigns_on_vaccination_center_id"


### PR DESCRIPTION
Fixes #781

## Résumé

Ajout d'un champ dans le formulaire de campagne pour renseigner un numéro de téléphone qui sera communiqué aux volontaires.

## Détails

J'ai ajouté le champ dans la section créée par @colinemarie dans #782. Le principe est le suivant : 
- lors de la première campagne, le champ est vide
- lors des campagnes suivantes, on utilise la valeur de la dernière campagne par défaut comme pour les autres champs
- si le contenu du champ n'est pas égal au numéro de téléphone du centre de vaccination, un bouton s'affiche pour utiliser ce numéro

![image](https://user-images.githubusercontent.com/3766352/118414202-91626000-b6a3-11eb-976d-289c2cdc9360.png)

![image](https://user-images.githubusercontent.com/3766352/118414223-a3440300-b6a3-11eb-9102-bbd96ea44901.png)

Pour le reste, en gros j'ai cherché où était utilisé le champ `extra_info` et j'ai rajouté `phone_number` aux mêmes endroits puisque les deux champs ont essentiellement le même statut.

J'ai testé la création de campagne et vérifié que le numéro de téléphone était bien enregistré en base de données. J'ai aussi vérifié qu'il apparaissait bien en valeur par défaut pour la campagne suivante.

⚠️⚠️⚠️

En revanche, je n'ai pas vérifié : 
- le mail envoyé aux volontaires
- la page de match
- le message envoyé sur Slack

Ça semble relativement safe a priori donc j'ouvre la PR, si quelqu'un pense que c'est bon et/ou qu'il est en mesure de tester le workflow complet facilement, elle serait mergeable. Sinon, j'essayerai dans la semaine de faire le nécessaire pour pouvoir tester de A à Z (j'imagine qu'il faut notamment créer des volontaires dans la bonne zone).

Dernière chose, je n'ai pas crypté le numéro de téléphone en base de données, j'ai vu que ce n'était pas fait pour les centres de vaccination donc ça m'a paru cohérent.
