### PR TITLE
Remove ulule box on home

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -208,4 +208,7 @@
   </div>
 </div>
 
-<%= render partial: "users/shared/box_cta", locals: {title: "Nous lançons un appel aux dons !", text: "Chaque semaine, Covidliste dépense quelques milliers d’euros pour assurer son fonctionnement.<br>Nous avons besoin de votre aide pour maintenir le service tout le long de la campagne vaccinale.", cta_text: "Faire un don", cta_href: "https://fr.ulule.com/covidliste/", cta_target: "_blank"} %>
+<%# Stop campagne Ulule pour le moment %>
+<% if false %>
+  <%= render partial: "users/shared/box_cta", locals: {title: "Nous lançons un appel aux dons !", text: "Chaque semaine, Covidliste dépense quelques milliers d’euros pour assurer son fonctionnement.<br>Nous avons besoin de votre aide pour maintenir le service tout le long de la campagne vaccinale.", cta_text: "Faire un don", cta_href: "https://fr.ulule.com/covidliste/", cta_target: "_blank"} %>
+<% end %>


### PR DESCRIPTION
[Discussion Slack](https://covidliste.slack.com/archives/C01T48BHRCL/p1622017573127600)

## Résumé

Mise en pause de la campagne Ulule : il restait une occurrence sur la home.

## Détails

- utilisation de `if false` pour qu'il soit facile de la remettre plus tard.