### PR TITLE
Remove share partial from emails

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.mjml
+++ b/app/views/devise/mailer/confirmation_instructions.mjml
@@ -19,8 +19,3 @@
     <%= render partial: "mailer/social_networks", formats: [:html] %>
   </mj-column>
 </mj-section>
-<mj-section background-color="#EDE2EE" padding-bottom="10px">
-  <mj-column>
-    <%= render partial: "mailer/share", formats: [:html] %>
-  </mj-column>
-</mj-section>

--- a/app/views/devise/mailer/reset_password_instructions.mjml
+++ b/app/views/devise/mailer/reset_password_instructions.mjml
@@ -22,8 +22,3 @@
     <%= render partial: "mailer/social_networks", formats: [:html] %>
   </mj-column>
 </mj-section>
-<mj-section background-color="#EDE2EE" padding-bottom="10px">
-  <mj-column>
-    <%= render partial: "mailer/share", formats: [:html] %>
-  </mj-column>
-</mj-section>

--- a/app/views/devise/mailer/unlock_instructions.mjml
+++ b/app/views/devise/mailer/unlock_instructions.mjml
@@ -20,8 +20,3 @@
     <%= render partial: "mailer/social_networks", formats: [:html] %>
   </mj-column>
 </mj-section>
-<mj-section background-color="#EDE2EE" padding-bottom="10px">
-  <mj-column>
-    <%= render partial: "mailer/share", formats: [:html] %>
-  </mj-column>
-</mj-section>


### PR DESCRIPTION
Retrait de la partial qui affichait un lien de partage pour l'instant, il ne devrait être que sur les pages pro.
Et le lien ne devrait pas mener vers la homepage mais vers un widget de sharing pour les reseaux sociaux.

<img width="743" alt="Screenshot 2021-06-01 at 17 06 55" src="https://user-images.githubusercontent.com/6686865/120346703-e89b3e00-c2fb-11eb-90d5-efa5c64cc0a2.png">
