### PR TITLE
Réparation des liens de suppression de compte dans les mails

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   include UserAuthenticationViaSignedId
 
-  before_action :authenticate_user!, except: %i[new create destroy]
+  before_action :authenticate_user!, except: %i[new create destroy confirm_destroy]
   before_action -> { authenticate_user_via_signed_id!(purpose: "users.destroy") }, only: %i[confirm_destroy destroy]
   before_action :sign_out_if_anonymized!
   before_action :find_or_create_match, only: %i[new show update]


### PR DESCRIPTION
## Résumé

Les liens étaient cassés par la PR #865 qui permet d'écrémer les utilisateurs inactifs. Ceci les répare.

## Détails

* La route `confirm_destroy` n'était pas exclue des routes vérifiées par l'authentification "normale". Le mécanisme d'authentification par token n'était donc pas utilisé.
