### PR TITLE
Meilleure information sur moderna en rappel

### DIFF
--- a/app/javascript/components/partners/campaign_creator/vaccineTypes.js
+++ b/app/javascript/components/partners/campaign_creator/vaccineTypes.js
@@ -6,6 +6,7 @@ export const vaccineTypes = [
   {
     value: "moderna",
     label: "Moderna",
+    minimumMinAge: 30,
   },
   {
     value: "janssen",

--- a/app/views/match_mailer/match_confirmation_instructions.mjml
+++ b/app/views/match_mailer/match_confirmation_instructions.mjml
@@ -2,27 +2,38 @@
 <mj-section padding-top="15px" padding-bottom="15px">
   <mj-column>
     <mj-text padding-bottom="0px">
-      <h1>Une dose de vaccin est disponible près de chez vous !</h1>
-      <br />
-      <strong>Si vous souhaitez en bénéficier, réservez la dose en confirmant le rendez-vous :</strong>
+      <h1>Une dose de vaccin <%= @match.campaign.vaccine_type.capitalize %> est disponible près de chez vous !</h1>
+      <br/>
+      <% if @match.campaign.vaccine_type == Vaccine::Brands::MODERNA || @match.campaign.vaccine_type ==
+      Vaccine::Brands::PFIZER %>
+      Ce vaccin <%= @match.campaign.vaccine_type.capitalize %> est <strong>utilisable comme dose de rappel peu importe
+      le vaccin
+      utilisé précédemment.</strong>
+      <% else %>
+      Ce vaccin <%= @match.campaign.vaccine_type.capitalize %> n'est pas utilisable comme dose de rappel.
+      <% end %>
+      <br/>
+      Si vous souhaitez en bénéficier, <strong>réservez la dose en confirmant le rendez-vous :</strong>
     </mj-text>
-    <mj-button href="<%= match_url(match_confirmation_token: @match_confirmation_token, source: 'email') %>" padding-bottom="0px">
+    <mj-button href="<%= match_url(match_confirmation_token: @match_confirmation_token, source: 'email') %>"
+               padding-bottom="0px">
       Réserver mon vaccin
     </mj-button>
     <mj-text>
       <strong>Si le lien ne fonctionne pas</strong>, copiez et collez l’adresse suivante dans votre navigateur :
-      <br />
+      <br/>
       <%= match_url(match_confirmation_token: @match_confirmation_token, source: 'email') %>
     </mj-text>
     <mj-text padding-bottom="0px">
       <strong>Vous ne souhaitez plus être informé de doses disponibles ?</strong>
     </mj-text>
-    <mj-button href="<%= confirm_destroy_profile_url(authentication_token: authentication_token) %>" padding-bottom="0px">
+    <mj-button href="<%= confirm_destroy_profile_url(authentication_token: authentication_token) %>"
+               padding-bottom="0px">
       Supprimer mon compte
     </mj-button>
     <mj-text>
       <strong>Si le lien ne fonctionne pas</strong>, copiez et collez l’adresse suivante dans votre navigateur :
-      <br />
+      <br/>
       <%= confirm_destroy_profile_url(authentication_token: authentication_token) %>
     </mj-text>
     <%= render partial: "mailer/social_networks", formats: [:html] %>

--- a/app/views/matches/_match_details.html.erb
+++ b/app/views/matches/_match_details.html.erb
@@ -66,6 +66,12 @@
   <div class="col-sm-12 col-md-6 col-lg-6">
     <%= icon("fas", "check-circle") %>
     <strong>Type de vaccin</strong>
-    <p><%= match.campaign.vaccine_type.capitalize %></p>
+    <p><%= match.campaign.vaccine_type.capitalize %> <br>
+      <% if match.campaign.vaccine_type == Vaccine::Brands::MODERNA || match.campaign.vaccine_type == Vaccine::Brands::PFIZER %>
+        <strong>Utilisable comme dose de rappel peu importe le vaccin utilisé précédemment.</strong>
+      <% else %>
+        Non utilisable comme dose de rappel.
+      <% end %>
+    </p>
   </div>
 </div>


### PR DESCRIPTION
## Résumé

Suite à [cette discussion slack](https://covidliste.slack.com/archives/C01SUGV0QH5/p1638909791322500), nous souhaitons mieux informer des possibilités de rappel avec moderna.

- Interdire moderna aux moins de 30 ans dans la création de campagne
- Petite phrase pour dire que peu importe le type de vaccin à la première dose
- Ajout du nom du vaccin dans le mail


### Email
|Avant |Après, Moderna/Pfizer|Après, Astrazeneca/Janssen|
|-|-|-|
|![Screenshot 2021-12-09 at 07-18-53 Une dose de vaccin est disponible près de chez vous](https://user-images.githubusercontent.com/5511564/145308698-fb5a0550-15fe-4282-abd9-b066a2e16b01.png)|![Screenshot 2021-12-09 at 07-40-51 Une dose de vaccin est disponible près de chez vous](https://user-images.githubusercontent.com/5511564/145308741-386ed4f1-a1e9-4a47-9b12-eb51592c3b78.png)|![image](https://user-images.githubusercontent.com/5511564/145308783-d37f7e51-fc36-4aa2-b423-eba24b247b21.png)|



### Page de confirmation
|Moderna/Pfizer|Astrazeneca/Janssen|
|-|-|
|![Screenshot 2021-12-09 at 07-44-25 Covidliste - Sauvons nos doses de vaccin 💉](https://user-images.githubusercontent.com/5511564/145308895-4e078b60-5266-4c15-90d3-3385f5aa32c3.png)|![Screenshot 2021-12-09 at 07-31-31 Covidliste - Sauvons nos doses de vaccin 💉](https://user-images.githubusercontent.com/5511564/145308843-e1c08b14-aef9-4590-8faa-6f9d52fc6458.png)|

### Création de campagne
<img width="753" alt="image" src="https://user-images.githubusercontent.com/5511564/145308641-7c8cb903-71d1-403b-9831-5b67b3849fa9.png">