### PR TITLE
Forward user to other match if available

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -3,6 +3,7 @@ class MatchesController < ApplicationController
 
   before_action :set_match, only: [:show, :update, :destroy]
   before_action :verify_match_validity, only: [:show]
+  before_action :verify_redirect_to_newer_match, only: [:show, :update]
   before_action :verify_age, only: [:show, :update]
   before_action :verify_expiration, only: [:update]
 
@@ -52,6 +53,15 @@ class MatchesController < ApplicationController
 
   def user_params
     params.require(:user).permit(:firstname, :lastname, :statement, :toc)
+  end
+
+  def verify_redirect_to_newer_match
+    if !@match.confirmable?
+      other = @match.find_other_available_match_for_user
+      if other.length != 0
+        redirect_to "/m/" + other[0].match_confirmation_token
+      end
+    end
   end
 
   def verify_match_validity

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -56,12 +56,10 @@ class MatchesController < ApplicationController
   end
 
   def verify_redirect_to_other_match
-    if !@match.confirmable?
-      other = @match.find_other_available_match_for_user
-      if other
-        redirect_to Rails.application.routes.url_helpers.match_url(match_confirmation_token: other.match_confirmation_token, source: "redirect")
-      end
-    end
+    return if @match.confirmable?
+    return unless (other = @match.find_other_available_match_for_user)
+
+    redirect_to Rails.application.routes.url_helpers.match_url(match_confirmation_token: other.match_confirmation_token, source: "redirect")
   end
 
   def verify_match_validity

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -58,8 +58,8 @@ class MatchesController < ApplicationController
   def verify_redirect_to_newer_match
     if !@match.confirmable?
       other = @match.find_other_available_match_for_user
-      if other.length != 0
-        redirect_to "/m/" + other[0].match_confirmation_token
+      if other
+        redirect_to Rails.application.routes.url_helpers.match_url(match_confirmation_token: other.match_confirmation_token, source: "redirect")
       end
     end
   end

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -57,9 +57,12 @@ class MatchesController < ApplicationController
 
   def verify_redirect_to_other_match
     return if @match.confirmable?
-    return unless (other = @match.find_other_available_match_for_user)
-
-    flash[:notice] = "La dose correspondant au lien sur lequel vous avez cliqué n'est plus disponible. Bonne nouvelle, nous avons trouvé une autre dose pour laquelle vous correspondez aux critères, nous vous avons donc redirigé dessus automatiquement."
+    if (other = @match.find_other_confirmed_match_for_user)
+      flash[:notice] = "Vous avez un RDV confirmé, nous vous avons donc redirigé dessus automatiquement."
+    else
+      return unless (other = @match.find_other_available_match_for_user)
+      flash[:notice] = "La dose correspondant au lien sur lequel vous avez cliqué n'est plus disponible. Bonne nouvelle, nous avons trouvé une autre dose pour laquelle vous correspondez aux critères, nous vous avons donc redirigé dessus automatiquement."
+    end
     redirect_to Rails.application.routes.url_helpers.match_url(match_confirmation_token: other.match_confirmation_token, source: "redirect")
   end
 

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -57,6 +57,7 @@ class MatchesController < ApplicationController
 
   def verify_redirect_to_other_match
     return if @match.confirmable?
+    track_click
     if (other = @match.find_other_confirmed_match_for_user)
       flash[:notice] = "Vous avez un RDV confirmé, nous vous avons donc redirigé dessus automatiquement."
     else

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -59,6 +59,7 @@ class MatchesController < ApplicationController
     return if @match.confirmable?
     return unless (other = @match.find_other_available_match_for_user)
 
+    flash[:notice] = "La dose correspondant au lieu sur lequel vous avez cliqué n'est plus disponible. Bonne nouvelle, nous avons trouvé une autre dose pour laquelle vous correspondez aux critères, nous vous avons donc redirigé dessus automatiquement."
     redirect_to Rails.application.routes.url_helpers.match_url(match_confirmation_token: other.match_confirmation_token, source: "redirect")
   end
 

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -57,6 +57,7 @@ class MatchesController < ApplicationController
 
   def verify_redirect_to_other_match
     return if @match.confirmable?
+    return if @match.refused?
     track_click
     if (other = @match.find_other_confirmed_match_for_user)
       flash[:notice] = "Vous avez un RDV confirmé, nous vous avons donc redirigé dessus automatiquement."

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -3,7 +3,7 @@ class MatchesController < ApplicationController
 
   before_action :set_match, only: [:show, :update, :destroy]
   before_action :verify_match_validity, only: [:show]
