### PR TITLE
Remove 'share to confrere' on user email

### DIFF
--- a/app/views/devise/mailer/magic_link.mjml
+++ b/app/views/devise/mailer/magic_link.mjml
@@ -19,8 +19,3 @@ Hash[@scope_name, {email: @resource.email, token: @token}]) %>
     <%= render partial: "mailer/social_networks", formats: [:html] %>
   </mj-column>
 </mj-section>
-<mj-section background-color="#EDE2EE" padding-bottom="10px">
-  <mj-column>
-    <%= render partial: "mailer/share", formats: [:html] %>
-  </mj-column>
-</mj-section>


### PR DESCRIPTION
Fixes #943 

## Résumé

Supprime un message de partage pour les pros qui était dans tous les mails d'auto-login.

@navidemad du coup le `mailer/share` n'est appelé nulle part, faudra voir ça plus tard :eye: 