### PR TITLE
Change link of professionals homepage cta

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -196,7 +196,7 @@
   </div>
 </div>
 
-<%= render partial: "users/shared/box_cta", locals: {title: "Vous êtes professionnel de santé ?", text: "Simplifiez la gestion de votre liste d’attente.<br>Commencez dès maintenant à gagner du temps.", cta_text: "Trouver des volontaires à la vaccination", cta_href: partenaires_inscription_path, cta_target: "_self"} %>
+<%= render partial: "users/shared/box_cta", locals: {title: "Vous êtes professionnel de santé ?", text: "Simplifiez la gestion de votre liste d’attente.<br>Commencez dès maintenant à gagner du temps.", cta_text: "Trouver des volontaires à la vaccination", cta_href: landing_page_pro_path, cta_target: "_self"} %>
 
 <div class="bg-white">
   <div class="container py-5 my-5">


### PR DESCRIPTION
## Résumé

Le CTA "Trouver des volontaires à la vaccination" renvoie vers la landing pro et non plus le formulaire d'inscription.
