### PR TITLE
Automatic user match creation

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -19,7 +19,11 @@ class UserPolicy < ApplicationPolicy
     if user.matches.confirmed.any?
       raise Pundit::NotAuthorizedError, "Vous ne pouvez pas modifier vos informations actuellement car vous avez confirmé un rendez-vous de vaccination. Votre profil sera anonymisé quelques jours après le RDV."
     elsif user.matches.pending.any?
-      raise Pundit::NotAuthorizedError, "Vous ne pouvez pas modifier vos informations actuellement car vous avez une proposition rendez vous de vaccination en cours."
+      user.matches.pending.each do |match|
+        if match.confirmable? && !match.expired?
+          raise Pundit::NotAuthorizedError, "Vous ne pouvez pas modifier vos informations actuellement car vous avez une proposition rendez vous de vaccination en cours."
+        end
+      end
     end
 
     user == record

--- a/app/views/users/_user_infos.html.erb
+++ b/app/views/users/_user_infos.html.erb
@@ -64,12 +64,14 @@
       Votre profil sera anonymisé quelques jours après le RDV.
     </div>
   <% elsif user.matches.pending.any? %>
-    <div class="alert alert-primary">
-      Vous ne pouvez pas modifier vos informations actuellement car vous avez une proposition rendez vous de
-      vaccination en cours.<br/>
-      Si vous ne confirmez pas le RDV, vous pourrez de nouveau modifier vos informations à partir du
-      <%= l(user.matches.pending.maximum(:expires_at)) %>.<br/>
-    </div>
+    <% if @match&.present? %>
+      <div class="alert alert-primary">
+        Vous ne pouvez pas modifier vos informations actuellement car vous avez une proposition rendez vous de
+        vaccination en cours.<br/>
+        Si vous ne confirmez pas le RDV, vous pourrez de nouveau modifier vos informations à partir du
+        <%= l(user.matches.pending.maximum(:expires_at)) %>.<br/>
+      </div>
+    <% end %>
   <% end %>
   <%= render partial: "mentions", locals: {text_color: 'black'} %>
   <%= hidden_field_tag :tab, params[:tab]  %>

--- a/spec/factories/sequence_factory.rb
+++ b/spec/factories/sequence_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  sequence(:birthdate) { Faker::Date.between(from: 100.years.ago, to: 10.years.ago) }
+  sequence(:birthdate) { Faker::Date.between(from: 70.years.ago, to: 20.years.ago) }
   sequence(:company_name) { Faker::Company.name }
   sequence(:description) { Faker::Lorem.paragraph(sentence_count: 2) }
   sequence(:firstname) { Faker::Name.first_name }

--- a/spec/system/matches_controller_spec.rb
+++ b/spec/system/matches_controller_spec.rb
@@ -143,11 +143,9 @@ RSpec.describe MatchesController, type: :system do
         create(:campaign, vaccination_center: center)
       end
 
-      it "does not redirect the user to the new campaign" do
-        # When match auto-creation is prodded, switch "does not redirect" to "redirects"
+      it "redirects the user to the new campaign" do
         visit match_path(match_confirmation_token)
-        expect(page).not_to have_text("Bonne nouvelle, nous avons trouvé une autre dose")
-        # When match auto-creation is prodded, switch "not_to" to "to"
+        expect(page).to have_text("Bonne nouvelle, nous avons trouvé une autre dose")
       end
     end
 
@@ -189,11 +187,9 @@ RSpec.describe MatchesController, type: :system do
         create(:campaign, vaccination_center: center)
       end
 
-      it "does not redirect the user to the new campaign" do
-        # When match auto-creation is prodded, switch "does not redirect" to "redirects"
+      it "redirects the user to the new campaign" do
         visit match_path(match_confirmation_token)
-        expect(page).not_to have_text("Bonne nouvelle, nous avons trouvé une autre dose")
-        # When match auto-creation is prodded, switch "not_to" to "to"
+        expect(page).to have_text("Bonne nouvelle, nous avons trouvé une autre dose")
       end
     end
 

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -193,11 +193,9 @@ RSpec.describe "Users", type: :system do
         create(:campaign, vaccination_center: center)
       end
 
-      it "it does not warn about match" do
-        # When match auto-creation is prodded, switch "does not warn" to "warns"
+      it "it warns about match" do
         visit profile_url
-        expect(page).not_to have_text("Nous avons trouvé une dose de vaccin pour vous !")
-        # When match auto-creation is prodded, switch "not_to" to "to"
+        expect(page).to have_text("Nous avons trouvé une dose de vaccin pour vous !")
       end
     end
 


### PR DESCRIPTION
Création automatique d'une proposition de RDV (si campagne en cours) en cas de visite sur son compte ou sur un match expiré.