### PR TITLE
Remove user update policy

### DIFF
--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -15,17 +15,6 @@ class UserPolicy < ApplicationPolicy
 
   def update?
     return false unless user.confirmed?
-
-    if user.matches.confirmed.any?
-      raise Pundit::NotAuthorizedError, "Vous ne pouvez pas modifier vos informations actuellement car vous avez confirmé un rendez-vous de vaccination. Votre profil sera anonymisé quelques jours après le RDV."
-    elsif user.matches.pending.any?
-      user.matches.pending.each do |match|
-        if match.confirmable? && !match.expired?
-          raise Pundit::NotAuthorizedError, "Vous ne pouvez pas modifier vos informations actuellement car vous avez une proposition rendez vous de vaccination en cours."
-        end
-      end
-    end
-
     user == record
   end
 

--- a/spec/system/user_spec.rb
+++ b/spec/system/user_spec.rb
@@ -146,54 +146,6 @@ RSpec.describe "Users", type: :system do
       end
     end
 
-    context "with a confirmed match" do
-      let(:campaign) { build(:campaign) }
-      let!(:match) { create(:match, campaign: campaign, confirmed_at: Time.now, user: user) }
-
-      it "it does not allow me to edit personal information" do
-        click_on "Je modifie mes informations"
-        expect(page).not_to have_text("Modifications enregistrées.")
-        expect(page).to have_text("Vous ne pouvez pas modifier vos informations actuellement car vous avez confirmé un rendez-vous de vaccination.")
-      end
-
-      it "it warns about match" do
-        visit profile_url
-        expect(page).to have_text("Vous avez un confirmé un RDV de vaccination")
-      end
-    end
-
-    context "with a pending match" do
-      let(:campaign) { build(:campaign) }
-      let!(:match) { create(:match, campaign: campaign, confirmed_at: nil, expires_at: 10.minutes.since, user: user) }
-
-      it "it does not allow me to edit personal information" do
-        click_on "Je modifie mes informations"
-        expect(page).not_to have_text("Modifications enregistrées.")
-        expect(page).to have_text("Vous ne pouvez pas modifier vos informations actuellement car vous avez une proposition rendez vous de vaccination en cours.")
-      end
-
-      it "it warns about match" do
-        visit profile_url
-        expect(page).to have_text("Nous avons trouvé une dose de vaccin pour vous !")
-      end
-    end
-
-    context "with a pending match" do
-      let(:campaign) { build(:campaign) }
-      let!(:match) { create(:match, campaign: campaign, confirmed_at: nil, expires_at: 10.minutes.since, user: user) }
-
-      it "it does not allow me to edit personal information" do
-        click_on "Je modifie mes informations"
-        expect(page).not_to have_text("Modifications enregistrées.")
-        expect(page).to have_text("Vous ne pouvez pas modifier vos informations actuellement car vous avez une proposition rendez vous de vaccination en cours.")
-      end
-
-      it "it warns about match" do
-        visit profile_url
-        expect(page).to have_text("Nous avons trouvé une dose de vaccin pour vous !")
-      end
-    end
-
     context "with a new campaign" do
       let!(:center) { create(:vaccination_center, :from_paris) }
       before do


### PR DESCRIPTION
Actuellement nous avons une contrainte qui empeche un utilisateur de modifier ses informations tant qu'il a un match.

### Probleme 
Cette contrainte empeche de modifier les parametres d'alertes pour les notifications VMD.
Par ailleurs cette contrainte n'a plus lieu d'etre car la vaccination est desormais ouverte a tout le monde. Elle avait ete mise en place pour contrer les utilisateurs qui modifiaient leur age avant d'etre matches.


### Solution
Supprimer la policy sur l'update d'un user, si il existe un match en cours ou confirme