-  before_action :verify_redirect_to_newer_match, only: [:show, :update]
+  before_action :verify_redirect_to_other_match, only: [:show, :update]
   before_action :verify_age, only: [:show, :update]
   before_action :verify_expiration, only: [:update]
 
@@ -55,7 +55,7 @@ class MatchesController < ApplicationController
     params.require(:user).permit(:firstname, :lastname, :statement, :toc)
   end
 
-  def verify_redirect_to_newer_match
+  def verify_redirect_to_other_match
     if !@match.confirmable?
       other = @match.find_other_available_match_for_user
       if other

--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -59,7 +59,7 @@ class MatchesController < ApplicationController
     return if @match.confirmable?
     return unless (other = @match.find_other_available_match_for_user)
 
-    flash[:notice] = "La dose correspondant au lieu sur lequel vous avez cliqué n'est plus disponible. Bonne nouvelle, nous avons trouvé une autre dose pour laquelle vous correspondez aux critères, nous vous avons donc redirigé dessus automatiquement."
+    flash[:notice] = "La dose correspondant au lien sur lequel vous avez cliqué n'est plus disponible. Bonne nouvelle, nous avons trouvé une autre dose pour laquelle vous correspondez aux critères, nous vous avons donc redirigé dessus automatiquement."
     redirect_to Rails.application.routes.url_helpers.match_url(match_confirmation_token: other.match_confirmation_token, source: "redirect")
   end
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -79,6 +79,7 @@ class Match < ApplicationRecord
       .where.not(id: id)
       .where(user_id: user_id)
       .where("(confirmed_at IS NOT NULL OR refused_at IS NOT NULL)")
+      .where("expires_at >= now()")
       .first
     return other_confirmed if other_confirmed
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -107,8 +107,8 @@ class Match < ApplicationRecord
       LIMIT 1
     SQL
     params = {
-      user_id: self.user_id,
-      match_id: self.id
+      user_id: user_id,
+      match_id: id
     }
     query = ActiveRecord::Base.send(:sanitize_sql_array, [sql, params])
     Match.where(id: ActiveRecord::Base.connection.execute(query).to_a.pluck("id")).first

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -73,12 +73,11 @@ class Match < ApplicationRecord
 
   def find_other_available_match_for_user
     return nil if confirmed?
-    return nil if refused_at?
 
     other_confirmed = Match
       .where.not(id: id)
       .where(user_id: user_id)
-      .where("confirmed_at IS NOT NULL OR (refused_at IS NOT NULL AND expires_at >= now())")
+      .where.not(confirmed_at: nil)
       .first
     return other_confirmed if other_confirmed
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -72,13 +72,12 @@ class Match < ApplicationRecord
   end
 
   def find_other_available_match_for_user
-    return nil if confirmed?
+    return if confirmed?
 
     other_confirmed = Match
       .where.not(id: id)
-      .where(user_id: user_id)
       .where.not(confirmed_at: nil)
-      .first
+      .find_by(user_id: user_id)
     return other_confirmed if other_confirmed
 
     sql = <<~SQL.tr("\n", " ").squish

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -90,6 +90,9 @@ class Match < ApplicationRecord
           JOIN matches m ON (m.campaign_id=c.id)
         WHERE
           m.user_id = :user_id
