### PR TITLE
Possibilité de modifier les opt-in des lieux depuis l'espace PRO

### DIFF
--- a/app/controllers/partners/vaccination_centers_controller.rb
+++ b/app/controllers/partners/vaccination_centers_controller.rb
@@ -35,12 +35,12 @@ module Partners
     def update
       if !@vaccination_center.visible_optin && ActiveRecord::Type::Boolean.new.cast(vaccination_center_optin_params["visible_optin"])
         @vaccination_center.visible_optin_at = Time.now.utc
-      elsif @vaccination_center.visible_optin && !ActiveRecord::Type::Boolean.new.cast(vaccination_center_optin_params["visible_optin"])
+      elsif @vaccination_center.visible_optin && (ActiveRecord::Type::Boolean.new.cast(vaccination_center_optin_params["visible_optin"]) == false)
         @vaccination_center.visible_optin_at = nil
       end
       if !@vaccination_center.media_optin && ActiveRecord::Type::Boolean.new.cast(vaccination_center_optin_params["media_optin"])
         @vaccination_center.media_optin_at = Time.now.utc
-      elsif @vaccination_center.media_optin && !ActiveRecord::Type::Boolean.new.cast(vaccination_center_optin_params["media_optin"])
+      elsif @vaccination_center.media_optin && (ActiveRecord::Type::Boolean.new.cast(vaccination_center_optin_params["media_optin"]) == false)
         @vaccination_center.media_optin_at = nil
       end
       flash[:success] = if @vaccination_center.update(vaccination_center_params)

--- a/app/controllers/partners/vaccination_centers_controller.rb
+++ b/app/controllers/partners/vaccination_centers_controller.rb
@@ -2,8 +2,8 @@ module Partners
   class VaccinationCentersController < ApplicationController
     before_action :define_as_page_pro
     before_action :authenticate_partner!
-    before_action :find_vaccination_center, only: [:show]
-    before_action :authorize!, except: [:index, :new, :create]
+    before_action :find_vaccination_center, only: [:show, :update]
+    before_action :authorize!, except: [:index, :new, :create, :update]
 
     helper_method :sort_column, :sort_direction
 
@@ -30,6 +30,26 @@ module Partners
       @partner_vaccination_center.save
       prepare_phone_number
       render action: :new
+    end
+
+    def update
+      if !@vaccination_center.visible_optin && ActiveRecord::Type::Boolean.new.cast(vaccination_center_optin_params["visible_optin"])
+        @vaccination_center.visible_optin_at = Time.now.utc
+      elsif @vaccination_center.visible_optin && !ActiveRecord::Type::Boolean.new.cast(vaccination_center_optin_params["visible_optin"])
+        @vaccination_center.visible_optin_at = nil
+      end
+      if !@vaccination_center.media_optin && ActiveRecord::Type::Boolean.new.cast(vaccination_center_optin_params["media_optin"])
+        @vaccination_center.media_optin_at = Time.now.utc
+      elsif @vaccination_center.media_optin && !ActiveRecord::Type::Boolean.new.cast(vaccination_center_optin_params["media_optin"])
+        @vaccination_center.media_optin_at = nil
+      end
+      if @vaccination_center.update(vaccination_center_params)
+        flash[:success] = "Ce centre a bien été modifié"
+        render :show
+      else
+        flash[:success] = "Une erreur est survenue : #{@vaccination_center.errors.full_messages.join(", ")}"
+        render :show
+      end
     end
 
     def prepare_phone_number

--- a/app/controllers/partners/vaccination_centers_controller.rb
+++ b/app/controllers/partners/vaccination_centers_controller.rb
@@ -43,13 +43,12 @@ module Partners
       elsif @vaccination_center.media_optin && !ActiveRecord::Type::Boolean.new.cast(vaccination_center_optin_params["media_optin"])
         @vaccination_center.media_optin_at = nil
       end
-      if @vaccination_center.update(vaccination_center_params)
-        flash[:success] = "Ce centre a bien été modifié"
-        render :show
+      flash[:success] = if @vaccination_center.update(vaccination_center_params)
+        "Ce centre a bien été modifié"
       else
-        flash[:success] = "Une erreur est survenue : #{@vaccination_center.errors.full_messages.join(", ")}"
-        render :show
+        "Une erreur est survenue : #{@vaccination_center.errors.full_messages.join(", ")}"
       end
+      render :show
     end
 
     def prepare_phone_number

--- a/app/views/partners/vaccination_centers/show.html.erb
+++ b/app/views/partners/vaccination_centers/show.html.erb
@@ -26,8 +26,23 @@
       </p>
 
       <p class="mb-2">
