### PR TITLE
Ajout d'une commande pour supprimer les utilisateurs inactifs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-[*.{rb,haml}]
+[*.{rb, haml, mjml}]
 indent_style = space
 indent_size = 2
 insert_final_newline = true

--- a/app/jobs/send_inactive_user_emails_job.rb
+++ b/app/jobs/send_inactive_user_emails_job.rb
@@ -38,8 +38,7 @@ class SendInactiveUserEmailsJob < ApplicationJob
       from target_users as u
       join match_stats_per_user as s
         on s.user_id = u.id
-       and s.unanswered_matches_count >= :min_unanswered_matches
-       and s.refused_matches_count = 0
+       and (s.unanswered_matches_count + s.refused_matches_count) >= :min_unanswered_matches
        and s.pending_matches_count = 0
        and s.confirmed_matches_count = 0
     SQL

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -16,4 +16,15 @@ class UserMailer < ApplicationMailer
       subject: "Attendez-vous toujours une dose de vaccin ?"
     )
   end
+
+  def send_inactive_user_anonymization_notice
+    user_email = params[:user_email]
+
+    return if user_email.blank?
+
+    mail(
+      to: user_email,
+      subject: "Nous avons supprimé votre compte Covidliste"
+    )
+  end
 end

--- a/app/views/user_mailer/send_inactive_user_anonymization_notice.mjml
+++ b/app/views/user_mailer/send_inactive_user_anonymization_notice.mjml
@@ -1,0 +1,23 @@
+<mj-section padding-bottom="15px" padding-top="15px">
+  <mj-column>
+    <mj-text padding-bottom="0px">
+      <h1>Vous avez été automatiquement désinscrit de Covidliste</h1>
+      <br/>
+      Nous avons constaté que vous n'étiez plus actif sur Covidliste depuis quelques temps.
+      Nous espérons que vous avez déjà pu vous faire vacciner ! <br>
+      Pour laisser une chance aux nouveaux inscrits d'avoir un vaccin, et protéger vos données personnelles,
+      nous avons supprimé votre compte, et anonymisé vos données.
+    </mj-text>
+
+    <mj-text>
+      <strong> Vous ne serez plus averti lorsqu'un vaccin est disponible.</strong> <br>
+      Vous ne recevrez plus de mails ni de sms de notre part.
+    </mj-text>
+    <mj-text padding-top="15px">
+      <strong><em>Vous cherchez toujours un vaccin ?</em></strong>
+      Recréez un compte sur <%= link_to "covidliste.com", root_url %> ! <br>
+      Vous aurez toutes les chances d'obtenir une dose.
+    </mj-text>
+    <%= render partial: "mailer/social_networks", formats: [:html] %>
+  </mj-column>
+</mj-section>

--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -3,14 +3,14 @@ namespace :emails do
   task inactive_users: :environment do |_t, args|
     tz = ActiveSupport::TimeZone["Europe/Paris"]
 
-    min_unanswered_matches = ENV["MIN_REFUSED_MATCHES"]&.to_i || 2
+    min_unanswered_matches = ENV["INACTIVE_USERS_MIN_REFUSED_MATCHES"]&.to_i || 2
 
-    min_age_range = ENV["MIN_AGE_RANGE"]&.to_i || 0
-    max_age_range = ENV["MAX_AGE_RANGE"]&.to_i || 200
+    min_age_range = ENV["INACTIVE_USERS_MIN_AGE_RANGE"]&.to_i || 0
+    max_age_range = ENV["INACTIVE_USERS_MAX_AGE_RANGE"]&.to_i || 200
     age_range = min_age_range..max_age_range
 
-    min_signed_up_date_range = ENV["MIN_SIGN_UP_DATE_RANGE"].try { |dt| tz.parse(dt) } || 200.years.ago
-    max_signed_up_date_range = ENV["MAX_SIGN_UP_DATE_RANGE"].try { |dt| tz.parse(dt) } || Date.current.end_of_day
+    min_signed_up_date_range = ENV["INACTIVE_USERS_MIN_SIGN_UP_DATE_RANGE"].try { |dt| tz.parse(dt) } || 200.years.ago
+    max_signed_up_date_range = ENV["INACTIVE_USERS_MAX_SIGN_UP_DATE_RANGE"].try { |dt| tz.parse(dt) } || Date.current.end_of_day
     signed_up_date_range = min_signed_up_date_range..max_signed_up_date_range
 
     puts "The following filter will apply:"
@@ -23,11 +23,11 @@ namespace :emails do
 
     if ENV["NO_HELP"].nil?
       puts "To customize this, use environment variables:"
