### PR TITLE
Fix babel warning about private-methods

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -63,6 +63,12 @@ module.exports = function (api) {
         },
       ],
       [
+        "@babel/plugin-proposal-private-methods",
+        {
+          loose: true,
+        },
+      ],
+      [
         "@babel/plugin-transform-runtime",
         {
           helpers: false,


### PR DESCRIPTION
This PR fix the following warning:

> 
> Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
> The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
> 	["@babel/plugin-proposal-private-methods", { "loose": true }]
> to the "plugins" section of your Babel config.

Source: https://github.com/rails/webpacker/pull/3016