### PR TITLE
Avoid no-shows and handle cancellation questions

### DIFF
--- a/app/controllers/matches_controller.rb
+++ b/app/controllers/matches_controller.rb
@@ -56,7 +56,8 @@ class MatchesController < ApplicationController
   end
 
   def verify_redirect_to_other_match
-    return if @match.confirmable?
+    return if @match.confirmed?
+    return if @match.confirmable? && !@match.expired?
     return if @match.refused?
     track_click
     if (other = @match.find_other_confirmed_match_for_user)
@@ -118,8 +119,10 @@ class MatchesController < ApplicationController
 
   def check_age_and_name_confirmed!
     unless ActiveRecord::Type::Boolean.new.cast(params["confirm_age"]) &&
-        ActiveRecord::Type::Boolean.new.cast(params["confirm_name"])
-      raise MissingConfirmation, "Vous devez confirmer votre âge et votre nom"
+        ActiveRecord::Type::Boolean.new.cast(params["confirm_name"]) &&
+        ActiveRecord::Type::Boolean.new.cast(params["confirm_distance"]) &&
+        ActiveRecord::Type::Boolean.new.cast(params["confirm_hours"])
+      raise MissingConfirmation, "Vous devez confirmer votre âge, votre nom, votre disponibilité et la possibilité de vous déplacer"
     end
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -87,7 +87,7 @@ class Match < ApplicationRecord
     return other_confirmed if other_confirmed
 
     user.matches.pending.where.not(id: id).order(id: :asc).each do |match|
-      if match.confirmable?
+      if match.confirmable? && !match.expired?
         return match
       end
     end

--- a/app/views/match_mailer/send_confirmed_match_details.mjml
+++ b/app/views/match_mailer/send_confirmed_match_details.mjml
@@ -25,7 +25,7 @@
       </ul>
       <strong>Notre mission s’arrête ici !</strong> Nous sommes heureux de vous permettre d'accéder à la vaccination. Votre compte sera automatiquement désactivé dans 72h. Si votre vaccination n’a pas pu avoir lieu, vous pourrez vous réinscrire sur Covidliste après 72h.
       <br />
-      <strong>En cas de problème, contactez <%= mail_to "hello@covidliste.com", "hello@covidliste.com" %>.</strong>
+      <strong>En cas de problème pour vous rendre au RDV, contactez le lieu de vaccination au <%= @match.vaccination_center.human_friendly_phone_number %>.</strong>
     </mj-text>
     <%= render partial: "mailer/social_networks", formats: [:html] %>
   </mj-column>

--- a/app/views/matches/_identity_form.html.erb
+++ b/app/views/matches/_identity_form.html.erb
@@ -1,4 +1,5 @@
 <% user = match.user %>
+<% vaccination_center = match.vaccination_center %>
 
 <h2 class="mt-4">Confirmez votre identité</h2>
 <form action="<%= match_path(match_confirmation_token: match.match_confirmation_token) %>" method="POST" class="needs-validation row" novalidate>
@@ -55,6 +56,38 @@
       <div class="invalid-feedback w-100">
         Vous devez confirmer votre date de naissance. <br>
         Si elle est inexacte, le practicien ne pourra pas vous vacciner.
