### PR TITLE
Remove an infinite loop within the reverse geocoding job

### DIFF
--- a/app/jobs/reverse_geocode_resource_job.rb
+++ b/app/jobs/reverse_geocode_resource_job.rb
@@ -5,6 +5,7 @@ class ReverseGeocodeResourceJob < ApplicationJob
     return if resource.nil? || resource.try(:lat).nil? || resource.try(:lon).nil?
 
     result = ReverseGeocodingService.new(resource.lat, resource.lon).call
+    resource.try(:skip_reverse_geocode=, true)
     resource.update!(result.slice(*resource.attributes.keys.map(&:to_sym))) if result
   rescue => error
     Rails.logger.error(error.message)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   has_phone_number_types %i[mobile]
   rolify
 
-  attr_accessor :address
+  attr_accessor :address, :skip_reverse_geocode
 
   devise :magic_link_authenticatable, :confirmable, :validatable
 
@@ -38,7 +38,8 @@ class User < ApplicationRecord
   before_save :extract_email_domain, if: -> { will_save_change_to_email? }
   before_save :randomize_lat_lon, if: -> { (will_save_change_to_lat? || will_save_change_to_lon?) }
   before_save :get_grid_cell, if: -> { (will_save_change_to_lat? || will_save_change_to_lon?) }
-  after_commit :reverse_geocode, if: -> { (saved_change_to_lat? || saved_change_to_lon?) && anonymized_at.nil? }
+  after_commit :reverse_geocode, if: -> { (saved_change_to_lat? || saved_change_to_lon?) && anonymized_at.nil? }, unless: :skip_reverse_geocode
+
   before_destroy :refuse_pending_matching, prepend: true
   after_create_commit :increment_total_users_counter
 


### PR DESCRIPTION
## Summary

After noticing that the workers were always busy locally, I found, what I believe is, some kind of infinite loop. This PR aims at fixing it.

## Détails

1. We do the `User#reverse_geocode` thanks to the `after_commit`,
2. We trigger a job that recompute the `lat` and `lon`,
3. We randomize the `lat` and `lon`, thanks to the `before_save`,
4. The job save and commit the updated resource and... we go back to `1.` :recycle: 

To avoid that, we skip the `after_commit :reverse_geocode` when we're about to save from the reverse geocode job itself.