### PR TITLE
Re-ajout du nom prénom dans Match details 

### DIFF
--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -49,9 +49,9 @@
       <strong> Informations personnelles </strong>
       <p>
         Date de naissance : <strong><%= user.birthdate.strftime('%d/%m/%Y') %></strong><br>
-        <strong>Date de naissance et nom seront vérifiés.</strong> <br>
-        Munissez-vous d’une pièce d’identité et de votre
-        carte vitale.<br>
+        <% if match.confirmed? %>
+          Identité : <strong><%= user.full_name %></strong>
+        <% end %>
       </p>
     </div>
   <% end %>


### PR DESCRIPTION
## Résumé

Les nom/prénom avaient disparu des détails du match confirmé et la mention "nom prénom seront vérifiés..." apparaissaient en double.

APRES
<img width="1139" alt="Capture d’écran 2021-05-18 à 00 27 18" src="https://user-images.githubusercontent.com/68182973/118564339-701b7580-b770-11eb-9706-60dd074fe89f.png">
<img width="714" alt="Capture d’écran 2021-05-18 à 00 27 39" src="https://user-images.githubusercontent.com/68182973/118564392-7873b080-b770-11eb-8728-d724c25ad465.png">


AVANT
<img width="898" alt="Capture d’écran 2021-05-18 à 00 29 38" src="https://user-images.githubusercontent.com/68182973/118564411-8295af00-b770-11eb-9f70-88fd51056ac3.png">
<img width="748" alt="Capture d’écran 2021-05-18 à 00 29 48" src="https://user-images.githubusercontent.com/68182973/118564419-85909f80-b770-11eb-9fbb-66cd6226710b.png">



