### PR TITLE
Rendre la Description d'un centre de vaccination facultative

### DIFF
--- a/app/views/partners/vaccination_centers/new.html.erb
+++ b/app/views/partners/vaccination_centers/new.html.erb
@@ -44,7 +44,7 @@
 
         <%= simple_form_for [:partners, @vaccination_center] do |f| %>
           <%= f.input :name, label: "Nom du lieu de vaccination", error: "Nom requis", placeholder: "Centre de vaccination Marseille", required: true %>
-          <%= f.input :description, label: "Description", error: "Description requise", placeholder: "Description du lieu de vaccination (accès, détails...)", required: true %>
+          <%= f.input :description, label: "Description", error: "Description requise", placeholder: "Description du lieu de vaccination (accès, détails...)" %>
           <%= f.input :kind, label: "Type de lieu de vaccination", collection: VaccinationCenter::Kinds::ALL %>
           <p class="small text-primary">
             <%= icon("fas", "info-circle", class: "text-secondary") %>

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -2,7 +2,7 @@ unless Rails.env.test?
   require "ddtrace"
 
   Datadog.configure do |c|
-    c.use :rack, quantize: { query: { show: :all } }
+    c.use :rack, quantize: {query: {show: :all}}
     c.use :rails, log_injection: true
   end
 end


### PR DESCRIPTION
Closes #886 

## Résumé

Rendre optionnel le champ « Description » dans le formulaire de création d'un centre de vaccination côté partenaire.

## Détails

- Retrait d'un `required: true`
- Prettier pour supprimer les espaces dans la config datadog
