### PR TITLE
Remove ulule banner

### DIFF
--- a/app/views/layouts/_banner.html.erb
+++ b/app/views/layouts/_banner.html.erb
@@ -1,3 +1,4 @@
+<!-- banner model to render in application layout if needed -->
 <div class="bg-light">
   <div class="container py-2">
     <%= link_to "https://fr.ulule.com/covidliste/", target: "_blank", class: "d-flex align-items-center justify-content-center flex-column flex-md-row font-weight-light text-primary text-center text-decoration-underline" do %>

--- a/app/views/layouts/admin_application.html.erb
+++ b/app/views/layouts/admin_application.html.erb
@@ -14,7 +14,6 @@
 <body>
 <div class="layout">
   <div class="layout__above-footer">
-    <%= render "layouts/banner" %>
     <%= render "layouts/admin_navbar" %>
     <div class="layout__content <%= "layout__content--no-padding" if @no_layout_content_padding ||= false %>">
       <%= render "layouts/alerts" unless @no_layout_alerts ||= false %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,6 @@
 <body>
 <div class="layout">
   <div class="layout__above-footer">
-    <%= render "layouts/banner" %>
     <%= render "layouts/navbar" %>
     <div class="layout__content <%= "layout__content--no-padding" if @no_layout_content_padding ||= false %>">
       <%= render "layouts/alerts" unless @no_layout_alerts ||= false %>


### PR DESCRIPTION
## Résumé

C'est la fin de la campagne 👋🏼 la banner
<img width="1064" alt="Capture d’écran 2021-05-21 à 11 41 55" src="https://user-images.githubusercontent.com/68182973/119117830-eb5b8080-ba29-11eb-940e-f9d2e3064b49.png">


## Détails

La partial banner existe toujours si on veut la réutiliser. J'ai juste supprimé le render dans `application.html.erb` et `admin_application.html.erb`