### PR TITLE
Réparer un avertissement dans la suite de tests automatisés

### DIFF
--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Match, type: :model do
         create(:match, user: user, campaign: campaign)
       end
       it "should not create a second match for the same campaign" do
-        expect { create(:match, user: user, campaign: campaign) }.to raise_error
+        expect { create(:match, user: user, campaign: campaign) }.to raise_error(ActiveRecord::RecordInvalid)
       end
     end
 


### PR DESCRIPTION
## Résumé

Un simple changement qui permet de faire disparaître un warning de RSpec.

## Détails

N/A
