### PR TITLE
Affichage du numéro de téléphone du centre dans les campagnes

### DIFF
--- a/app/assets/stylesheets/config/_index.scss
+++ b/app/assets/stylesheets/config/_index.scss
@@ -2,5 +2,6 @@
 @import "colors";
 @import "typography";
 @import "navbar";
+@import "tooltip";
 
 $spacer: 1.2rem !default;

--- a/app/assets/stylesheets/config/_tooltip.scss
+++ b/app/assets/stylesheets/config/_tooltip.scss
@@ -1,0 +1,1 @@
+$tooltip-max-width: 250px;

--- a/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
+++ b/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
@@ -62,7 +62,17 @@ const _CampaignCreator = ({
                 d’identité.
               </p>
               <CampaignCreatorExtraInfo />
-              {/*ajouter la possibilité de faire apparaître son téléphone*/}
+              <p
+                tabIndex={0}
+                data-toggle="tooltip"
+                title="Mauvais numéro ?<br/>Contactez-nous à partenaires@covidliste.com"
+                data-html="true"
+                data-placement="right"
+              >
+                <em>Votre numéro {vaccinationCenter.phoneNumber} sera communiqué aux volontaires ayant confirmé leur venue.</em>
+                {' '}
+                ℹ️
+              </p>
 
               <h2>
                 <i className="fas fa-bullhorn"></i> Lancer la campagne

--- a/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
+++ b/app/javascript/components/partners/campaign_creator/CampaignCreator.jsx
@@ -69,8 +69,10 @@ const _CampaignCreator = ({
                 data-html="true"
                 data-placement="right"
               >
-                <em>Votre numéro {vaccinationCenter.phoneNumber} sera communiqué aux volontaires ayant confirmé leur venue.</em>
-                {' '}
+                <em>
+                  Votre numéro {vaccinationCenter.phoneNumber} sera communiqué
+                  aux volontaires ayant confirmé leur venue.
+                </em>{" "}
                 ℹ️
               </p>
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -31,7 +31,7 @@ document.addEventListener("turbolinks:load", () => {
   togglePasswordVisibility();
   smoothScrollAnchor();
   toggleMobileMatchInformation();
-  $('body').tooltip({ selector: '[data-toggle="tooltip"]' });
+  $("body").tooltip({ selector: '[data-toggle="tooltip"]' });
 
   // webpack will load this JS async
   if (document.getElementById("fuzzy-search")) {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -31,7 +31,7 @@ document.addEventListener("turbolinks:load", () => {
   togglePasswordVisibility();
   smoothScrollAnchor();
   toggleMobileMatchInformation();
-  $('[data-toggle="tooltip"]').tooltip();
+  $('body').tooltip({ selector: '[data-toggle="tooltip"]' });
 
   // webpack will load this JS async
   if (document.getElementById("fuzzy-search")) {

--- a/app/views/match_mailer/send_confirmed_match_details.html.erb
+++ b/app/views/match_mailer/send_confirmed_match_details.html.erb
@@ -14,7 +14,7 @@
       <% if @match.campaign.extra_info.present? %>
         <li>Détails d’accès : <%= @match.campaign.extra_info %></li>
       <% end %>
-      <li>Numéro de téléphone : <%= @match.vaccination_center.phone_number %></li>
+      <li>Numéro de téléphone : <%= @match.vaccination_center.human_friendly_phone_number %></li>
     </ul>
   </p>
 

--- a/app/views/match_mailer/send_confirmed_match_details.html.erb
+++ b/app/views/match_mailer/send_confirmed_match_details.html.erb
@@ -14,7 +14,7 @@
       <% if @match.campaign.extra_info.present? %>
         <li>Détails d’accès : <%= @match.campaign.extra_info %></li>
       <% end %>
-      <!-- numéro de téléphone facultatif -->
+      <li>Numéro de téléphone : <%= @match.vaccination_center.phone_number %></li>
     </ul>
   </p>
 

--- a/app/views/matches/_confirmed.html.erb
+++ b/app/views/matches/_confirmed.html.erb
@@ -17,7 +17,7 @@
 <% if match.campaign.extra_info.present? %>
   <div>
     <p>
-      <i class="fas fa-info-circle"></i>
+      <%= icon("fas", "info-circle") %>
       <%= match.campaign.extra_info %>
     </p>
   </div>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -13,7 +13,7 @@
       <strong>Numéro de téléphone</strong>
       <p>
         <a href="tel:<%= vaccination_center.phone_number %>">
-          <%= vaccination_center.phone_number %>
+          <%= vaccination_center.human_friendly_phone_number %>
         </a>
       </p>
     <% else %>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -9,6 +9,13 @@
       <p>
         <%= vaccination_center.address %>
       </p>
+      <i class="fas fa-phone"></i>
+      <strong>Numéro de téléphone</strong>
+      <p>
+        <a href="tel:<%= vaccination_center.phone_number %>">
+          <%= vaccination_center.phone_number %>
+        </a>
+      </p>
     <% else %>
       <strong> Distance du centre de vaccination </strong>
       <p>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -3,13 +3,13 @@
 
 <div class="row">
   <div class="col-sm-12 col-md-6 col-lg-6">
-    <i class="fas fa-map-pin"></i>
+    <%= icon("fas", "map-pin") %>
     <% if match.confirmed? || vaccination_center.lat.blank? || vaccination_center.lon.blank? %>
       <strong> Adresse du centre de vaccination </strong>
       <p>
         <%= vaccination_center.address %>
       </p>
-      <i class="fas fa-phone"></i>
+      <%= icon("fas", "phone") %>
       <strong>Numéro de téléphone</strong>
       <p>
         <a href="tel:<%= vaccination_center.phone_number %>">
@@ -34,7 +34,7 @@
   </div>
 
   <div class="col-sm-12 col-md-6 col-lg-6">
-    <i class="fas fa-clock"></i>
+    <%= icon("fas", "clock") %>
     <strong> Créneau horaire </strong>
     <% starts_at = match.campaign.starts_at %>
     <% ends_at = match.campaign.ends_at %>
@@ -46,13 +46,13 @@
 
   <% if user.blank? %>
     <div class="col-sm-12 col-md-6 col-lg-6">
-      <i class="fas fa-minus-circle"></i>
+      <%= icon("fas", "minus-circle") %>
       <p>L’utilisateur a supprimé son compte.</p>
     </div>
     <%# elsif user.anonymized_at #TODO PR #197 %>
   <% else %>
     <div class="col-sm-12 col-md-6 col-lg-6">
-      <i class="fas fa-user-lock"></i>
+      <%= icon("fas", "user-lock") %>
       <strong> Informations personnelles </strong>
       <p>
         Date de naissance : <strong><%= user.birthdate.strftime('%d/%m/%Y') %></strong><br>
@@ -64,7 +64,7 @@
   <% end %>
 
   <div class="col-sm-12 col-md-6 col-lg-6">
-    <i class="fas fa-check-circle"></i>
+    <%= icon("fas", "check-circle") %>
     <strong>Type de vaccin</strong>
     <p><%= match.campaign.vaccine_type.capitalize %></p>
   </div>

--- a/app/views/partners/vaccination_centers/new.html.erb
+++ b/app/views/partners/vaccination_centers/new.html.erb
@@ -61,11 +61,10 @@
           <%= f.input :astrazeneca, as: :boolean, label: Vaccine::Brands::ASTRAZENECA.capitalize, class: "form-check-inline" %>
           <%= f.input :janssen, as: :boolean, label: Vaccine::Brands::JANSSEN.capitalize %>
           <%= f.input :address, label: "Adresse", error: "Adresse requise", placeholder: "5 rue Larue, 13600 Marseille", required: true %>
-          <%= f.input :phone_number, label: "Numéro de téléphone fixe", error: "Numéro de téléphone requis", placeholder: "01 02 03 04 05", required: true %>
+          <%= f.input :phone_number, label: "Numéro de téléphone public", error: "Numéro de téléphone requis", placeholder: "01 02 03 04 05", required: true %>
           <p class="small text-primary">
             <%= icon("fas", "info-circle", class: "text-secondary") %>
-            Ce numéro sera utilisé pour la vérification de votre centre de vaccination.<br />
-            Il ne sera transmis aux volontaires que si vous le souhaitez, lorsqu'ils auront confirmé leur disponibilité.
+            Ce numéro sera utilisé pour la <strong>vérification de votre centre de vaccination</strong> et il sera <strong>communiqué aux volontaires ayant confirmé leur RDV</strong>.
           </p>
           
           <%= f.button :submit, "Envoyer la demande", class: "btn btn-primary", data: { disable_with: "Validation..." } %>

--- a/app/views/slot_alert_mailer/notify.html.erb
+++ b/app/views/slot_alert_mailer/notify.html.erb
@@ -10,7 +10,7 @@
 
   <div class="row">
   <div class="col-sm-12 col-md-6 col-lg-6">
-    <i class="fas fa-map-pin"></i>
+    <%= icon("fas", "map-pin") %>
     <p>
       <strong> Centre de vaccination </strong>
       <br/><%= @slot.name %>
@@ -25,7 +25,7 @@
   </div>
 
   <div class="col-sm-12 col-md-6 col-lg-6 mt-2">
-    <i class="fas fa-check-circle"></i>
+    <%= icon("fas", "check-circle") %>
     <p>
       <strong>Type de vaccin</strong>
       <br/><%= @slot.vaccine_type %>


### PR DESCRIPTION
Fixes #781

## Résumé

Le numéro de téléphone indiqué lors de la création d'un centre de vaccination est désormais communiqué aux volontaires après confirmation du match.

## Détails

### Précision sur le formulaire de création du centre de vaccination

![image](https://user-images.githubusercontent.com/3766352/119223086-bb7aae80-baf7-11eb-8551-e9d62f8e5ba7.png)

### Précision sur le formulaire de création de campagne 
 
![image](https://user-images.githubusercontent.com/3766352/119223117-ee24a700-baf7-11eb-9bb6-0eacd04b196d.png)

### Précision au survol

NB : le mail n'est pas cliquable parce que le tooltip disparait quand on essaye d'aller dessus... j'ai cherché des manières de contourner le problème mais c'était sans compter l'équation fondamentale :
```
React + jQuery + bootstrap.js = 🤯 
```

![image](https://user-images.githubusercontent.com/3766352/119223125-fb419600-baf7-11eb-9003-010f2a31f009.png)

### Affichage dans le mail et la page de confirmation

![image](https://user-images.githubusercontent.com/3766352/119223134-072d5800-baf8-11eb-9117-127a5e69588a.png)
