### PR TITLE
Fix SQL bug in anonymization criteria

### DIFF
--- a/app/jobs/send_inactive_user_emails_job.rb
+++ b/app/jobs/send_inactive_user_emails_job.rb
@@ -36,11 +36,11 @@ class SendInactiveUserEmailsJob < ApplicationJob
       )
       select u.id
       from target_users as u
-      join match_stats_per_user as s
+      left join match_stats_per_user as s
         on s.user_id = u.id
-       and (s.unanswered_matches_count + s.refused_matches_count) >= :min_unanswered_matches
+       where ((s.unanswered_matches_count + s.refused_matches_count) >= :min_unanswered_matches
        and s.pending_matches_count = 0
-       and s.confirmed_matches_count = 0
+       and s.confirmed_matches_count = 0) OR s.user_id IS NULL
     SQL
     params = {
       min_unanswered_matches: min_unanswered_matches,


### PR DESCRIPTION
## Résumé

* Il y avait un bug lorsque `min_unanswered_matches = 0`, c'est à dire qu'on voulait anonymiser peu importe le nombre de matchs : les utilisateurs avec aucun match n'étaient pas anonymisés
* Réparé en modifiant légèrement la query. Testé en local et sur blazer prod.