### PR TITLE
Accusé de réception + lien de suppression auto (rendre l'inbox privacy@covidliste.com plus simple)

### DIFF
--- a/app/jobs/send_user_anonymization_link_after_user_requested_job.rb
+++ b/app/jobs/send_user_anonymization_link_after_user_requested_job.rb
@@ -1,0 +1,20 @@
+class SendUserAnonymizationLinkAfterUserRequestedJob < ApplicationJob
+  queue_as :mailers
+
+  def perform(user_id)
+    user = User.find(user_id)
+
+    return if user.anonymized_at?
+    UserMailer.with(user_id: user.id).send_user_anonymization_link_after_user_requested.deliver_now
+  rescue Postmark::InactiveRecipientError => e
+    Rails.logger.error(e.message)
+    user.anonymize!
+  rescue Postmark::ApiInputError => e
+    if e.message.start_with?("Invalid 'To' address:")
+      Rails.logger.error(e.message)
+      user.anonymize!
+    else
+      raise e
+    end
+  end
+end

--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -1,0 +1,6 @@
+class ApplicationMailbox < ActionMailbox::Base
+  PRIVACY_REGEX = /privacy@covidliste.com/i
+
+  # route for incoming emails on that email to PrivacyMailbox
+  routing PRIVACY_REGEX => :privacy
+end

--- a/app/mailboxes/privacy_mailbox.rb
+++ b/app/mailboxes/privacy_mailbox.rb
@@ -4,7 +4,7 @@ class PrivacyMailbox < ApplicationMailbox
   def process
     return if !@user ||@user.anonymized_at?
 
-    puts "[PrivacyMailbox] Auto-sending an email notice to ##{@user.id} with a destroy link"
+    Rails.logger.info("[PrivacyMailbox] Auto-sending an email notice to ##{@user.id} with a destroy link")
     SendUserAnonymizationLinkAfterUserRequestedJob.perform_later(@user.id)
   end
 

--- a/app/mailboxes/privacy_mailbox.rb
+++ b/app/mailboxes/privacy_mailbox.rb
@@ -1,0 +1,16 @@
+class PrivacyMailbox < ApplicationMailbox
+  before_processing :find_user
+
+  def process
+    return if !@user ||@user.anonymized_at?
+
+    puts "[PrivacyMailbox] Auto-sending an email notice to ##{@user.id} with a destroy link"
+    SendUserAnonymizationLinkAfterUserRequestedJob.perform_later(@user.id)
+  end
+
+  private
+
+  def find_user
+    @user ||= User.find_by(email: mail.from)
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -27,4 +27,15 @@ class UserMailer < ApplicationMailer
       subject: "Nous avons supprimé votre compte Covidliste"
     )
   end
+
+  def send_user_anonymization_link_after_user_requested
+    @user = User.find(params[:user_id])
+
+    return if @user.email.blank?
+
+    mail(
+      to: @user.email,
+      subject: "Nous avons bien reçu votre email"
+    )
+  end
 end

--- a/app/views/user_mailer/send_user_anonymization_link_after_user_requested.mjml
+++ b/app/views/user_mailer/send_user_anonymization_link_after_user_requested.mjml
@@ -1,0 +1,19 @@
+<% authentication_token = @user.signed_id(purpose: "users.destroy", expires_in: 7.days) %>
+<mj-section padding-bottom="15px" padding-top="15px">
+  <mj-column>
+    <mj-text padding-bottom="0px">
+      <h1>Nous avons bien reçu votre email</h1>
+      <br/>
+      Si vous souhaitez supprimer votre compte, vous pouvez le faire directement ici :
+    </mj-text>
+    <mj-button href="<%= confirm_destroy_profile_url(authentication_token: authentication_token) %>" padding-bottom="0px">
+      Supprimer mon compte et mes données personnelles
+    </mj-button>
+    <mj-text>
+      <strong>Si le lien ne fonctionne pas</strong>, copiez et collez l’adresse suivante dans votre navigateur :
+      <br />
+      <%= confirm_destroy_profile_url(authentication_token: authentication_token) %>
+    </mj-text>
+    <%= render partial: "mailer/social_networks", formats: [:html] %>
+  </mj-column>
+</mj-section>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,6 +113,9 @@ Rails.application.configure do
     password: ENV["SMTP_PASSWORD"]
   }
 
+  config.action_mailbox.ingress = :postmark
+  config.action_mailbox.queues.routing = :low
+
   config.force_ssl = true
   config.ssl_options = {hsts: {subdomains: true, preload: true, expires: 1.year}}
 

--- a/db/migrate/20211205222341_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20211205222341_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index %i[ blob_id variation_digest ], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20211205222342_create_action_mailbox_tables.action_mailbox.rb
+++ b/db/migrate/20211205222342_create_action_mailbox_tables.action_mailbox.rb
@@ -1,0 +1,14 @@
+# This migration comes from action_mailbox (originally 20180917164000)
+class CreateActionMailboxTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_mailbox_inbound_emails do |t|
+      t.integer :status, default: 0, null: false
+      t.string  :message_id, null: false
+      t.string  :message_checksum, null: false
+
+      t.timestamps
+
+      t.index [ :message_id, :message_checksum ], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,47 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_15_105445) do
+ActiveRecord::Schema.define(version: 2021_12_05_222342) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "action_mailbox_inbound_emails", force: :cascade do |t|
+    t.integer "status", default: 0, null: false
+    t.string "message_id", null: false
+    t.string "message_checksum", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["message_id", "message_checksum"], name: "index_action_mailbox_inbound_emails_uniqueness", unique: true
+  end
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "ahoy_clicks", force: :cascade do |t|
     t.string "campaign"
