### PR TITLE
Add pause-specific anonymization notice email

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -22,6 +22,15 @@ class UserMailer < ApplicationMailer
 
     return if user_email.blank?
 
+    if Flipper.enabled?(:pause_service)
+      mail(
+        to: user_email,
+        subject: "Nous avons supprimé votre compte Covidliste",
+        template_name: "send_inactive_user_anonymization_notice_service_paused"
+      )
+      return
+    end
+
     mail(
       to: user_email,
       subject: "Nous avons supprimé votre compte Covidliste"

--- a/app/views/user_mailer/send_inactive_user_anonymization_notice.mjml
+++ b/app/views/user_mailer/send_inactive_user_anonymization_notice.mjml
@@ -6,7 +6,7 @@
       Nous avons constaté que vous n'étiez plus actif sur Covidliste depuis quelques temps.
       Nous espérons que vous avez déjà pu vous faire vacciner ! <br>
       Pour laisser une chance aux nouveaux inscrits d'avoir un vaccin, et protéger vos données personnelles,
-      nous avons supprimé votre compte, et anonymisé vos données.
+      nous avons supprimé votre compte.
     </mj-text>
 
     <mj-text>

--- a/app/views/user_mailer/send_inactive_user_anonymization_notice_service_paused.mjml
+++ b/app/views/user_mailer/send_inactive_user_anonymization_notice_service_paused.mjml
@@ -1,0 +1,56 @@
+<mj-section padding-bottom="15px" padding-top="15px">
+  <mj-column>
+    <mj-text padding-bottom="0px">
+      <h1>Covidliste est en pause, nous vous avons désinscrit automatiquement.</h1>
+      <br/>
+      La tension vaccinale étant réduite, le service Covidliste est en pause.
+      Il n'est plus possible de s'inscrire, ni d'obtenir de rendez-vous. <br>
+      Pour protéger vos données personnelles, nous avons supprimé votre compte, et anonymisé vos données.
+    </mj-text>
+
+    <mj-text>
+      <strong> Vous ne serez plus averti lorsqu'un vaccin est disponible.</strong> <br>
+      Vous ne recevrez plus de mails ni de sms de notre part.
+    </mj-text>
+    <mj-text padding-top="15px" padding-bottom="0px">
+      <strong>Vous cherchez toujours un vaccin ?</strong> <br>
+      Nous vous conseillons de vous tourner vers les canaux traditionels, avec <a
+      href="https://vitemadose.covidtracker.fr/">Vitemadose</a>,
+      vous aurez toutes les chances d'obtenir une dose rapidement. <br>
+    </mj-text>
+    <mj-text padding-bottom="0px">
+      <b>Vous souhaitez avoir des nouvelles de Covidliste, et être au courant si nous relançons le service ? <br>
+        Suivez-nous sur :</b>
+    </mj-text>
+    <mj-social
+      font-size="15px"
+      icon-size="30px"
+      mode="horizontal"
+      align="left"
+      padding-top="0px"
+      padding-bottom="0px"
+    >
+      <mj-social-element
+        name="twitter"
+        alt="twitter-logo"
+        src="https://covidliste-files.s3.fr-par.scw.cloud/images/twitter.png"
+        href="https://twitter.com/covidliste"
+      ></mj-social-element>
+      <mj-social-element
+        name="facebook"
+        alt="facebook-logo"
+        src="https://covidliste-files.s3.fr-par.scw.cloud/images/facebook.png"
+        href="https://www.facebook.com/covidliste"
+      ></mj-social-element>
+      <mj-social-element
+        name="instagram"
+        alt="instagram-logo"
+        src="https://covidliste-files.s3.fr-par.scw.cloud/images/instagram.png"
+        href="https://www.instagram.com/covidliste/"
+      ></mj-social-element>
+    </mj-social>
+    <mj-text padding-top="0px" padding-bottom="0px">
+      <%= link_to "www.covidliste.com", "https://www.covidliste.com" %>
+    </mj-text>
+  </mj-column>
+</mj-section>

--- a/app/views/user_mailer/send_inactive_user_anonymization_notice_service_paused.mjml
+++ b/app/views/user_mailer/send_inactive_user_anonymization_notice_service_paused.mjml
@@ -19,8 +19,10 @@
       vous aurez toutes les chances d'obtenir une dose rapidement. <br>
     </mj-text>
     <mj-text padding-bottom="0px">
-      <b>Vous souhaitez avoir des nouvelles de Covidliste, et être au courant si nous relançons le service ? <br>
-        Suivez-nous sur :</b>
+      <strong>
+        Vous souhaitez avoir des nouvelles de Covidliste, et être au courant si nous relançons le service ? <br>
+        Suivez-nous sur :
+      </strong>
     </mj-text>
     <mj-social
       font-size="15px"

--- a/app/views/user_mailer/send_inactive_user_anonymization_notice_service_paused.mjml
+++ b/app/views/user_mailer/send_inactive_user_anonymization_notice_service_paused.mjml
@@ -5,7 +5,7 @@
       <br/>
       La tension vaccinale étant réduite, le service Covidliste est en pause.
       Il n'est plus possible de s'inscrire, ni d'obtenir de rendez-vous. <br>
-      Pour protéger vos données personnelles, nous avons supprimé votre compte, et anonymisé vos données.
+      Pour protéger vos données personnelles, nous avons supprimé votre compte.
     </mj-text>
 
     <mj-text>


### PR DESCRIPTION
## Résumé

* Active automatiquement un mail d'anonymisation différent lorsque le service est en pause.
* Celui-ci n'invite notamment pas les utilisateurs à se réinscrire en cas de besoin, mais les redirige vers **Vitemadose**

## Détails

|Email existant (service non pausé)|Nouvel email (service en pause)|
|-|-|
|![image](https://user-images.githubusercontent.com/5511564/158497055-b7a36cb9-d86f-43de-9686-d743d7b57180.png)|![image](https://user-images.githubusercontent.com/5511564/158496988-991481c6-58c7-498c-bc0d-eb4cbb8e9dcf.png)|
