### PR TITLE
Allow user authentication from email links

### DIFF
--- a/app/controllers/concerns/user_authentication_via_signed_id.rb
+++ b/app/controllers/concerns/user_authentication_via_signed_id.rb
@@ -1,0 +1,14 @@
+module UserAuthenticationViaSignedId
+  extend ActiveSupport::Concern
+
+  def authenticate_user_via_signed_id!(purpose: "#{controller_name}.#{action_name}")
+    if params.key?("authentication_token")
+      @current_user = User.find_signed(
+        params.fetch("authentication_token"),
+        purpose: purpose
+      )
+    end
+
+    authenticate_user! unless user_signed_in?
+  end
+end

--- a/app/controllers/matches/users_controller.rb
+++ b/app/controllers/matches/users_controller.rb
@@ -1,6 +1,6 @@
 module Matches
   class UsersController < ApplicationController
-    before_action :set_match, only: [:edit, :destroy]
+    before_action :set_match, only: [:edit]
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
     def pundit_user
@@ -8,12 +8,6 @@ module Matches
     end
 
     def edit
-    end
-
-    def destroy
-      authorize @match.user, :destroy?
-      @match.user.anonymize!
-      redirect_to root_path, notice: "🎉 🎉 🎉 Votre compte a été supprimé de nos serveurs. Portez-vous bien."
     end
 
     private

--- a/app/controllers/matches/users_controller.rb
+++ b/app/controllers/matches/users_controller.rb
@@ -11,7 +11,7 @@ module Matches
     end
 
     def destroy
-      authorize @match.user, :delete?
+      authorize @match.user, :destroy?
       @match.user.anonymize!
       redirect_to root_path, notice: "🎉 🎉 🎉 Votre compte a été supprimé de nos serveurs. Portez-vous bien."
     end

--- a/app/controllers/slot_alerts/users_controller.rb
+++ b/app/controllers/slot_alerts/users_controller.rb
@@ -11,7 +11,7 @@ module SlotAlerts
     end
 
     def destroy
-      authorize @alert.user, :delete?
+      authorize @alert.user, :destroy?
       @alert.user.anonymize!
       redirect_to root_path, notice: "🎉 🎉 🎉 Votre compte a été supprimé de nos serveurs. Portez-vous bien."
     end

--- a/app/controllers/slot_alerts/users_controller.rb
+++ b/app/controllers/slot_alerts/users_controller.rb
@@ -1,6 +1,6 @@
 module SlotAlerts
   class UsersController < ApplicationController
-    before_action :set_alert, only: [:destroy, :edit]
+    before_action :set_alert, only: [:edit]
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
     def pundit_user
@@ -8,12 +8,6 @@ module SlotAlerts
     end
 
     def edit
-    end
-
-    def destroy
-      authorize @alert.user, :destroy?
-      @alert.user.anonymize!
-      redirect_to root_path, notice: "🎉 🎉 🎉 Votre compte a été supprimé de nos serveurs. Portez-vous bien."
     end
 
     private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,10 @@ class UsersController < ApplicationController
   invisible_captcha only: [:create], honeypot: :subtitle
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  def index
+    redirect_to action: :new
+  end
+
   def new
     skip_authorization
     if current_partner
@@ -55,12 +59,12 @@ class UsersController < ApplicationController
     render action: :new, status: :unprocessable_entity
   end
 
-  def delete
+  def destroy
     @user = current_user
     authorize @user
     sign_out @user
     @user.anonymize!
-    flash[:success] = "Votre compte a bien été supprimé."
+    flash[:success] = "🎉 🎉 🎉 Votre compte a été supprimé de nos serveurs. Portez-vous bien."
     redirect_to root_path
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,8 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!, except: %i[new create]
+  include UserAuthenticationViaSignedId
+
+  before_action :authenticate_user!, except: %i[new create destroy]
+  before_action :authenticate_user_via_signed_id!, only: %i[destroy]
   before_action :sign_out_if_anonymized!
   invisible_captcha only: [:create], honeypot: :subtitle
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -32,4 +32,6 @@ class UserPolicy < ApplicationPolicy
 
     user == record
   end
+
+  alias_method :confirm_destroy?, :destroy?
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -25,7 +25,7 @@ class UserPolicy < ApplicationPolicy
     user == record
   end
 
