### PR TITLE
Match throttling

### DIFF
--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -27,13 +27,15 @@ RSpec.describe Match, type: :model do
       expect(match.geo_context).to eq "GEO_CONTEXT"
     end
 
-    context "user has already a recent match" do
+    context "user has already too many matches" do
       let(:user) { create(:user) }
       before do
-        create(:match, user: user)
+        5.times.each do |i|
+          create(:match, user: user)
+        end
       end
       it "should not create a second match" do
-        expect { create(:match, user: user) }.to raise_error(ActiveRecord::RecordInvalid, "La validation a échoué : Cette personne a déjà été matchée récemment")
+        expect { create(:match, user: user) }.to raise_error(ActiveRecord::RecordInvalid, "La validation a échoué : Too many matches for this user")
       end
     end
   end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Match, type: :model do
       expect(match.geo_context).to eq "GEO_CONTEXT"
     end
 
+    context "same campaign" do
+      let(:user) { create(:user) }
+      before do
+        create(:match, user: user, campaign: campaign)
+      end
+      it "should not create a second match for the same campaign" do
+        expect { create(:match, user: user, campaign: campaign) }.to raise_error
+      end
+    end
+
     context "user has already too many matches" do
       let(:user) { create(:user) }
       before do


### PR DESCRIPTION
## Résumé

- Un volontaire ne peut pas être matché + de 5 fois (`THROTTLING_RATE`)  par 24 heures (`THROTTLING_INTERVAL`)
- Un volontaire ne peut être matché 2 fois sur la meme campagne.

Cette nouvelle remplace la précédente qui était:
- Un volontaire ne peut pas être matché + d'une fois toute les 3 heures