### PR TITLE
Multiple small fixes : warning when trying to stop a campaign before 1h, not trying to send emails to anonymized_users, disabling recruitment form, removing old vetting call information

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -13,6 +13,7 @@ class PagesController < ApplicationController
   def benevoles
     @volunteers = Volunteer.where(old: false, anon: false).order(sort_name: :asc) + Volunteer.where(old: false, anon: true).order(sort_name: :asc)
     @old_volunteers = Volunteer.where(old: true).order(sort_name: :asc)
+    @enable_recruitment = false
   end
 
   def donateurs

--- a/app/jobs/send_match_email_job.rb
+++ b/app/jobs/send_match_email_job.rb
@@ -5,7 +5,7 @@ class SendMatchEmailJob < ApplicationJob
   def perform(match_id)
     match = Match.find(match_id)
 
-    return if match.mail_sent_at.present? || match.expired?
+    return if match.mail_sent_at.present? || match.expired? || match.refused?
     match.set_expiration!
     MatchMailer.with(match: match).match_confirmation_instructions.deliver_now
     match.update(mail_sent_at: Time.now.utc)

--- a/app/views/pages/benevoles.html.erb
+++ b/app/views/pages/benevoles.html.erb
@@ -18,7 +18,9 @@
   <p class="text-justify text-sm-left">Grâce à Covidliste, les soignants gagnent de précieuses heures par jour. Finies
     les heures passées au téléphone pour remplir les créneaux disponibles, c'est Covidliste qui se charge de leur
     adresser les volontaires en quelques clics.</p>
-  <p class="text-justify text-sm-left">Vous voulez nous rejoindre ? C'est en bas de la page !</p>
+  <% if @enable_recruitment %>
+    <p class="text-justify text-sm-left">Vous voulez nous rejoindre ? C'est en bas de la page !</p>
+  <% end %>
 
   <div class="mt-2 mb-5">
     <p class="text-center text-muted mt-4 mb-4">
@@ -51,56 +53,58 @@
     </div>
   </div>
 
-  <h2 id="devenir-benevole">Envie de prendre part au projet ?</h2>
+  <% if @enable_recruitment %>
+    <h2 id="devenir-benevole">Envie de prendre part au projet ?</h2>
 
-  <p class="mt-4">Nous avons besoin de bénévoles pour venir renforcer nos rangs 💪</p>
+    <p class="mt-4">Nous avons besoin de bénévoles pour venir renforcer nos rangs 💪</p>
 
-  <p class="text-primary small">
-    Tous les champs du formulaire comportant un astérisque (*) sont obligatoires car nécessaires à Hostolab, en tant que
-    responsable de traitement, pour l’examen de votre candidature. A défaut de les remplir, nous ne pourrons pas traiter
-    votre candidature.
-  </p>
+    <p class="text-primary small">
+      Tous les champs du formulaire comportant un astérisque (*) sont obligatoires car nécessaires à Hostolab, en tant que
+      responsable de traitement, pour l’examen de votre candidature. A défaut de les remplir, nous ne pourrons pas traiter
+      votre candidature.
+    </p>
 
-  <p class="text-primary small">
-    Conformément à la réglementation applicable, vous disposez d’un droit d’accès, de rectification, de suppression et,
-    le cas échéant, de portabilité de vos données personnelles. Vous pouvez également vous opposer au traitement de vos
-    données et, le cas échéant, en demander la limitation. Vous pouvez enfin définir des directives relatives au sort de
-    vos données en cas de décès. Ces droits peuvent être exercés directement auprès de Hostolab par email à l’adresse
-    suivante : <%= mail_to "privacy@covidliste.com" %>. Au besoin, vous bénéficiez du droit d’introduire une réclamation
-    auprès de la CNIL.
-  </p>
+    <p class="text-primary small">
+      Conformément à la réglementation applicable, vous disposez d’un droit d’accès, de rectification, de suppression et,
+      le cas échéant, de portabilité de vos données personnelles. Vous pouvez également vous opposer au traitement de vos
+      données et, le cas échéant, en demander la limitation. Vous pouvez enfin définir des directives relatives au sort de
+      vos données en cas de décès. Ces droits peuvent être exercés directement auprès de Hostolab par email à l’adresse
+      suivante : <%= mail_to "privacy@covidliste.com" %>. Au besoin, vous bénéficiez du droit d’introduire une réclamation
+      auprès de la CNIL.
+    </p>
 
-  <p class="text-primary small">
-    Pour en savoir plus sur l’utilisation de vos données personnelles, veuillez consulter
-    la <%= link_to "politique de protection des données personnelles", privacy_volontaires_path %>.
-  </p>
+    <p class="text-primary small">
+      Pour en savoir plus sur l’utilisation de vos données personnelles, veuillez consulter
+      la <%= link_to "politique de protection des données personnelles", privacy_volontaires_path %>.
+    </p>
 