-  def delete?
+  def destroy?
     if user.matches.confirmed.any?
       raise Pundit::NotAuthorizedError, "Vous ne pouvez pas supprimer vos informations actuellement car vous avez confirmé un rendez-vous de vaccination. Votre profil sera anonymisé quelques jours après le RDV."
     end

--- a/app/services/randomize_coordinates_service.rb
+++ b/app/services/randomize_coordinates_service.rb
@@ -8,13 +8,19 @@ class RandomizeCoordinatesService
   end
 
   def call
-    dy = rand(-@meters_range..@meters_range) / 1000.0
-    dx = rand(-@meters_range..@meters_range) / 1000.0
+    dy = generate_random_delta
+    dx = generate_random_delta
 
     new_lat = @lat + (dy / EARTH_RADIUS) * (180 / Math::PI)
     new_lon = @lon + (dx / EARTH_RADIUS) * (180 / Math::PI) / Math.cos(@lat * Math::PI / 180)
     distance = Geocoder::Calculations.distance_between([@lat, @lon], [new_lat, new_lon], {unit: :km})
 
     {lat: new_lat, lon: new_lon, distance_from_original: distance, dy: dy, dx: dx}
+  end
+
+  private
+
+  def generate_random_delta
+    rand(-@meters_range..@meters_range) / 1000.0
   end
 end

--- a/app/views/matches/users/edit.html.erb
+++ b/app/views/matches/users/edit.html.erb
@@ -1,5 +1,4 @@
 <% if @match.confirmed? %>
-
   <div class="container">
     <div class="d-flex align-items-center flex-column my-4 my-lg-5">
       <h4 class="text-center mb-4">
@@ -13,17 +12,5 @@
     </div>
   </div>
 <% else %>