-        <%= humanize_boolean @vaccination_center.visible_optin_at.present? %> Affichage sur la carte publique<br />
-        <%= humanize_boolean @vaccination_center.media_optin_at.present? %> Communication presse et réseaux sociaux
+        <div class="d-flex align-items-center">
+          <%= humanize_boolean @vaccination_center.visible_optin_at.present? %><span class='ml-2'>Affichage sur la carte publique</span>
+          <%= form_for [:partners, @vaccination_center], html: { class: 'ml-3' } do |f| %>
+            <%= f.hidden_field :visible_optin, value: !@vaccination_center.visible_optin_at.present? %>
+            <%= f.hidden_field :media_optin, value: @vaccination_center.media_optin_at.present? %>
+            <%= f.submit @vaccination_center.visible_optin_at.present? ? "Je ne souhaite plus apparaitre" : "Je souhaite apparaitre", class: 'btn btn-primary', style: 'font-size: 10px;' %>
+          <% end %>
+        </div>
+        <br/>
+        <div class="d-flex align-items-center"">
+          <%= humanize_boolean @vaccination_center.media_optin_at.present? %><span class='ml-2'>Communication presse et réseaux sociaux</span>
+          <%= form_for [:partners, @vaccination_center], html: { class: 'ml-3' } do |f| %>
+            <%= f.hidden_field :visible_optin, value: @vaccination_center.visible_optin_at.present? %>
+            <%= f.hidden_field :media_optin, value: !@vaccination_center.media_optin_at.present? %>
+            <%= f.submit @vaccination_center.media_optin_at.present? ? "Je ne souhaite plus apparaitre" : "Je souhaite apparaitre", class: 'btn btn-primary', style: 'font-size: 10px;' %>
+          <% end %>
+        </div>
       </p>
 
       <%- if @vaccination_center.lat && @vaccination_center.lon%>

--- a/app/views/partners/vaccination_centers/show.html.erb
+++ b/app/views/partners/vaccination_centers/show.html.erb
@@ -30,15 +30,13 @@
           <%= humanize_boolean @vaccination_center.visible_optin_at.present? %><span class='ml-2'>Affichage sur la carte publique</span>
           <%= form_for [:partners, @vaccination_center], html: { class: 'ml-3' } do |f| %>
             <%= f.hidden_field :visible_optin, value: !@vaccination_center.visible_optin_at.present? %>
-            <%= f.hidden_field :media_optin, value: @vaccination_center.media_optin_at.present? %>
             <%= f.submit @vaccination_center.visible_optin_at.present? ? "Je ne souhaite plus apparaitre" : "Je souhaite apparaitre", class: 'btn btn-primary', style: 'font-size: 10px;' %>
           <% end %>
         </div>
         <br/>
-        <div class="d-flex align-items-center"">
+        <div class="d-flex align-items-center">
           <%= humanize_boolean @vaccination_center.media_optin_at.present? %><span class='ml-2'>Communication presse et réseaux sociaux</span>
           <%= form_for [:partners, @vaccination_center], html: { class: 'ml-3' } do |f| %>
-            <%= f.hidden_field :visible_optin, value: @vaccination_center.visible_optin_at.present? %>
             <%= f.hidden_field :media_optin, value: !@vaccination_center.media_optin_at.present? %>
             <%= f.submit @vaccination_center.media_optin_at.present? ? "Je ne souhaite plus apparaitre" : "Je souhaite apparaitre", class: 'btn btn-primary', style: 'font-size: 10px;' %>
           <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,7 +107,7 @@ Rails.application.routes.draw do
   get "/partenaires/faq" => "pages#faq_pro", :as => :partenaires_faq
 
   namespace :partners do
-    resources :vaccination_centers, only: [:index, :show, :new, :create] do
+    resources :vaccination_centers, only: [:index, :show, :new, :create, :update] do
       resources :campaigns, only: [:new, :create] do
         post :simulate_reach, on: :collection
       end


### PR DESCRIPTION
## Résumé

Fixes #905 
Voir également #473 et #903

Possibilité de modifier les opt-in des lieux depuis l'espace PRO des partners avec l'ajout de deux buttons.

## Détails

Ajout deux boutons sur l'interface PRO permettant à l'utilisateurs de switcher entre `Je souhaite apparaitre` / `Je ne souhaite plus apparaitre` pour chacun des deux opt-in.
J'ai repris la logique du code qui avait été appliquée sur l'interface admin pour l'update des `vaccination_centers`.

C'est ma première PR j'espère que ça ira et que ça répond bien à l'issue qui avait été ouverte ;)

## Avant

![Screenshot from 2021-06-10 20-52-22](https://user-images.githubusercontent.com/55108072/121611143-fa808d80-ca2d-11eb-9993-43481459a1b9.png)

## Après

![Screenshot from 2021-06-10 20-53-39](https://user-images.githubusercontent.com/55108072/121611152-fce2e780-ca2d-11eb-8fec-112ac5a8d05b.png)
