### PR TITLE
Ajout d'un avertissement si une campagne semble être pour une autre date

### DIFF
--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorExtraInfo.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorExtraInfo.jsx
@@ -1,10 +1,15 @@
 import React from "react";
-import { Field } from "formik";
+import { Field, useFormikContext } from "formik";
 import { CampaignCreatorField } from "components/partners/campaign_creator/fields/CampaignCreatorField";
 
 export const CampaignCreatorExtraInfo = () => {
+  const { values } = useFormikContext();
   return (
-    <CampaignCreatorField label="Détails d’accès" name="extraInfo">
+    <CampaignCreatorField
+      label="Détails d’accès"
+      name="extraInfo"
+      warning={dateInExtraInfoWarning(values.extraInfo)}
+    >
       <Field
         as="textarea"
         name="extraInfo"
@@ -16,4 +21,16 @@ export const CampaignCreatorExtraInfo = () => {
       />
     </CampaignCreatorField>
   );
+};
+
+const dateInExtraInfoWarning = (info) => {
+  const dateRegex = /(lundi|mardi|mercredi|jeudi|vendredi|janvier|f[eé]vrier|mars|avril|mai|juin|juillet|ao[uû]t|septembre|octobre|novembre|d[eé]cembre|demain)/i;
+  if (info.match(dateRegex)) {
+    return (
+      <>
+        Votre message semble contenir une date : n'oubliez pas que les campagnes
+        doivent être envoyées pour le jour même !
+      </>
+    );
+  }
 };


### PR DESCRIPTION
Fixes #772

## Résumé

Le champ "Détails d’accès" dans les campagnes peut être utilisé pour indiquer une date différente de celle d'aujourd'hui. Nous ajoutons un message pour dissuader les partenaires de faire cela.

## Détails

J'ai mis un warning **non-bloquant** si le message contient un nom de jour ou de mois, ou "demain".

![image](https://user-images.githubusercontent.com/3766352/118438994-7dd7e900-b6e5-11eb-8d27-b33473eb18d1.png)

C'est très facile de le transformer en erreur (bloquante) si vous pensez que c'est préférable. Dites-moi !
