### PR TITLE
Remove autocomplete="off" on login

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -30,7 +30,6 @@
 
         <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
           <%= f.input :email,
-            autocomplete: 'off',
             autofocus: true,
             required: true,
             id: 'inputEmail',


### PR DESCRIPTION
## Résumé

Having an `autocomplete: off` in the login for receiving a connection link that adds unnecessary friction. 

## Détails
Current behavior:
https://user-images.githubusercontent.com/8673685/120192010-f200a980-c21a-11eb-9926-6bac160ee11d.mov

Cette PR enlève seulement le `autocomplete: off` pour pouvoir avoir les suggestions du browser / iOS.

One counterargument would be if there are many using covidliste from shared computers to avoid leaking past connection that way. But that seems a very limited risk.