+          AND m.confirmed_at IS NULL
+          AND m.refused_at IS NULL
+          AND m.expires_at >= now()
       ), remaining_doses_campaigns AS (
         SELECT id
         FROM (

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -100,10 +100,10 @@ class Match < ApplicationRecord
       WHERE
         m.id != :match_id
         AND m.user_id = :user_id
-        AND confirmed_at IS NULL
-        AND refused_at IS NULL
-        AND expires_at >= now()
-      ORDER BY id
+        AND m.confirmed_at IS NULL
+        AND m.refused_at IS NULL
+        AND m.expires_at >= now()
+      ORDER BY m.id
       LIMIT 1
     SQL
     params = {

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -78,8 +78,7 @@ class Match < ApplicationRecord
     other_confirmed = Match
       .where.not(id: id)
       .where(user_id: user_id)
-      .where("(confirmed_at IS NOT NULL OR refused_at IS NOT NULL)")
-      .where("expires_at >= now()")
+      .where("confirmed_at IS NOT NULL OR (refused_at IS NOT NULL AND expires_at >= now())")
       .first
     return other_confirmed if other_confirmed
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -76,9 +76,9 @@ class Match < ApplicationRecord
     return nil if refused_at?
 
     other_confirmed = Match
-      .where(user_id: user_id)
-      .where.not(confirmed_at: nil)
       .where.not(id: id)
+      .where(user_id: user_id)
+      .where("(confirmed_at IS NOT NULL OR refused_at IS NOT NULL)")
       .first
     return other_confirmed if other_confirmed
 

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -72,6 +72,16 @@ class Match < ApplicationRecord
   end
 
   def find_other_available_match_for_user
+    return nil if confirmed?
+    return nil if refused_at?
+
+    other_confirmed = Match
+      .where(user_id: user_id)
+      .where.not(confirmed_at: nil)
+      .where.not(id: id)
+      .first
+    return other_confirmed if other_confirmed
+
     sql = <<~SQL.tr("\n", " ").squish
       WITH user_campaigns AS (
         SELECT DISTINCT c.id, c.available_doses

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -82,6 +82,7 @@ class Match < ApplicationRecord
 
   def find_other_available_match_for_user
     return if confirmed?
+    return if refused?
     other_confirmed = find_other_confirmed_match_for_user
     return other_confirmed if other_confirmed
 

--- a/app/views/partners/vaccination_centers/show.html.erb
+++ b/app/views/partners/vaccination_centers/show.html.erb
@@ -65,7 +65,7 @@
         </thead>
 
         <tbody>
-          <% @vaccination_center.campaigns.order(id: :desc).each do |campaign| %>
+          <% @vaccination_center.campaigns.includes([:partner]).order(id: :desc).each do |campaign| %>
             <tr>
               <td class="font-weight-bold"> <%= link_to campaign.id, partners_campaign_path(campaign) %> </td>
               <td>

--- a/spec/factories/match_multi_factory.rb
+++ b/spec/factories/match_multi_factory.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :match_multi, class: "Match" do
+    association :vaccination_center
+
+    user { create(:user) }
+    campaign { create(:campaign, available_doses: 1) }
+
+    trait :confirmed do
+      confirmed_at { Time.zone.now }
+    end
+
+    trait :available do
+      expires_at { 1.hours.from_now }
+    end
+  end
+end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -135,10 +135,10 @@ RSpec.describe Match, type: :model do
   describe "#multi match fallback" do
     it "should have other match" do
       users = create_list(:user, 2, birthdate: Time.now.utc.to_date - 60.years,
-                              zipcode: "75001",
-                              city: "Paris",
-                              geo_citycode: "75001",
-                              geo_context: "GEO_CONTEXT")
+        zipcode: "75001",
+        city: "Paris",
+        geo_citycode: "75001",
+        geo_context: "GEO_CONTEXT")
       u1 = users.first
       u2 = users.second
 
@@ -162,10 +162,10 @@ RSpec.describe Match, type: :model do
 
     it "should not have other match" do
       users = create_list(:user, 2, birthdate: Time.now.utc.to_date - 60.years,
-                              zipcode: "75001",
-                              city: "Paris",
-                              geo_citycode: "75001",
-                              geo_context: "GEO_CONTEXT")
+        zipcode: "75001",
+        city: "Paris",
+        geo_citycode: "75001",
+        geo_context: "GEO_CONTEXT")
       u1 = users.first
       u2 = users.second
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -134,18 +134,13 @@ RSpec.describe Match, type: :model do
 
   describe "#multi match fallback" do
     it "should have other match" do
-      u1 = create(:user,
-        birthdate: Time.now.utc.to_date - 60.years,
-        zipcode: "75001",
-        city: "Paris",
-        geo_citycode: "75001",
-        geo_context: "GEO_CONTEXT")
-      u2 = create(:user,
-        birthdate: Time.now.utc.to_date - 60.years,
-        zipcode: "75001",
-        city: "Paris",
-        geo_citycode: "75001",
-        geo_context: "GEO_CONTEXT")
+      users = create_list(:user, 2, birthdate: Time.now.utc.to_date - 60.years,
+                              zipcode: "75001",
+                              city: "Paris",
+                              geo_citycode: "75001",
+                              geo_context: "GEO_CONTEXT")
+      u1 = users.first
+      u2 = users.second
 
       vc1 = create(:vaccination_center, :from_paris)
       vc2 = create(:vaccination_center, :from_paris)
@@ -166,15 +161,13 @@ RSpec.describe Match, type: :model do
     end
 
     it "should not have other match" do
-      let(:users) do
-        create_list(:user, 2, birthdate: Time.now.utc.to_date - 60.years,
+      users = create_list(:user, 2, birthdate: Time.now.utc.to_date - 60.years,
                               zipcode: "75001",
                               city: "Paris",
                               geo_citycode: "75001",
                               geo_context: "GEO_CONTEXT")
-      end
-      let(:u1) { users.first }
-      let(:u2) { users.second }
+      u1 = users.first
+      u2 = users.second
 
       vc1 = create(:vaccination_center, :from_paris)
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -166,18 +166,15 @@ RSpec.describe Match, type: :model do
     end
 
     it "should not have other match" do
-      u1 = create(:user,
-        birthdate: Time.now.utc.to_date - 60.years,
-        zipcode: "75001",
-        city: "Paris",
-        geo_citycode: "75001",
-        geo_context: "GEO_CONTEXT")
-      u2 = create(:user,
-        birthdate: Time.now.utc.to_date - 60.years,
-        zipcode: "75001",
-        city: "Paris",
-        geo_citycode: "75001",
-        geo_context: "GEO_CONTEXT")
+      let(:users) do
+        create_list(:user, 2, birthdate: Time.now.utc.to_date - 60.years,
+                              zipcode: "75001",
+                              city: "Paris",
+                              geo_citycode: "75001",
+                              geo_context: "GEO_CONTEXT")
+      end
+      let(:u1) { users.first }
+      let(:u2) { users.second }
 
       vc1 = create(:vaccination_center, :from_paris)
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -135,10 +135,10 @@ RSpec.describe Match, type: :model do
   describe "#multi match fallback" do
     it "should have other match" do
       users = create_list(:user, 2, birthdate: Time.now.utc.to_date - 60.years,
-        zipcode: "75001",
-        city: "Paris",
-        geo_citycode: "75001",
-        geo_context: "GEO_CONTEXT")
+                                    zipcode: "75001",
+                                    city: "Paris",
+                                    geo_citycode: "75001",
+                                    geo_context: "GEO_CONTEXT")
       u1 = users.first
       u2 = users.second
 
@@ -162,10 +162,10 @@ RSpec.describe Match, type: :model do
 
     it "should not have other match" do
       users = create_list(:user, 2, birthdate: Time.now.utc.to_date - 60.years,
-        zipcode: "75001",
-        city: "Paris",
-        geo_citycode: "75001",
-        geo_context: "GEO_CONTEXT")
+                                    zipcode: "75001",
+                                    city: "Paris",
+                                    geo_citycode: "75001",
+                                    geo_context: "GEO_CONTEXT")
       u1 = users.first
       u2 = users.second
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -131,4 +131,68 @@ RSpec.describe Match, type: :model do
       end
     end
   end
+
+  describe "#multi match fallback" do
+    it "should have other match" do
+      u1 = create(:user,
+        birthdate: Time.now.utc.to_date - 60.years,
+        zipcode: "75001",
+        city: "Paris",
+        geo_citycode: "75001",
+        geo_context: "GEO_CONTEXT")
+      u2 = create(:user,
+        birthdate: Time.now.utc.to_date - 60.years,
+        zipcode: "75001",
+        city: "Paris",
+        geo_citycode: "75001",
+        geo_context: "GEO_CONTEXT")
+
+      vc1 = create(:vaccination_center, :from_paris)
+      vc2 = create(:vaccination_center, :from_paris)
+
+      c1 = create(:campaign, vaccination_center: vc1, ends_at: 2.hours.from_now, available_doses: 1)
+      c2 = create(:campaign, vaccination_center: vc2, ends_at: 2.hours.from_now, available_doses: 1)
+
+      m1 = create(:match, user: u1, campaign: c1, vaccination_center: vc1)
+      m2 = create(:match, :confirmed, user: u2, campaign: c1, vaccination_center: vc1)
+      m3 = create(:match, user: u1, campaign: c2, vaccination_center: vc2)
+
+      m1.set_expiration!
+      m2.set_expiration!
+      m3.set_expiration!
+
+      other = m1.find_other_available_match_for_user
+      expect(other.id).to eq(m3.id)
+    end
+
+    it "should not have other match" do
+      u1 = create(:user,
+        birthdate: Time.now.utc.to_date - 60.years,
+        zipcode: "75001",
+        city: "Paris",
+        geo_citycode: "75001",
+        geo_context: "GEO_CONTEXT")
+      u2 = create(:user,
+        birthdate: Time.now.utc.to_date - 60.years,
+        zipcode: "75001",
+        city: "Paris",
+        geo_citycode: "75001",
+        geo_context: "GEO_CONTEXT")
+
+      vc1 = create(:vaccination_center, :from_paris)
+      vc2 = create(:vaccination_center, :from_paris)
+
+      c1 = create(:campaign, vaccination_center: vc1, ends_at: 2.hours.from_now, available_doses: 1)
+      c2 = create(:campaign, vaccination_center: vc2, ends_at: 2.hours.from_now, available_doses: 1)
+
+      m1 = create(:match, user: u1, campaign: c1, vaccination_center: vc1)
+      m2 = create(:match, :confirmed, user: u2, campaign: c1, vaccination_center: vc1)
+
+      m1.set_expiration!
+      m2.set_expiration!
+
+      other = m1.find_other_available_match_for_user
+      expect(other).to eq(nil)
+    end
+  end
 end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -183,7 +183,6 @@ RSpec.describe Match, type: :model do
       vc2 = create(:vaccination_center, :from_paris)
 
       c1 = create(:campaign, vaccination_center: vc1, ends_at: 2.hours.from_now, available_doses: 1)
-      c2 = create(:campaign, vaccination_center: vc2, ends_at: 2.hours.from_now, available_doses: 1)
 
       m1 = create(:match, user: u1, campaign: c1, vaccination_center: vc1)
       m2 = create(:match, :confirmed, user: u2, campaign: c1, vaccination_center: vc1)

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -180,7 +180,6 @@ RSpec.describe Match, type: :model do
         geo_context: "GEO_CONTEXT")
 
       vc1 = create(:vaccination_center, :from_paris)
