### PR TITLE
Déplacement du message d'erreur pour les campagnes avant 7h

### DIFF
--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorChecks.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorChecks.jsx
@@ -1,9 +1,8 @@
 import React from "react";
 import { Field, useFormikContext } from "formik";
-import { CampaignCreatorField } from "components/partners/campaign_creator/fields/CampaignCreatorField";
 
 export const CampaignCreatorChecks = () => {
-  const { values } = useFormikContext();
+  const { getFieldMeta, values } = useFormikContext();
   return (
     <div>
       <fieldset className="form-group boolean required">
@@ -25,6 +24,11 @@ export const CampaignCreatorChecks = () => {
             {values.endsAt?.format("HH:mm")}
           </label>
         </div>
+        { getFieldMeta("checkDoses").error && (
+          <div className="alert alert-danger" role="alert">
+            {getFieldMeta("checkDoses").error}
+          </div>
+        ) }
       </fieldset>
       <fieldset className="form-group boolean required">
         <div className="form-check">
@@ -45,6 +49,11 @@ export const CampaignCreatorChecks = () => {
           </label>
         </div>
       </fieldset>
+        { getFieldMeta("checkNotify").error && (
+          <div className="alert alert-danger" role="alert">
+            {getFieldMeta("checkNotify").error}
+          </div>
+        ) }
     </div>
   );
 };

--- a/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorChecks.jsx
+++ b/app/javascript/components/partners/campaign_creator/fields/CampaignCreatorChecks.jsx
@@ -24,11 +24,11 @@ export const CampaignCreatorChecks = () => {
             {values.endsAt?.format("HH:mm")}
           </label>
         </div>
-        { getFieldMeta("checkDoses").error && (
+        {getFieldMeta("checkDoses").error && (
           <div className="alert alert-danger" role="alert">
             {getFieldMeta("checkDoses").error}
           </div>
-        ) }
+        )}
       </fieldset>
       <fieldset className="form-group boolean required">
         <div className="form-check">
@@ -49,11 +49,11 @@ export const CampaignCreatorChecks = () => {
           </label>
         </div>
       </fieldset>
-        { getFieldMeta("checkNotify").error && (
-          <div className="alert alert-danger" role="alert">
-            {getFieldMeta("checkNotify").error}
-          </div>
-        ) }
+      {getFieldMeta("checkNotify").error && (
+        <div className="alert alert-danger" role="alert">
+          {getFieldMeta("checkNotify").error}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/javascript/components/partners/campaign_creator/validateCampaignCreatorForm.js
+++ b/app/javascript/components/partners/campaign_creator/validateCampaignCreatorForm.js
@@ -79,7 +79,7 @@ export const validateCampaignCreatorForm = (values) => {
 
   // Campaign launch date validation
   if (now.isBefore(now.hour(7))) {
-    errors.extraInfo =
+    errors.checkNotify =
       "Les campagnes ne peuvent pas être lancées avant 7h du matin, pour ne pas prévenir de volontaires dans leur sommeil.";
   }
 


### PR DESCRIPTION
## Résumé

Le message d'erreur est déplacé en bas du formulaire, près de la checkbox où le partenaire coche la case disant qu'il va réveiller des gens.

![image](https://user-images.githubusercontent.com/3766352/119220749-52da0480-baec-11eb-9f72-1502007d9257.png)


## Détails

Problème repéré au cours de la PR #793 qui a été annulée.