### PR TITLE
Hotfix match confirmation email

### DIFF
--- a/app/jobs/send_confirmed_match_email_job.rb
+++ b/app/jobs/send_confirmed_match_email_job.rb
@@ -1,5 +1,5 @@
 class SendConfirmedMatchEmailJob < ApplicationJob
-  queue_as :mailer
+  queue_as :mailers
 
   def perform(match_id)
     match = Match.find(match_id)


### PR DESCRIPTION
## Résumé

Les mails de confirmation de match ne partaient pas, ceci le fix.

## Détails

⚠️ Commande à exécuter post merge pour déplacer les jobs de `mailer` vers `mailers`
```ruby
count_block = proc{ Sidekiq.redis do |conn|
  conn.llen("queue:mailer")  
end }

while count_block.call > 0
  Sidekiq.redis do |conn|
    conn.rpoplpush "queue:mailer", "queue:mailers"
  end
end
```
(testé et approuvé en local)
 
It's all about that s, 'bout that s