-  <div class="container">
-    <div class="d-flex align-items-center flex-column my-4 my-lg-5">
-      <h4 class="text-center">
-        Vous souhaitez vous désinscrire de Covidliste en supprimant votre compte ?
-      </h4>
-      <%= button_to "Supprimer mon compte", matches_users_path(match_confirmation_token: @match.match_confirmation_token),
-        method: :delete,
-        id: dom_id(@match.user, :delete),
-        class: "btn btn-outline-danger btn-lg mt-4",
-        data: {
-          confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr ?"} %>
-    </div>
-  </div>
+  <%= render partial: "users/confirm_destroy_message", locals: { user: @match.user } %>
 <% end %>

--- a/app/views/slot_alerts/users/edit.html.erb
+++ b/app/views/slot_alerts/users/edit.html.erb
@@ -1,13 +1,1 @@
-<div class="container">
-  <div class="d-flex align-items-center flex-column my-4 my-lg-5">
-    <h4 class="text-center">
-      Vous souhaitez vous désinscrire de Covidliste en supprimant votre compte ?
-    </h4>
-    <%= button_to "Supprimer mon compte", slot_alerts_users_path(token: @alert.token),
-      method: :delete,
-      id: dom_id(@alert.user, :delete),
-      class: "btn btn-outline-danger btn-lg mt-4",
-      data: {
-        confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr ?"} %>
-  </div>
-</div>
+<%= render partial: "users/confirm_destroy_message", locals: { user: @alert.user } %>

--- a/app/views/users/_confirm_destroy_message.html.erb
+++ b/app/views/users/_confirm_destroy_message.html.erb
@@ -1,0 +1,14 @@
+<div class="container">
+  <div class="d-flex align-items-center flex-column my-4 my-lg-5">
+    <h4 class="text-center">
+      Vous souhaitez vous désinscrire de Covidliste en supprimant votre compte ?
+    </h4>
+    <% token = user.signed_id(purpose: "users.destroy", expires_in: 1.hour) %>
+    <%= button_to "Supprimer mon compte", profile_path(authentication_token: token),
+      method: :delete,
+      id: dom_id(user, :delete),
+      class: "btn btn-outline-danger btn-lg mt-4",
+      data: {
+        confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr ?"} %>
+  </div>
+</div>

--- a/app/views/users/_confirm_destroy_message.html.erb
+++ b/app/views/users/_confirm_destroy_message.html.erb
@@ -9,6 +9,6 @@
       id: dom_id(user, :delete),
       class: "btn btn-outline-danger btn-lg mt-4",
       data: {
-        confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr ?"} %>
+        confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr(e) ?"} %>
   </div>
 </div>

--- a/app/views/users/confirm_destroy.html.erb
+++ b/app/views/users/confirm_destroy.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "users/confirm_destroy_message", locals: { user: current_user } %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -147,7 +147,7 @@
 
       <p class="mt-3">
         Vous souhaitez vérifier vos données personnelles ?
-        <%= link_to "Télécharger mes données (CSV)", user_path(format: :csv) %>
+        <%= link_to "Télécharger mes données (CSV)", profile_path(format: :csv) %>
       </p>
 
       <p class="mt-3">
@@ -159,7 +159,7 @@
             Votre profil sera anonymisé quelques jours après le RDV.
           </div>
         <% end %>
-      <%= button_to "Supprimer mon compte", :delete_user, method: :delete, class: "btn btn-danger",
+      <%= button_to "Supprimer mon compte", :profile, method: :delete, class: "btn btn-danger",
         data: {confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr ?"} %>
       </p>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -159,7 +159,7 @@
             Votre profil sera anonymisé quelques jours après le RDV.
           </div>
         <% end %>
-      <%= button_to "Supprimer mon compte", :profile, method: :delete, class: "btn btn-danger",
+      <%= button_to "Supprimer mon compte", profile_path, method: :delete, class: "btn btn-danger",
         data: {confirm: "En confirmant, votre compte ainsi que toutes les données associées seront supprimées de nos serveurs. Êtes-vous sûr ?"} %>
       </p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,11 +88,11 @@ Rails.application.routes.draw do
   ####################
 
   ## users
-  resources :users, only: [:create, :new]
-  get "/users/profile" => "users#show", :as => :profile
-  put "/users/profile" => "users#update", :as => :user
-  delete "/users/profile" => "users#delete", :as => :delete_user
-  get "/users" => "users#new"
+  resources :users, only: [:create, :new, :index] do
+    collection do
+      resource :profile, controller: "users", only: [:show, :update, :destroy]
+    end
+  end
 
   ## Partners
   resources :partners, only: [:new, :create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,7 +90,9 @@ Rails.application.routes.draw do
   ## users
   resources :users, only: [:create, :new, :index] do
     collection do
-      resource :profile, controller: "users", only: [:show, :update, :destroy]
+      resource :profile, controller: "users", only: [:show, :update, :destroy] do
+        get :confirm_destroy
+      end
     end
   end
 
@@ -113,14 +115,14 @@ Rails.application.routes.draw do
 
   ## matches
   namespace :matches do
-    resource :users, only: [:edit, :destroy]
+    resource :users, only: [:edit]
   end
 
   # slot alerts
   get "/s/:token" => "slot_alerts#show", :as => :slot_alert
   patch "/s/:token" => "slot_alerts#update"
   namespace :slot_alerts do
-    resource :users, only: [:edit, :destroy]
+    resource :users, only: [:edit]
   end
 
   get "/m/:match_confirmation_token(/:source)" => "matches#show", :as => :match

--- a/spec/controllers/concerns/user_authentication_via_signed_id_spec.rb
+++ b/spec/controllers/concerns/user_authentication_via_signed_id_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe UserAuthenticationViaSignedId, type: :controller do
+  controller(ApplicationController) do
+    include UserAuthenticationViaSignedId
+
+    before_action :authenticate_user_via_signed_id!, only: %i[index]
+    before_action -> { authenticate_user_via_signed_id!(purpose: :testing) }, only: %i[show]
+
+    def index
+      render plain: ""
+    end
+
+    def new
+      render plain: ""
+    end
+
+    def skip_pundit?
+      true
+    end
+  end
+
+  describe "when an authentication_token param is provided" do
+    let(:user) { create(:user) }
+
+    context "when the purpose of the authentication_token is properly set" do
+      it "executes the controller's action" do
+        get :index, params: {authentication_token: user.signed_id(purpose: "anonymous.index")}
+        expect(response).to have_http_status(:ok)
+
+        get :new, params: {authentication_token: user.signed_id(purpose: :testing)}
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when the purpose of the authentication_token is not set" do
+      it "redirects to the login page" do
+        get :index, params: {authentication_token: user.signed_id}
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
+
+  describe "when devise authentication is provided" do
+    let(:user) { create(:user) }
+    before { sign_in user }
+
+    it "executes the controller's action" do
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "when no authentication is provided" do
+    it "redirects to the login page" do
+      get :index
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -72,6 +72,14 @@ RSpec.describe User, type: :model do
     end
 
     it "randomize lat/lon at user update" do
+      # This prevents flaky specs when the change in lat/lng is zero (1/200)
+      allow_any_instance_of(RandomizeCoordinatesService)
+        .to receive(:generate_random_delta)
+        .and_wrap_original do |method, *args|
+          original_result = method.call(*args)
+          original_result.zero? ? 0.001 : original_result
+        end
+
       lat = 48.345
       lon = 2.123
       user = create(:user)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -16,7 +16,7 @@ ActiveRecord::Migration.maintain_test_schema!
 DatabaseCleaner[:active_record].strategy = :truncation
 
 Capybara.default_max_wait_time = 10
-Capybara.server = :puma
+Capybara.server = :puma, {Silent: true}
 Capybara.javascript_driver = :cuprite
 
 Capybara.register_driver(:cuprite) do |app|

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Users", type: :system do
         end
       end.to change { User.active.count }.by(-1)
 
-      expect(page).to have_text("Votre compte a bien été supprimé.")
+      expect(page).to have_text("Votre compte a été supprimé")
     end
 
     it "it allows me to decline the delete" do
@@ -174,7 +174,7 @@ RSpec.describe "Users", type: :system do
           end
         end.to change { User.active.count }.by(0)
 
-        expect(page).to_not have_text("Votre compte a bien été supprimé.")
+        expect(page).to_not have_text("Votre compte a été supprimé")
         expect(page).to have_text("Vous ne pouvez pas supprimer votre compte actuellement car vous avez confirmé un rendez-vous de vaccination.")
       end
     end
@@ -196,7 +196,7 @@ RSpec.describe "Users", type: :system do
           end
         end.to change { User.active.count }.by(-1)
 
-        expect(page).to have_text("Votre compte a bien été supprimé.")
+        expect(page).to have_text("Votre compte a été supprimé")
       end
     end
   end

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -228,4 +228,27 @@ RSpec.describe "Users", type: :system do
       end
     end
   end
+
+  describe "Confirmation to delete an account" do
+    before do
+      user.save!
+
+      token = Devise::Passwordless::LoginToken.encode(user)
+      visit users_magic_link_url({user: {email: user.email, token: token}})
+
+      expect(page).to have_current_path(profile_path)
+    end
+
+    scenario "it confirms then delete the account" do
+      visit confirm_destroy_profile_path
+
+      expect do
+        accept_confirm_modal do
+          click_on "Supprimer mon compte"
+        end
+      end.to change { User.active.count }.by(-1)
+
+      expect(page).to have_text("Votre compte a été supprimé")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Note: this PR replaces #858 

As part of https://github.com/hostolab/covidliste/issues/829 I would like to authenticate users right from emails. This PR sets the foundations to do this.

So far we authenticated users using `matches`' tokens or `slot_alerts`'s tokens.
Now we need `users`' tokens: we need communication unrelated to any of the above events.

## Details

**No functional changes should be part of _this_ PR.**

It adds a concern for controllers `UserAuthenticationViaSignedId` that complements the usual devise/warden authentication using an `authentication_token` based on [globalid](https://github.com/rails/globalid).

It creates a single partial to DRY those routes:
* `users#destroy`,
* `matches/users#destroy`, and
* `slot_alerts/users#destroy`.

Also DRY those views:
* `slot_alerts/users#edit`, and
* `matches/users#edit`

... into `users/_confirm_destroy_message`.

The goal is to reuse `confirm_destroy_profile_path` from email and sign it with an authentication token.

This `users#confirm_destroy` action looks like this:

![Screenshot from 2021-05-23 10-53-57](https://user-images.githubusercontent.com/163953/119254193-45d51800-bbb5-11eb-9aa0-6b5064a791ca.png)


Poke @mininao as you authored the original issue.

The next steps are:
1. Create the `rake` task to identify the appropriate users
2. Create emails to send to those users, include a link to `confirm_destroy_profile_path` with an auth token
3. Reuse that in `matches`'s emails (and `slot_alers`'s ones) when offering the user the ability to remove themselves from the list