### PR TITLE
Replace `master` with `main` for badges and doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Covidliste
 
-[![Test](https://github.com/hostolab/covidliste/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/hostolab/covidliste/actions/workflows/test.yml)
+[![Test](https://github.com/hostolab/covidliste/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/hostolab/covidliste/actions/workflows/test.yml)
 [![Ruby Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://github.com/testdouble/standard)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=hostolab_covidliste&metric=security_rating)](https://sonarcloud.io/dashboard?id=hostolab_covidliste)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=hostolab_covidliste&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=hostolab_covidliste)
-[![codecov](https://codecov.io/gh/hostolab/covidliste/branch/master/graph/badge.svg?token=Z6SM94ONW9)](https://codecov.io/gh/hostolab/covidliste)
+[![codecov](https://codecov.io/gh/hostolab/covidliste/branch/main/graph/badge.svg?token=Z6SM94ONW9)](https://codecov.io/gh/hostolab/covidliste)
 
 [Covidliste](https://www.covidliste.com) makes it easy to manage waiting lists for vaccination centers in France.
 We aim to minimize vaccine losses by connecting people who wish to be inoculated with health vaccination centers with unused doses at the end of the day.

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -47,7 +47,7 @@ You may:
 
 - Only some contributors are authorized to merge (see [champions](./champions.md) to see who).
 - More are allowed to review, easing the work of those who can merge.
-- Merging in `master` will automatically deploy to production.
+- Merging in `main` will automatically deploy to production.
 
 ## Reviewing code
 


### PR DESCRIPTION
## Résumé

Remplace `master` par `main` à 2 endroits : pour les badges des tests et de la couverture de tests dans le README et dans un doc.

## Détails

- 3 remplacements simples
- je n'ai pas repéré d'autres occurrences pertinences du renommage du repo