-      puts "- MIN_REFUSED_MATCHES: int default 2"
-      puts "- MIN_AGE_RANGE:          integer;  default: 0"
-      puts "- MAX_AGE_RANGE:          integer;  default: 200"
-      puts "- MIN_SIGN_UP_DATE_RANGE: datetime; default: 200 years ago; format: YYYY-MM-DD hh:mm:ss"
-      puts "- MAX_SIGN_UP_DATE_RANGE: datetime; default: end of today;  format: YYYY-MM-DD hh:mm:ss"
+      puts "- INACTIVE_USERS_MIN_REFUSED_MATCHES: int default 2"
+      puts "- INACTIVE_USERS_MIN_AGE_RANGE:          integer;  default: 0"
+      puts "- INACTIVE_USERS_MAX_AGE_RANGE:          integer;  default: 200"
+      puts "- INACTIVE_USERS_MIN_SIGN_UP_DATE_RANGE: datetime; default: 200 years ago; format: YYYY-MM-DD hh:mm:ss"
+      puts "- INACTIVE_USERS_MAX_SIGN_UP_DATE_RANGE: datetime; default: end of today;  format: YYYY-MM-DD hh:mm:ss"
       puts ""
     end
 
@@ -46,15 +46,15 @@ namespace :emails do
   task delete_inactive_users_now: :environment do |_t, args|
     tz = ActiveSupport::TimeZone["Europe/Paris"]
 
-    min_unanswered_matches = ENV["MIN_REFUSED_MATCHES"]&.to_i || 10
-    batch_size = ENV["BATCH_SIZE"]&.to_i || 1000000
+    min_unanswered_matches = ENV["INACTIVE_USERS_MIN_REFUSED_MATCHES"]&.to_i || 10
+    batch_size = ENV["INACTIVE_USERS_BATCH_SIZE"]&.to_i || 1000000
 
-    min_age_range = ENV["MIN_AGE_RANGE"]&.to_i || 0
-    max_age_range = ENV["MAX_AGE_RANGE"]&.to_i || 200
+    min_age_range = ENV["INACTIVE_USERS_MIN_AGE_RANGE"]&.to_i || 0
+    max_age_range = ENV["INACTIVE_USERS_MAX_AGE_RANGE"]&.to_i || 200
     age_range = min_age_range..max_age_range
 
-    min_signed_up_date_range = ENV["MIN_SIGN_UP_DATE_RANGE"].try { |dt| tz.parse(dt) } || 200.years.ago
-    max_signed_up_date_range = ENV["MAX_SIGN_UP_DATE_RANGE"].try { |dt| tz.parse(dt) } || 3.weeks.ago
+    min_signed_up_date_range = ENV["INACTIVE_USERS_MIN_SIGN_UP_DATE_RANGE"].try { |dt| tz.parse(dt) } || 200.years.ago
+    max_signed_up_date_range = ENV["INACTIVE_USERS_MAX_SIGN_UP_DATE_RANGE"].try { |dt| tz.parse(dt) } || 3.weeks.ago
     signed_up_date_range = min_signed_up_date_range..max_signed_up_date_range
 
     puts "The following filters will apply:"
@@ -68,12 +68,12 @@ namespace :emails do
 
     if ENV["NO_HELP"].nil?
       puts "To customize this, use environment variables:"
-      puts "- MIN_REFUSED_MATCHES: int default 10"
-      puts "- BATCH_SIZE: int default 1000000"
-      puts "- MIN_AGE_RANGE:          integer;  default: 0"
-      puts "- MAX_AGE_RANGE:          integer;  default: 200"
-      puts "- MIN_SIGN_UP_DATE_RANGE: datetime; default: 200 years ago; format: YYYY-MM-DD hh:mm:ss"
-      puts "- MAX_SIGN_UP_DATE_RANGE: datetime; default: 3 weeks ago;  format: YYYY-MM-DD hh:mm:ss"
+      puts "- INACTIVE_USERS_MIN_REFUSED_MATCHES: int default 10"
+      puts "- INACTIVE_USERS_BATCH_SIZE: int default 1000000"
+      puts "- INACTIVE_USERS_MIN_AGE_RANGE:          integer;  default: 0"
+      puts "- INACTIVE_USERS_MAX_AGE_RANGE:          integer;  default: 200"
+      puts "- INACTIVE_USERS_MIN_SIGN_UP_DATE_RANGE: datetime; default: 200 years ago; format: YYYY-MM-DD hh:mm:ss"
+      puts "- INACTIVE_USERS_MAX_SIGN_UP_DATE_RANGE: datetime; default: 3 weeks ago;  format: YYYY-MM-DD hh:mm:ss"
       puts ""
     end
 

--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -37,8 +37,62 @@ namespace :emails do
       gets
     end
 
-    SendInactiveUserEmailsJob.perform_later(min_unanswered_matches, age_range, signed_up_date_range)
+    SendInactiveUserEmailsJob.perform_now(min_unanswered_matches, age_range, signed_up_date_range)
 
     puts "Emails are enqueued!"
