### PR TITLE
Adding canceled doses and matches count into campaigns with stats in admin area

### DIFF
--- a/app/controllers/admin/campaigns_controller.rb
+++ b/app/controllers/admin/campaigns_controller.rb
@@ -12,6 +12,8 @@ module Admin
       campaigns = campaigns.where(status: @statuses) if @statuses.present?
       campaigns = campaigns.where(vaccine_type: @vaccines) if @vaccines.present?
 
+      @campaigns_today = policy_scope(Campaign).where("starts_at >= ?", Date.today.midnight)
+
       respond_to do |format|
         format.html {
           @pagy_campaigns, @campaigns = pagy(campaigns.includes(:vaccination_center).order(ActiveRecord::Base.sanitize_sql("#{sort_column} #{sort_direction}")))

--- a/app/controllers/admin/vaccination_centers_controller.rb
+++ b/app/controllers/admin/vaccination_centers_controller.rb
@@ -48,7 +48,7 @@ module Admin
         format.html {
           @pagy_vaccination_centers, @vaccination_centers = pagy(vaccination_centers.order(ActiveRecord::Base.sanitize_sql("#{sort_column} #{sort_direction}")))
         }
-        format.csv { send_data vaccination_centers.includes([:partners, :confirmer]).order(id: :asc).to_csv, filename: "vaccination_centers-#{Date.today}.csv" }
+        format.csv { send_data vaccination_centers.includes(:confirmer, partners: [:partner_exteral_accounts]).order(id: :asc).to_csv, filename: "vaccination_centers-#{Date.today}.csv" }
       end
     end
 

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -26,8 +26,15 @@ class Campaign < ApplicationRecord
 
   def canceled!
     update_attribute(:canceled_at, Time.now.utc)
+    update_attribute(:canceled_doses, remaining_doses)
     update_attribute(:available_doses, matches.confirmed.count)
+    compute_matches
     super
+  end
+
+  def compute_matches
+    update_attribute(:matches_count, (matches.count || 0))
+    update_attribute(:matches_confirmed_count, (matches.confirmed.count || 0))
   end
 
   def remaining_doses

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -30,6 +30,7 @@ class Match < ApplicationRecord
   before_create :save_user_info
   before_save :cache_distance_in_meters_between_user_and_vaccination_center
   after_create_commit :notify
+  after_commit :compute_campaign_matches, on: [:create, :update]
 
   scope :confirmed, -> { where.not(confirmed_at: nil) }
   scope :refused, -> { where.not(refused_at: nil) }
@@ -46,6 +47,10 @@ class Match < ApplicationRecord
     self.geo_citycode = user.geo_citycode
     self.geo_context = user.geo_context
     self
+  end
+
+  def compute_campaign_matches
+    campaign.compute_matches
   end
 
   def confirmed?

--- a/app/views/admin/campaigns/index.html.erb
+++ b/app/views/admin/campaigns/index.html.erb
@@ -1,25 +1,78 @@
-<div class="container-fluid py-4">
-  <h2>
-    Campagnes
-  </h2>
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-lg-5 pr-5">
+      <h2>
+        Campagnes
+      </h2>
+      <div class="d-inline-flex mt-2 mb-4">
+        <%= simple_form_for :campaigns_search,
+                            url: admin_campaigns_path,
+                            html: { class: "form-inline inline-block mr-4" },
+                            defaults: { label: false, required: false, input_html: { class: "form-control-sm selectpicker mr-2", multiple: true } },
+                            method: :get do |f| %>
+          <%= f.input :statuses, collection: [["En cours", "running"], ["Terminée", "completed"], ["Interrompue", "canceled"]],
+                      input_html: { name: "statuses[]", "data-none-selected-text": "Statut" },
+                      selected: params["statuses"] %>
 
-  <div class="d-inline-flex my-2">
+          <%= f.input :vaccines, collection: Vaccine::Brands::ALL.map { |v| [v.capitalize, v] },
+                      input_html: { name: "vaccines[]", "data-none-selected-text": "Vaccin" },
+                      selected: params["vaccines"] %>
 
-    <%= simple_form_for :campaigns_search,
-                        url: admin_campaigns_path,
-                        html: { class: "form-inline inline-block mr-4" },
-                        defaults: { label: false, required: false, input_html: { class: "form-control-sm selectpicker mr-2", multiple: true } },
-                        method: :get do |f| %>
-      <%= f.input :statuses, collection: [["En cours", "running"], ["Terminée", "completed"], ["Interrompue", "canceled"]],
-                  input_html: { name: "statuses[]", "data-none-selected-text": "Statut" },
-                  selected: params["statuses"] %>
-
-      <%= f.input :vaccines, collection: Vaccine::Brands::ALL.map { |v| [v.capitalize, v] },
-                  input_html: { name: "vaccines[]", "data-none-selected-text": "Vaccin" },
-                  selected: params["vaccines"] %>
-
-      <%= f.button :submit, "Appliquer", class: "btn-sm", name: nil %>
-    <% end %>
+          <%= f.button :submit, "Appliquer", class: "btn-sm", name: nil %>
+        <% end %>
+      </div>
+    </div>
+    <div class="col-lg-7">
+      <div class="text-center border rounded p-3">
+        <div class="mb-3 h5">
+          Statistiques d'aujourd'hui :
+        </div>
+        <div class="d-flex justify-content-around">
+          <% campaigns_today_running = @campaigns_today.where(status: :running) %>
+          <% campaigns_today_completed = @campaigns_today.where(status: :completed) %>
+          <% campaigns_today_canceld = @campaigns_today.where(status: :canceled) %>
+          <div class="px-1">
+            <%= icon("far", "clock", class: "fa-2x") %><br />
+            <%= campaigns_today_running.size %> campagnes <span class="badge badge-primary">en cours</span><br />
+            <%= campaigns_today_running.sum(:available_doses) %> <small class="text-muted">doses attribuées</small><br />
+            <%= campaigns_today_running.sum(:matches_confirmed_count) %> <small class="text-muted">doses en attente</small><br />
+            <small>
+              <% Vaccine::Brands::ALL.each do |vaccine| %>
+                <% if campaigns_today_running.where(vaccine_type: vaccine).sum(:matches_confirmed_count) > 0 %>
+                  <%= campaigns_today_running.where(vaccine_type: vaccine).sum(:matches_confirmed_count) %> <small class="text-muted"><%= vaccine.capitalize %></small>
+                <% end %>
+              <% end %>
+            </small>
+          </div>
+          <div class="px-1">
+            <%= icon("far", "check-square", class: "fa-2x") %><br />
+            <%= campaigns_today_completed.size %> campagnes <span class="badge badge-success">terminées</span><br />
+            <%= campaigns_today_completed.sum(:available_doses) %> <small class="text-muted">doses attribuées</small><br />
+            <%= campaigns_today_completed.sum(:matches_confirmed_count) %> <small class="text-muted">doses non attribuées</small><br />
+            <small>
+              <% Vaccine::Brands::ALL.each do |vaccine| %>
+                <% if campaigns_today_completed.where(vaccine_type: vaccine).sum(:matches_confirmed_count) > 0 %>
+                  <%= campaigns_today_completed.where(vaccine_type: vaccine).sum(:matches_confirmed_count) %> <small class="text-muted"><%= vaccine.capitalize %></small>
+                <% end %>
+              <% end %>
+            </small>
+          </div>
+          <div class="px-1">
+            <%= icon("far", "hand-paper", class: "fa-2x") %><br />
+            <%= campaigns_today_canceld.size %> campagnes <span class="badge badge-danger">interrompues</span><br />
+            <%= campaigns_today_canceld.sum(:available_doses) %> <small class="text-muted">doses attribuées</small><br />
+            <%= campaigns_today_canceld.sum(:canceled_doses) %> <small class="text-muted">doses annulées</small><br />
+            <small>
+              <% Vaccine::Brands::ALL.each do |vaccine| %>
+                <% if campaigns_today_canceld.where(vaccine_type: vaccine).sum(:canceled_doses) > 0 %>
+                  <%= campaigns_today_canceld.where(vaccine_type: vaccine).sum(:canceled_doses) %> <small class="text-muted"><%= vaccine.capitalize %></small>
+                <% end %>
+              <% end %>
+            </small>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 
   <div class="mt-3"><%= number_with_delimiter(@pagy_campaigns.count, delimiter: ".") %> résultats</div>
@@ -29,55 +82,81 @@
       <table class="table table-hover table-bordered table-sm small">
         <thead class="thead-light">
           <tr>
-            <th class="text-right"><%= sortable("id", "#") %></th>
-            <th><%= sortable("vaccination_center_id", "Centre") %></th>
-            <th class="text-center"><%= sortable("status", "Statut") %></th>
-            <th class="text-center"><%= sortable("created_at", "Date") %></th>
-            <th class="text-center"><%= sortable("created_at", "Lancée") %></th>
-            <th class="text-center"><%= sortable("starts_at", "Début") %></th>
-            <th class="text-center"><%= sortable("ends_at", "Fin") %></th>
-            <th><%= sortable("vaccine_type", "Vaccin") %></th>
-            <th class="text-center"><%= sortable("min_age", "Âge min") %></th>
-            <th class="text-center"><%= sortable("max_age", "Âge max") %></th>
-            <th class="text-center"><%= sortable("max_distance_in_meters", "Rayon") %></th>
-            <th class="text-center"><%= sortable("available_doses", "doses") %></th>
-            <th class="text-center">Contactés</th>
-            <th class="text-center">Confirmés</th>
-            <th class="text-center">Taux Confirm</th>
-            <th class="text-center">Taux Rempli</th>
-            <th>Remplissage</th>
-
+            <th scope="col" class="text-right"><%= sortable("id", "#") %></th>
+            <th scope="col"><%= sortable("vaccination_center_id", "Centre") %></th>
+            <th scope="col" class="text-center"><%= sortable("status", "Statut") %></th>
+            <th scope="col" class="text-center"><%= sortable("created_at", "Lancée") %></th>
+            <th scope="col" class="text-center"><%= sortable("starts_at", "Début") %></th>
+            <th scope="col" class="text-center"><%= sortable("ends_at", "Fin") %></th>
+            <th scope="col" class="text-center">Critères</th>
+            <th scope="col" class="text-center">
+              <%= sortable("available_doses", "Doses") %><br />
+              <%= sortable("vaccine_type", "Vaccin") %>
+            </th>
+            <th scope="col" class="text-center">
+              Confirmés<br />
+              Contactés
+            </th>
+            <th scope="col" class="text-center">
+              Taux<br />
+              Confirm.
+            </th>
+            <th scope="col" class="text-center">
+              Taux<br />
+              Remplissage
+            </th>
           </tr>
         </thead>
 
         <tbody>
           <% @campaigns.each do |campaign| %>
             <% matches = campaign.matches %>
-            <%- fill_rate = campaign.available_doses > 0 ? (100 * matches.confirmed.size.to_f / campaign.available_doses).round(1) : 0%>
+            <% fill_rate = campaign.available_doses > 0 ? (100 * matches.confirmed.size.to_f / campaign.available_doses).round(1) : 0.0 %>
+            <% confirm_rate = matches.size > 0 ? (100 * matches.confirmed.size.to_f / matches.size).round(1) : 0.0 %>
             <tr>
-              <th class="text-right"><%= campaign.id %></th>
+              <td class="text-right font-weight-bold"><%= campaign.id %></td>
               <td><%= link_to campaign.vaccination_center&.name, admin_vaccination_center_path(campaign.vaccination_center) %></td>
               <td class="text-center text-nowrap">
                 <%= content_tag :span, french_status(campaign), class: "badge badge-sm #{status_badge(campaign)}" %>
+                <% if campaign.canceled_doses and campaign.canceled_doses > 0 %>
+                  <br />
+                  <%= campaign.canceled_doses %> <small class="text-muted">doses annulées</small><br />
+                <% end %>
               </td>
-              <td class="text-center text-nowrap"><%= l(campaign.created_at, format: "%d/%m") %></td>
-              <td class="text-center text-nowrap"><%= l(campaign.created_at, format: "%H:%M") %></td>
-              <td class="text-center text-nowrap"><%= l(campaign.starts_at, format: "%H:%M") %></td>
-              <td class="text-center text-nowrap"><%= l(campaign.ends_at, format: "%H:%M") %></td>
-              <td><%= campaign.vaccine_type.to_s.capitalize %></td>
-              <td class="text-center"><%= campaign.min_age %></td>
-              <td class="text-center"><%= campaign.max_age %></td>
-              <td class="text-center"><%= (campaign.max_distance_in_meters.to_f / 1000).to_i.to_s + " km" %></td>
-              <td class="text-center"><%= campaign.available_doses %></td>
-              <td class="text-center"><%= matches.size %></td>
-              <td class="text-center"><%= matches.confirmed.size %></td>
-              <td class="text-center"><%= matches.size > 0 ? (100 * matches.confirmed.size.to_f / matches.size).round(1).to_s + "%" : "0%" %></td>
-              <td class="text-center"><%= "#{fill_rate}%" %></td>
+              <td class="text-center text-nowrap">
+                <%= l(campaign.created_at, format: "%d/%m") %><br />
+                <%= l(campaign.created_at, format: "%Hh%M") %>
+              </td>
+              <td class="text-center text-nowrap">
+                <%= l(campaign.starts_at, format: "%d/%m") %><br />
+                <%= l(campaign.starts_at, format: "%Hh%M") %>
+              </td>
+              <td class="text-center text-nowrap">
+                <%= l(campaign.ends_at, format: "%d/%m") %><br />
+                <%= l(campaign.ends_at, format: "%Hh%M") %>
+              </td>
+              <td class="text-center">
+                <%= campaign.min_age %>-<%= campaign.max_age %> <small class="text-muted">ans</small><br />
+                <%= (campaign.max_distance_in_meters / 1000).to_i.to_s %> <small class="text-muted">km</small>
+              </td>
+              <td class="text-center">
+                <%= campaign.available_doses %> <small class="text-muted">doses</small><br />
+                <%= campaign.vaccine_type.to_s.capitalize %>
+              </td>
+              <td class="text-center">
+                <%= matches.confirmed.size %> <small class="text-muted">confirmés</small><br />
+                <%= matches.size %> <small class="text-muted">contactés</small>
+              </td>
+              <td class="text-center"><%= "#{confirm_rate} %" %></td>
               <td>
-              <div class="progress">
-                <div class="progress-bar" role="progressbar" 
-                  style="width: <%= fill_rate %>%"  aria-valuenow=<%= "#{fill_rate}" %> aria-valuemin="0" aria-valuemax="100"></div>
-              </div>
+                <div class="progress position-relative">
+                  <div class="d-flex flex-row align-items-center justify-content-center position-absolute w-100 h-100">
+                    <span class="text-dark"><%= "#{fill_rate} %" %></span>
+                  </div>
+                  <div class="progress-bar" role="progressbar" aria-valuemin="0"
+                       style="width: <%= fill_rate %>%"  aria-valuenow=<%= "#{fill_rate}" %> aria-valuemax="100">
+                  </div>
+                </div>
               </td>
             </tr>
           <% end %>

--- a/app/views/admin/vaccination_centers/index.html.erb
+++ b/app/views/admin/vaccination_centers/index.html.erb
@@ -55,7 +55,7 @@
         <tbody>
           <% @vaccination_centers.each do |vaccination_center| %>
             <tr>
-              <th><%= vaccination_center.id %></th>
+              <td class="font-weight-bold"><%= vaccination_center.id %></td>
               <td>
                 <strong><%= link_to vaccination_center.name, admin_vaccination_center_path(vaccination_center.id) %></strong>
                 <br>

--- a/app/views/partners/campaigns/show.html.erb
+++ b/app/views/partners/campaigns/show.html.erb
@@ -41,6 +41,9 @@
     <span class="d-none d-print-inline ml-5">
       <%= icon("fas", "syringe") %>
       <%= @campaign.matches.confirmed.size %> doses attribuées / <%= @campaign.available_doses %>
+      <% if @campaign.canceled_doses and @campaign.canceled_doses > 0 %>
+        <small class="ml-4">(<%= @campaign.canceled_doses %> doses annulées)</small>
+      <% end %>
     </span>
   </p>
 
@@ -72,6 +75,9 @@
 
       <h2 class="text-center mt-4">
         <%= @campaign.matches.confirmed.size %> doses attribuées / <%= @campaign.available_doses %>
+        <% if @campaign.canceled_doses and @campaign.canceled_doses > 0 %>
+          <small class="ml-4">(<%= @campaign.canceled_doses %> doses annulées)</small>
+        <% end %>
       </h2>
     </div>
 

--- a/db/migrate/20210529122300_add_canceled_doses_and_matches_count_to_campaigns.rb
+++ b/db/migrate/20210529122300_add_canceled_doses_and_matches_count_to_campaigns.rb
@@ -1,0 +1,7 @@
+class AddCanceledDosesAndMatchesCountToCampaigns < ActiveRecord::Migration[6.1]
+  def change
+    add_column :campaigns, :canceled_doses, :integer, default: 0, null: false
+    add_column :campaigns, :matches_count, :integer, default: 0, null: false
+    add_column :campaigns, :matches_confirmed_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_28_185732) do
+ActiveRecord::Schema.define(version: 2021_05_29_122300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -124,6 +124,9 @@ ActiveRecord::Schema.define(version: 2021_05_28_185732) do
     t.datetime "canceled_at"
     t.string "algo_version"
     t.jsonb "parameters"
+    t.integer "canceled_doses", default: 0, null: false
+    t.integer "matches_count", default: 0, null: false
+    t.integer "matches_confirmed_count", default: 0, null: false
     t.index ["partner_id"], name: "index_campaigns_on_partner_id"
     t.index ["status"], name: "index_campaigns_on_status"
     t.index ["vaccination_center_id"], name: "index_campaigns_on_vaccination_center_id"


### PR DESCRIPTION
Statistiques des campagnes dans la zone admin.
Gestion des doses annulées et mise en cache du nombre de match dans les campagnes.

<img width="995" alt="Capture d’écran 2021-05-29 à 15 44 21" src="https://user-images.githubusercontent.com/666182/120072557-c3f15d00-c094-11eb-96ce-af3eb77aa4a6.png">

<img width="1175" alt="Capture d’écran 2021-05-29 à 15 51 09" src="https://user-images.githubusercontent.com/666182/120072768-b8eafc80-c095-11eb-818d-9105ec6f3586.png">

Commande à lancer après la prod pour mettre à jour les campagnes existantes :
```
campaigns = Campaign.all
campaigns.each do |campaign|
  campaign.compute_matches
end
```