-      vc2 = create(:vaccination_center, :from_paris)
 
       c1 = create(:campaign, vaccination_center: vc1, ends_at: 2.hours.from_now, available_doses: 1)
 

--- a/test/mailers/previews/match_mailer_preview.rb
+++ b/test/mailers/previews/match_mailer_preview.rb
@@ -8,8 +8,8 @@ class MatchMailerPreview < ActionMailer::Preview
 
   def match_confirmation_instructions_multi_match
     match = FactoryBot.create(:match_multi, :available)
-    match_fill_campaign = FactoryBot.create(:match_multi, :confirmed, :campaign => match.campaign)
-    match_new_campaign = FactoryBot.create(:match_multi, :available, :user => match.user)
+    FactoryBot.create(:match_multi, :confirmed, campaign: match.campaign)
+    FactoryBot.create(:match_multi, :available, user: match.user)
     MatchMailer.with(match: match).match_confirmation_instructions.deliver_now
   end
 

--- a/test/mailers/previews/match_mailer_preview.rb
+++ b/test/mailers/previews/match_mailer_preview.rb
@@ -6,6 +6,13 @@ class MatchMailerPreview < ActionMailer::Preview
     MatchMailer.with(match: match).match_confirmation_instructions.deliver_now
   end
 
+  def match_confirmation_instructions_multi_match
+    match = FactoryBot.create(:match_multi, :available)
+    match_fill_campaign = FactoryBot.create(:match_multi, :confirmed, :campaign => match.campaign)
+    match_new_campaign = FactoryBot.create(:match_multi, :available, :user => match.user)
+    MatchMailer.with(match: match).match_confirmation_instructions.deliver_now
+  end
+
   def send_anonymisation_notice
     match = FactoryBot.create(:match, :confirmed)
     MatchMailer.with(match: match).send_anonymisation_notice.deliver_now


### PR DESCRIPTION
## Résumé

Now that users might have multiple matches active at the same time, if campaign link user has clicked is full, automatically redirect user towards another campaign if it has available doses.

## Détails

- on arrival to confirmation page, if no more doses available, check if user has been linked to other running campaign
- if user has other available campaign with doses, forward user to that campaign via 302 redirect

## Testing

To test locally go to 
```
http://localhost:3000/rails/mailers/match_mailer/match_confirmation_instructions_multi_match
```

This will generate 3 matches for 2 users in 2 different campaigns. One campaign will be full and the other will not.  

Follow the link provided in the email, which is to the full campaign and you will be automatically redirected to second campaign which still has available doses.

The final landing page will contain `redirect` as the source, eg `http://localhost:3000/m/PNoWakXy3diSFX6YiXTonLUi/redirect`
