### PR TITLE
Empêcher les matchs confirmés de supprimer leur compte

### DIFF
--- a/app/controllers/matches/users_controller.rb
+++ b/app/controllers/matches/users_controller.rb
@@ -3,6 +3,10 @@ module Matches
     before_action :set_match, only: [:edit, :destroy]
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+    def pundit_user
+      @match.user
+    end
+
     def edit
     end
 
@@ -19,10 +23,10 @@ module Matches
 
       if @match.blank?
         flash[:error] = "Désolé, ce lien d’invitation n’est pas valide."
-        redirect_to root_path
+        return redirect_to root_path
       elsif @match.user.blank?
         flash[:error] = "Désolé, ce lien d’invitation n’est plus valide. L’utilisateur a été supprimé."
-        redirect_to root_path
+        return redirect_to root_path
       end
       authorize @match
     end

--- a/app/controllers/matches/users_controller.rb
+++ b/app/controllers/matches/users_controller.rb
@@ -1,11 +1,13 @@
 module Matches
   class UsersController < ApplicationController
     before_action :set_match, only: [:edit, :destroy]
+    rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
     def edit
     end
 
     def destroy
+      authorize @match.user, :delete?
       @match.user.anonymize!
       redirect_to root_path, notice: "🎉 🎉 🎉 Votre compte a été supprimé de nos serveurs. Portez-vous bien."
     end
@@ -23,6 +25,14 @@ module Matches
         redirect_to root_path
       end
       authorize @match
+    end
+
+    def user_not_authorized(exception)
+      policy_name = exception
+        .policy.class.to_s.underscore
+      message = exception.message || (t "#{policy_name}.#{exception.query}", scope: "pundit", default: :default)
+      flash[:error] = message
+      redirect_back(fallback_location: root_path)
     end
   end
 end

--- a/app/views/matches/users/edit.html.erb
+++ b/app/views/matches/users/edit.html.erb
@@ -1,13 +1,29 @@
-<div class="container">
-  <div class="d-flex align-items-center flex-column my-4 my-lg-5">
-    <h4 class="text-center">
-      Vous souhaitez vous désinscrire de Covidliste en supprimant votre compte ?
-    </h4>
-    <%= button_to "Supprimer mon compte", matches_users_path(match_confirmation_token: @match.match_confirmation_token),
-          method: :delete,
-          id: dom_id(@match.user, :delete),
-          class: "btn btn-outline-danger btn-lg mt-4",
-          data: {
-            confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr ?"} %>
+<% if @match.confirmed? %>
+
+  <div class="container">
+    <div class="d-flex align-items-center flex-column my-4 my-lg-5">
+      <h4 class="text-center mb-4">
+        Vous avez confirmé votre rendez-vous.
+      </h4>
+      <p class="alert alert-info">
+        Vous ne pouvez pas supprimer vos informations actuellement car vous avez confirmé un rendez-vous de vaccination.
+        <br>
+        Votre profil sera anonymisé quelques jours après le RDV.
+      </p>
+    </div>
   </div>
-</div>
+<% else %>
+  <div class="container">
+    <div class="d-flex align-items-center flex-column my-4 my-lg-5">
+      <h4 class="text-center">
+        Vous souhaitez vous désinscrire de Covidliste en supprimant votre compte ?
+      </h4>
+      <%= button_to "Supprimer mon compte", matches_users_path(match_confirmation_token: @match.match_confirmation_token),
+        method: :delete,
+        id: dom_id(@match.user, :delete),
+        class: "btn btn-outline-danger btn-lg mt-4",
+        data: {
+          confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr ?"} %>
+    </div>
+  </div>
+<% end %>

--- a/spec/system/matches/destroy_user_account_spec.rb
+++ b/spec/system/matches/destroy_user_account_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Destroy user account from match email", type: :system do
   subject { visit match_path(match_confirmation_token, source: "sms") }
 
   context "with a valid match" do
-    scenario "the user can destroy he account" do
+    scenario "the user can destroy their account" do
       visit edit_matches_users_path(match_confirmation_token: match_confirmation_token)
       expect(page).to have_current_path(edit_matches_users_path, ignore_query: true)
       expect(page).to have_selector(:id, dom_id(user, :delete))
@@ -29,6 +29,23 @@ RSpec.describe "Destroy user account from match email", type: :system do
       expect(page).to have_selector(:id, dom_id(user, :delete))
       visit profile_path
       expect(page).to have_current_path(new_user_session_path)
+    end
+  end
+
+  context "with a confirmed match" do
+    before do
+      visit match_path(match_confirmation_token, source: "sms")
+      fill_in :user_firstname, with: user.firstname
+      fill_in :user_lastname, with: user.lastname
+      check :confirm_age
+      check :confirm_name
+      click_on("Je confirme le RDV")
+    end
+    scenario "the user cannot destroy their account" do
+      visit edit_matches_users_path(match_confirmation_token: match_confirmation_token)
+      expect(page).to have_current_path(edit_matches_users_path, ignore_query: true)
+      expect(page).to_not have_selector(:id, dom_id(user, :delete))
+      expect(page).to have_text("Vous ne pouvez pas supprimer vos informations")
     end
   end
 end


### PR DESCRIPTION
Fixes #802 

<img src="https://user-images.githubusercontent.com/5511564/118563102-3fd2d780-b76e-11eb-83a2-671e87e2d7fd.png">

## Résumé

Actuellement les volontaires peuvent supprimer leur compte après avoir été matchés via le lien dans leur mail. Cela nous empêche de fournir leurs informations aux centres et créé des bugs.
Ce changement les en empêche.

## Détails

* Test mis à jour
* Le bouton de suppression de compte n'est pas affiché si match confirmé
* La suppression de compte est bloquée de toute façon par pundit, si le bouton de suppression était sur une page déjà chargée.