+      </div>
+    </div>
+  </div>
+  <div class="col-12 mb-2">
+    <div class="form-check flex-wrap">
+      <input class="form-check-input" type="checkbox" value="1" id="confirm_hours" name="confirm_hours" required>
+      <label class="form-check-label w-75" for="confirm_hours">
+        Je confirme être disponible
+        <strong>
+          <% starts_at = match.campaign.starts_at %>
+          <% ends_at = match.campaign.ends_at %>
+          <%= l(starts_at, format: '%A %e %B %Y') %> entre <%= l(starts_at, format: '%Hh%M') %>
+          et <%= l(ends_at, format: '%Hh%M') %>
+        </strong>
+      </label>
+      <div class="invalid-feedback w-100">
+        Vous devez confirmer votre disponibilité pendant le créneau horaire du RDV.
+      </div>
+    </div>
+  </div>
+  <div class="col-12 mb-2">
+    <div class="form-check flex-wrap">
+      <input class="form-check-input" type="checkbox" value="1" id="confirm_distance" name="confirm_distance" required>
+      <label class="form-check-label w-75" for="confirm_distance">
+        Je confirme pouvoir me rendre à
+        <strong>
+          <% distance = distance_delta({lat: user.lat, lon: user.lon}, {lat: vaccination_center.lat, lon: vaccination_center.lon}) %>
+          <%= distance[:delta_in_words] %><%= ", à #{vaccination_center.human_friendly_geo_area}" if vaccination_center.human_friendly_geo_area %>
+        </strong>
+      </label>
+      <div class="invalid-feedback w-100">
+        Vous devez confirmer que vous pouvez vous déplacer sur le lieu de vaccination.
       </div>
     </div>
   </div>

--- a/spec/requests/matches_request_spec.rb
+++ b/spec/requests/matches_request_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe "Matches", type: :request do
             lastname: "Dupont"
           },
           confirm_age: "1",
-          confirm_name: "1"
+          confirm_name: "1",
+          confirm_distance: "1",
+          confirm_hours: "1"
         }
       }.to change { match.reload.confirmed_at }
     end

--- a/spec/system/matches/destroy_user_account_spec.rb
+++ b/spec/system/matches/destroy_user_account_spec.rb
@@ -39,6 +39,8 @@ RSpec.describe "Destroy user account from match email", type: :system do
       fill_in :user_lastname, with: user.lastname
       check :confirm_age
       check :confirm_name
+      check :confirm_distance
+      check :confirm_hours
       click_on("Je confirme le RDV")
     end
     scenario "the user cannot destroy their account" do

--- a/spec/system/matches_controller_spec.rb
+++ b/spec/system/matches_controller_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe MatchesController, type: :system do
         fill_in :user_lastname, with: ""
         check :confirm_age
         check :confirm_name
+        check :confirm_distance
+        check :confirm_hours
         click_on("Je confirme le RDV")
         expect(page).to have_text("Vous devez renseigner votre")
 
@@ -32,6 +34,8 @@ RSpec.describe MatchesController, type: :system do
         fill_in :user_lastname, with: user.lastname
         check :confirm_age
         check :confirm_name
+        check :confirm_distance
+        check :confirm_hours
         click_on("Je confirme le RDV")
         expect(page).to have_text("Vous devez renseigner votre")
 
@@ -39,6 +43,8 @@ RSpec.describe MatchesController, type: :system do
         fill_in :user_lastname, with: user.lastname
         check :confirm_age
         check :confirm_name
+        check :confirm_distance
+        check :confirm_hours
         click_on("Je confirme le RDV")
         expect(page).not_to have_text("Vous devez renseigner votre")
         expect(page).to have_text("Votre rendez-vous est confirmé")
@@ -123,6 +129,8 @@ RSpec.describe MatchesController, type: :system do
         fill_in :user_lastname, with: generate(:lastname)
         check :confirm_age
         check :confirm_name
+        check :confirm_distance
+        check :confirm_hours
         click_on("Je confirme le RDV")
         expect(page).to have_text("Mince 😔, toutes les doses disponibles ont déjà été réservées")
         Match.where(confirmation_failed_reason: "Match::AlreadyConfirmedError").count == already_confirmed_count + 1


### PR DESCRIPTION
Ajout du numéro de téléphone en bas du mail de confirmation de RDV pour faciliter les annulations


Ajout de confirmations dans la page de match pour la distance/le lieu et le créneau pour éviter les erreurs

![Capture d’écran 2021-05-30 205846](https://user-images.githubusercontent.com/666182/120116736-d9947e80-c189-11eb-8b9a-ec3b1752c1be.png)