-  <p class="my-4">
-    <%= link_to "Postuler pour devenir bénévole", "https://bit.ly/recrutement-covidliste", class: "btn btn-primary", target: "_blank", rel: "noopener" %>
-  </p>
+    <p class="my-4">
+      <%= link_to "Postuler pour devenir bénévole", "https://bit.ly/recrutement-covidliste", class: "btn btn-primary", target: "_blank", rel: "noopener" %>
+    </p>
 
-  <p>Exemples de missions :</p>
+    <p>Exemples de missions :</p>
 
-  <ul>
-    <li>Contribuer au développement de la plateforme technologique</li>
-    <li>Travailler sur les interfaces pour que le produit soit utilisable facilement par tout le monde</li>
-    <li>Valider les nouveaux centres de vaccination partenaires</li>
-    <li>Faire connaître le service covidliste auprès de nouveaux centres</li>
-    <li>etc.</li>
-  </ul>
+    <ul>
+      <li>Contribuer au développement de la plateforme technologique</li>
+      <li>Travailler sur les interfaces pour que le produit soit utilisable facilement par tout le monde</li>
+      <li>Valider les nouveaux centres de vaccination partenaires</li>
+      <li>Faire connaître le service covidliste auprès de nouveaux centres</li>
+      <li>etc.</li>
+    </ul>
 
-  <p>Voici des exemples d'engagements de certains de nos bénévoles :</p>
+    <p>Voici des exemples d'engagements de certains de nos bénévoles :</p>
 
-  <ul>
-    <li>3h00 le mardi matin</li>
-    <li>1h00 le mercredi après-midi, jeudi après-midi et vendredi après-midi</li>
-    <li>tout le lundi après-midi</li>
-    <li>3 heures le dimanche matin</li>
-    <li>etc.</li>
-  </ul>
+    <ul>
+      <li>3h00 le mardi matin</li>
+      <li>1h00 le mercredi après-midi, jeudi après-midi et vendredi après-midi</li>
+      <li>tout le lundi après-midi</li>
+      <li>3 heures le dimanche matin</li>
+      <li>etc.</li>
+    </ul>
 
-  <p class="mt-5">
-    Si vous êtes développeur, vous pouvez également apporter votre aide en collaborant sur le
-    <%= link_to "GitHub du projet", "https://github.com/hostolab/covidliste", target: "_blank", rel: "noopener" %>.
-  </p>
+    <p class="mt-5">
+      Si vous êtes développeur, vous pouvez également apporter votre aide en collaborant sur le
+      <%= link_to "GitHub du projet", "https://github.com/hostolab/covidliste", target: "_blank", rel: "noopener" %>.
+    </p>
+  <% end %>
 </div>

--- a/app/views/partners/campaigns/show.html.erb
+++ b/app/views/partners/campaigns/show.html.erb
@@ -20,6 +20,10 @@
       <%- cancel_message = "Vous êtes sur le point d'interrompre cette campagne." %>
       <% if confirmed_matches_count > 0 %>
         <%- cancel_message =  "#{cancel_message} #{confirmed_matches_count} doses sont déjà attribuées à des volontaires ayant confirmé leur RDV et le resteront. Attendez-vous à ce que les #{confirmed_matches_count} volontaires se présentent à l'heure prévue. Les autres doses seront retirées de la campagne et ne pourront plus être réservées." %>
+      <% elsif @campaign.matches.size == 0 && @campaign.created_at > Time.now.utc - 1.hours %>
+        <% if (@campaign.vaccine_type != Vaccine::Brands::ASTRAZENECA) && (@campaign.vaccine_type != Vaccine::Brands::JANSSEN) %>
+          <%- cancel_message =  "#{cancel_message} Votre campagne peut prendre plusieurs dizaines de minutes pour démarrer, nous vous recommandons d'attendre au minimum 1 heure après son lancement avant de l'interrompre." %>
+        <% end %>
       <% end %>
       <span class="small d-print-none">
         <%= link_to "Interrompre",

--- a/app/views/partners/vaccination_centers/new.html.erb
+++ b/app/views/partners/vaccination_centers/new.html.erb
@@ -15,10 +15,6 @@
         membre d’un centre de vaccination, cabinet de médecine libérale, cabinet infirmier, hôpital, pharmacie...
       </p>
 
-      <p>
-        Nous prendrons contact avec vous pour valider la création du lieu.
-      </p>
-
       <% if @vaccination_center.persisted? %>
         <div class="alert alert-success mt-2">
           <p>


### PR DESCRIPTION

Petit message sur les campagnes sans match < 1h pour dissuader d'annuler trop tôt :
<img width="554" alt="Capture d’écran 2021-06-09 à 20 18 52" src="https://user-images.githubusercontent.com/666182/121408213-70b6be80-c960-11eb-97d6-5579d0edd2c3.png">

Désactivation de l'envoi de mails de match aux utilisateur anonymisés
Désactivation du formulaire de recrutement
Suppression d'un ancien message indiquant que le validation implique un appel au pro.