+  end
+
+  desc "Delete inactive users and email them to tell them"
+  task delete_inactive_users_now: :environment do |_t, args|
+    tz = ActiveSupport::TimeZone["Europe/Paris"]
+
+    min_unanswered_matches = ENV["MIN_REFUSED_MATCHES"]&.to_i || 10
+    batch_size = ENV["BATCH_SIZE"]&.to_i || 1000000
+
+    min_age_range = ENV["MIN_AGE_RANGE"]&.to_i || 0
+    max_age_range = ENV["MAX_AGE_RANGE"]&.to_i || 200
+    age_range = min_age_range..max_age_range
+
+    min_signed_up_date_range = ENV["MIN_SIGN_UP_DATE_RANGE"].try { |dt| tz.parse(dt) } || 200.years.ago
+    max_signed_up_date_range = ENV["MAX_SIGN_UP_DATE_RANGE"].try { |dt| tz.parse(dt) } || 3.weeks.ago
+    signed_up_date_range = min_signed_up_date_range..max_signed_up_date_range
+
+    puts "The following filters will apply:"
+    puts "- Refused/Unanswered Matches >= #{min_unanswered_matches}"
+    puts "- #{min_age_range} <= Age <= #{max_age_range}"
+    puts "- #{min_signed_up_date_range} <= Sign-up Date <= #{max_signed_up_date_range}"
+    puts ""
+    puts "Number of users to delete: ##{SendInactiveUserEmailsJob.inactive_user_ids(min_unanswered_matches, age_range, signed_up_date_range).size}"
+    puts "This batch will be limited to ##{batch_size} users"
+    puts ""
+
+    if ENV["NO_HELP"].nil?
+      puts "To customize this, use environment variables:"
+      puts "- MIN_REFUSED_MATCHES: int default 10"
+      puts "- BATCH_SIZE: int default 1000000"
+      puts "- MIN_AGE_RANGE:          integer;  default: 0"
+      puts "- MAX_AGE_RANGE:          integer;  default: 200"
+      puts "- MIN_SIGN_UP_DATE_RANGE: datetime; default: 200 years ago; format: YYYY-MM-DD hh:mm:ss"
+      puts "- MAX_SIGN_UP_DATE_RANGE: datetime; default: 3 weeks ago;  format: YYYY-MM-DD hh:mm:ss"
+      puts ""
+    end
+
+    if ENV["NO_PROMPT"].nil?
+      puts "Is that okay? Enter to continue / Ctrl + C to abort"
+      puts ">"
+      gets
+    end
+
+    user_ids_to_anonymize = SendInactiveUserEmailsJob.inactive_user_ids(min_unanswered_matches, age_range, signed_up_date_range)[0..(batch_size - 1)]
+    puts user_ids_to_anonymize
+    user_ids_to_anonymize.each do |user_id,|
+      user_to_anonymize = User.find(user_id)
+      puts user_to_anonymize.id
+      user_email = user_to_anonymize.email
+      user_to_anonymize.anonymize!("delete_inactive_users_now")
+      UserMailer.with(user_email: user_email).send_inactive_user_anonymization_notice.deliver_later
+    end
+
+    puts "Deletion done"
   end
 end

--- a/lib/tasks/populate.rake
+++ b/lib/tasks/populate.rake
@@ -30,12 +30,12 @@ namespace :populate do
   desc "Generate lot of data: this was designed at testing inactive user query"
   task generate_many_users_and_matches: :environment do
     params = {
-      users_count: 2_000_000,
+      users_count: 90_000,
       min_users_id: 5_000_000,
-      matches_count: 500_000,
+      matches_count: 30_000,
       min_matches_id: 5_000_000,
       matches_per_user: 30,
-      matches_cycle: 500_000 / 30
+      matches_cycle: 30_000 / 30
     }
 
     query = ActiveRecord::Base.send(:sanitize_sql_array, [<<~SQL, params])

--- a/spec/jobs/send_inactive_user_emails_job_spec.rb
+++ b/spec/jobs/send_inactive_user_emails_job_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe SendInactiveUserEmailsJob do
     context "when a user have at least a refused match" do
       let(:refused_matches_count) { 1 }
 
-      it "excludes users having refused matches, they are considered active users" do
-        expect(inactive_user_ids).not_to include(matching_user.id)
+      it "includes users having refused matches, they are not considered active users" do
+        expect(inactive_user_ids).to include(matching_user.id)
       end
     end
 


### PR DESCRIPTION
## Résumé

Supprime les utilisateurs inscrits depuis plus de X semaines, ayant refusé/ignoré plus de X notifications, et leur envoie un mail.

<img src="https://user-images.githubusercontent.com/5511564/125121612-771d8f00-e0f4-11eb-95db-2f9eff4e44d0.png">

## Détails

* C'est pas ultra propre, mais je pense juste la faire tourner quelques fois à la main, d'où les puts qui trainent.