@@ -397,6 +434,8 @@ ActiveRecord::Schema.define(version: 2021_06_15_105445) do
     t.index ["department"], name: "index_vmd_slots_on_department"
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "campaign_batches", "campaigns"
   add_foreign_key "campaign_batches", "partners"
   add_foreign_key "campaign_batches", "vaccination_centers"

--- a/spec/jobs/send_user_anonymization_link_after_user_requested_job_spec.rb
+++ b/spec/jobs/send_user_anonymization_link_after_user_requested_job_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe SendUserAnonymizationLinkAfterUserRequestedJob do
+  let!(:user) { create(:user) }
+
+  subject { SendUserAnonymizationLinkAfterUserRequestedJob.new.perform(user.id) }
+
+  context "user is not anonymized" do
+    before do
+      user.update(anonymized_at: nil)
+    end
+    it "sends the email" do
+      mail = double(:mail)
+      allow(UserMailer).to receive_message_chain("with.send_user_anonymization_link_after_user_requested").and_return(mail)
+      expect(mail).to receive(:deliver_now)
+      subject
+    end
+  end
+
+  context "user is already anonymized" do
+    before do
+      user.update(anonymized_at: Time.now.utc)
+    end
+    it "does not send the email" do
+      mail = double(:mail)
+      allow(UserMailer).to receive_message_chain("with.send_user_anonymization_link_after_user_requested").and_return(mail)
+      expect(mail).not_to receive(:deliver_now)
+      subject
+    end
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -24,4 +24,21 @@ RSpec.describe UserMailer, type: :mailer do
       expect(User.find_signed(token, purpose: "users.destroy")).to eq(user)
     end
   end
+
+  describe "#send_user_anonymization_link_after_user_requested" do
+    let(:mail) { described_class.with(user_id: user.id).send_user_anonymization_link_after_user_requested }
+    let(:user) { create(:user) }
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Nous avons bien reçu votre email")
+      expect(mail.to).to eq([user.email])
+      expect(mail.from).to eq(["inscription@covidliste.com"])
+    end
+
+    it "includes a signed link to the confirm_destroy_profile URL" do
+      match_data = mail.body.encoded.match(%r{/users/profile/confirm_destroy\?authentication_token=([^"]+)"})
+      token = CGI.unescape(match_data.captures.first)
+      expect(User.find_signed(token, purpose: "users.destroy")).to eq(user)
+    end
+  end
 end

--- a/spec/support/mailbox.rb
+++ b/spec/support/mailbox.rb
@@ -1,0 +1,5 @@
+require "action_mailbox/test_helper"
+
+RSpec.configure do |config|
+  config.include ActionMailbox::TestHelper, type: :mailbox
+end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class UserMailerPreview < ActionMailer::Preview
+  def send_user_anonymization_link_after_user_requested
+    user = FactoryBot.create(:user)
+    UserMailer.with(user_id: user.id).send_user_anonymization_link_after_user_requested.deliver_now
+  end
+end


### PR DESCRIPTION
## Résumé

À la demande de Martin, il fallait pouvoir supprimer les users qui envoient un email à privacy@covidliste.com de manière automatique.

## Détails

Après discussion avec Maxence, on a opté pour envoyer un accusé de réception automatique lorsque quelqu'un envoit un email à privacy@covidliste et de mettre dans ce mail un bouton pour pouvoir supprimer son compte et anonymiser ses données (cf. pièce jointe)

## Aperçu

<img width="800" alt="Screenshot 2021-12-06 at 00 57 36" src="https://user-images.githubusercontent.com/6686865/144771365-08bc4a75-0064-48de-bee3-0791a5da90a5.png">

## Setup

J'utilise la feature Action Mailbox de Rails pour exposer des points d'accès afin que notre SMTP (Postmark) puisse nous pinger quand un utilisateur envoit un email sur une de nos adresses.
En l'occurence, ici je me suis focalisé sur l'adresse privacy@covidliste.com
Deux migrations seront à faire passer qui sont nécessaires pour faire marcher Action Mailbox.

Ensuite, il faut définir sur la machine de production une nouvelle variable d'environnement qui fera office de sécurité, pour que Action Mailbox accepte uniquement les personnes qui appel notre endpoint avec ce password
**RAILS_INBOUND_EMAIL_PASSWORD**

Ensuite, il faut configurer la webhook url sur l'interface de postmark (https://postmarkapp.com/manual#configure-your-inbound-webhook-url).
> When configuring your Postmark inbound webhook, be sure to check the box labeled "Include raw email content in JSON payload". Action Mailbox needs the raw email content to work.

Donc mettre comme url:
`https://actionmailbox:$RAILS_INBOUND_EMAIL_PASSWORD@covidliste.com/rails/action_mailbox/postmark/inbound_emails`
> Remplacer $RAILS_INBOUND_EMAIL_PASSWORD par le contenu que vous avez mis sur la machine de production.

Have fun :)