### PR TITLE
Display vac center address on campaign page

### DIFF
--- a/app/views/admin/campaigns/index.html.erb
+++ b/app/views/admin/campaigns/index.html.erb
@@ -151,7 +151,10 @@
             <% confirm_rate = matches.size > 0 ? (100 * matches.confirmed.size.to_f / matches.size).round(1) : 0.0 %>
             <tr>
               <td class="text-right font-weight-bold"><%= campaign.id %></td>
-              <td><%= link_to campaign.vaccination_center&.name, admin_vaccination_center_path(campaign.vaccination_center) %></td>
+              <td>
+                <%= link_to campaign.vaccination_center&.name, admin_vaccination_center_path(campaign.vaccination_center) %><br />
+                <small class="text-muted"><%= campaign.vaccination_center&.address %></small>
+              </td>
               <td class="text-center text-nowrap">
                 <%= content_tag :span, french_status(campaign), class: "badge badge-sm #{status_badge(campaign)}" %>
                 <% if campaign.canceled_doses and campaign.canceled_doses > 0 %>


### PR DESCRIPTION
<img width="677" alt="Capture d’écran 2021-06-13 à 20 19 35" src="https://user-images.githubusercontent.com/666182/121817956-ade2bf80-cc84-11eb-8b81-6fafc8cb2152.png">
